### PR TITLE
LFXV2-324: Add meeting deletion message handler with registrant cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The service is built using a clean architecture pattern with the following layer
 - **Meeting Management**: Complete CRUD operations with platform integration (Zoom support)
 - **Registrant Management**: Registration handling with email uniqueness validation
 - **NATS JetStream Storage**: Scalable and resilient data persistence
+- **NATS Messaging**: Event-driven communication with other services
 - **JWT Authentication**: Secure API access via Heimdall integration
 - **OpenAPI Documentation**: Auto-generated API specifications
 - **Comprehensive Testing**: Full unit test coverage with mocks
@@ -383,6 +384,52 @@ make docker-build
 # Run with Docker
 docker run -p 8080:8080 linuxfoundation/lfx-v2-meeting-service:latest
 ```
+
+## 📡 NATS Messaging
+
+The service uses NATS for event-driven communication with other LFX platform services.
+
+### Published Subjects
+
+The service publishes messages to the following NATS subjects:
+
+| Subject | Purpose | Message Schema |
+|---------|---------|----------------|
+| `lfx.index.meeting` | Meeting indexing events | `MeetingIndexerMessage` |
+| `lfx.index.meeting_settings` | Meeting settings indexing events | `MeetingIndexerMessage` |
+| `lfx.index.meeting_registrant` | Registrant indexing events | `MeetingIndexerMessage` |
+| `lfx.update_access.meeting` | Meeting access control updates | `MeetingAccessMessage` |
+| `lfx.delete_all_access.meeting` | Meeting access control deletion | `MeetingAccessMessage` |
+| `lfx.put_registrant.meeting` | Registrant access control updates | `MeetingRegistrantAccessMessage` |
+| `lfx.remove_registrant.meeting` | Registrant access control deletion | `MeetingRegistrantAccessMessage` |
+| `lfx.meetings-api.meeting_deleted` | Meeting deletion events (internal) | `MeetingDeletedMessage` |
+
+### Handled Subjects
+
+The service handles incoming messages on these subjects:
+
+| Subject | Purpose | Handler |
+|---------|---------|---------|
+| `lfx.meetings-api.get_title` | Meeting title requests | `HandleMeetingGetTitle` |
+| `lfx.meetings-api.meeting_deleted` | Meeting deletion cleanup | `HandleMeetingDeleted` |
+
+### Message Schemas
+
+All message schemas are defined in `internal/domain/models/messaging.go`. Key schemas include:
+
+- **MeetingIndexerMessage**: For search indexing operations
+- **MeetingAccessMessage**: For meeting-level access control
+- **MeetingRegistrantAccessMessage**: For registrant-level access control  
+- **MeetingDeletedMessage**: For internal cleanup when meetings are deleted
+
+### Event Flow
+
+When meetings or registrants are modified, the service automatically:
+
+1. **Updates NATS KV storage** for persistence
+2. **Publishes indexing messages** for search services
+3. **Publishes access control messages** for permission services
+4. **Handles cleanup messages** for cascading deletions
 
 ## 📖 API Documentation
 

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -325,18 +325,26 @@ func getKeyValueStores(ctx context.Context, natsConn *nats.Conn) (*store.NatsMee
 
 // createNatsSubcriptions creates the NATS subscriptions for the meeting service.
 func createNatsSubcriptions(ctx context.Context, svc *MeetingsAPI, natsConn *nats.Conn) error {
-	slog.InfoContext(ctx, "subscribing to NATS subjects", "nats_url", natsConn.ConnectedUrl(), "servers", natsConn.Servers(), "subjects", []string{models.MeetingGetTitleSubject})
+	subjects := []string{
+		// Get meeting title subscription
+		models.MeetingGetTitleSubject,
+		// Meeting deletion cleanup subscription
+		models.MeetingDeletedSubject,
+	}
+
+	slog.InfoContext(ctx, "subscribing to NATS subjects", "nats_url", natsConn.ConnectedUrl(), "servers", natsConn.Servers(), "subjects", subjects)
 	queueName := models.MeetingsAPIQueue
 
-	// Get meeting name subscription
-	meetingGetNameSubject := models.MeetingGetTitleSubject
-	_, err := natsConn.QueueSubscribe(meetingGetNameSubject, queueName, func(msg *nats.Msg) {
-		natsMsg := &messaging.NatsMsg{Msg: msg}
-		svc.service.HandleMessage(ctx, natsMsg)
-	})
-	if err != nil {
-		slog.ErrorContext(ctx, "error creating NATS queue subscription", errKey, err)
-		return err
+	for _, subject := range subjects {
+		_, err := natsConn.QueueSubscribe(subject, queueName, func(msg *nats.Msg) {
+			natsMsg := &messaging.NatsMsg{Msg: msg}
+			svc.service.HandleMessage(ctx, natsMsg)
+		})
+		if err != nil {
+			slog.ErrorContext(ctx, "error creating NATS queue subscription", errKey, err, "subject", subject)
+			return err
+		}
+		slog.With("subject", subject, "queue", queueName).Debug("successfully subscribed to NATS subject")
 	}
 
 	return nil

--- a/internal/domain/messaging.go
+++ b/internal/domain/messaging.go
@@ -14,6 +14,7 @@ type Message interface {
 	Subject() string
 	Data() []byte
 	Respond(data []byte) error
+	HasReply() bool
 }
 
 // MessageHandler defines how the service handles incoming messages
@@ -33,4 +34,5 @@ type MessageBuilder interface {
 	SendDeleteAllAccessMeeting(ctx context.Context, data string) error
 	SendPutMeetingRegistrantAccess(ctx context.Context, data models.MeetingRegistrantAccessMessage) error
 	SendRemoveMeetingRegistrantAccess(ctx context.Context, data models.MeetingRegistrantAccessMessage) error
+	SendMeetingDeleted(ctx context.Context, data models.MeetingDeletedMessage) error
 }

--- a/internal/domain/messaging_test.go
+++ b/internal/domain/messaging_test.go
@@ -15,6 +15,7 @@ type mockMessage struct {
 	subject   string
 	data      []byte
 	responded bool
+	hasReply  bool
 }
 
 func (m *mockMessage) Subject() string {
@@ -28,6 +29,10 @@ func (m *mockMessage) Data() []byte {
 func (m *mockMessage) Respond(data []byte) error {
 	m.responded = true
 	return nil
+}
+
+func (m *mockMessage) HasReply() bool {
+	return m.hasReply
 }
 
 // mockMessageHandler implements the MessageHandler interface for testing
@@ -92,7 +97,7 @@ func TestMessage_Interface(t *testing.T) {
 
 func TestMessageHandler_Interface(t *testing.T) {
 	handler := &mockMessageHandler{}
-	msg := &mockMessage{subject: "test", data: []byte("data")}
+	msg := &mockMessage{subject: "test", data: []byte("data"), hasReply: true}
 
 	handler.HandleMessage(context.Background(), msg)
 

--- a/internal/domain/mock.go
+++ b/internal/domain/mock.go
@@ -136,6 +136,11 @@ func (m *MockMessageBuilder) SendRemoveMeetingRegistrantAccess(ctx context.Conte
 	return args.Error(0)
 }
 
+func (m *MockMessageBuilder) SendMeetingDeleted(ctx context.Context, data models.MeetingDeletedMessage) error {
+	args := m.Called(ctx, data)
+	return args.Error(0)
+}
+
 // MockMessage implements Message for testing
 type MockMessage struct {
 	mock.Mock

--- a/internal/domain/models/messaging.go
+++ b/internal/domain/models/messaging.go
@@ -46,6 +46,10 @@ const (
 	// MeetingGetTitleSubject is the subject for the meeting get title.
 	// The subject is of the form: lfx.meetings-api.get_title
 	MeetingGetTitleSubject = "lfx.meetings-api.get_title"
+
+	// MeetingDeletedSubject is the subject for meeting deletion events.
+	// The subject is of the form: lfx.meetings-api.meeting_deleted
+	MeetingDeletedSubject = "lfx.meetings-api.meeting_deleted"
 )
 
 // MessageAction is a type for the action of a meeting message.
@@ -87,4 +91,10 @@ type MeetingRegistrantAccessMessage struct {
 	MeetingUID string `json:"meeting_uid"`
 	Username   string `json:"username"`
 	Host       bool   `json:"host"`
+}
+
+// MeetingDeletedMessage is the schema for the message sent when a meeting is deleted.
+// This message is used internally to trigger cleanup of all associated registrants.
+type MeetingDeletedMessage struct {
+	MeetingUID string `json:"meeting_uid"`
 }

--- a/internal/infrastructure/messaging/mock.go
+++ b/internal/infrastructure/messaging/mock.go
@@ -36,6 +36,7 @@ type INatsMsg interface {
 	Respond(data []byte) error
 	Data() []byte
 	Subject() string
+	HasReply() bool
 }
 
 // NatsMsg is a wrapper around [nats.Msg] that implements [INatsMsg].
@@ -58,13 +59,19 @@ func (m *NatsMsg) Subject() string {
 	return m.Msg.Subject
 }
 
+// HasReply implements [INatsMsg.HasReply].
+func (m *NatsMsg) HasReply() bool {
+	return m.Reply != ""
+}
+
 // Ensure NatsMsg implements domain.Message interface
 var _ domain.Message = (*NatsMsg)(nil)
 
 type MockNatsMsg struct {
 	mock.Mock
-	data    []byte
-	subject string
+	data     []byte
+	subject  string
+	hasReply bool
 }
 
 func (m *MockNatsMsg) Respond(data []byte) error {
@@ -78,6 +85,10 @@ func (m *MockNatsMsg) Data() []byte {
 
 func (m *MockNatsMsg) Subject() string {
 	return m.subject
+}
+
+func (m *MockNatsMsg) HasReply() bool {
+	return m.hasReply
 }
 
 // MockKeyValue is a mock implementation of the [INatsKeyValue] interface.

--- a/internal/infrastructure/messaging/nats_messaging.go
+++ b/internal/infrastructure/messaging/nats_messaging.go
@@ -196,3 +196,14 @@ func (m *MessageBuilder) SendRemoveMeetingRegistrantAccess(ctx context.Context, 
 
 	return m.sendMessage(ctx, models.RemoveRegistrantMeetingSubject, dataBytes)
 }
+
+// SendMeetingDeleted sends a message about a meeting being deleted to trigger registrant cleanup.
+func (m *MessageBuilder) SendMeetingDeleted(ctx context.Context, data models.MeetingDeletedMessage) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		slog.ErrorContext(ctx, "error marshalling data into JSON", logging.ErrKey, err)
+		return err
+	}
+
+	return m.sendMessage(ctx, models.MeetingDeletedSubject, dataBytes)
+}

--- a/internal/service/meeting_service_test.go
+++ b/internal/service/meeting_service_test.go
@@ -190,8 +190,9 @@ func setupServiceForTesting() (*MeetingsService, *domain.MockMeetingRepository, 
 
 // Mock message for testing
 type mockMessage struct {
-	subject string
-	data    []byte
+	subject  string
+	data     []byte
+	hasReply bool
 	mock.Mock
 }
 
@@ -208,9 +209,23 @@ func (m *mockMessage) Respond(data []byte) error {
 	return args.Error(0)
 }
 
+func (m *mockMessage) HasReply() bool {
+	return m.hasReply
+}
+
 func newMockMessage(subject string, data []byte) *mockMessage {
 	return &mockMessage{
 		subject: subject,
 		data:    data,
+		// Default to true for backward compatibility with existing tests
+		hasReply: true,
+	}
+}
+
+func newMockMessageNoReply(subject string, data []byte) *mockMessage {
+	return &mockMessage{
+		subject:  subject,
+		data:     data,
+		hasReply: false,
 	}
 }

--- a/internal/service/registrant_operations.go
+++ b/internal/service/registrant_operations.go
@@ -371,6 +371,67 @@ func (s *MeetingsService) UpdateMeetingRegistrant(ctx context.Context, payload *
 	return registrant, nil
 }
 
+// deleteRegistrantWithCleanup is an internal helper that deletes a registrant and sends cleanup messages.
+// It can optionally skip revision checking when skipRevisionCheck is true (useful for bulk cleanup operations).
+func (s *MeetingsService) deleteRegistrantWithCleanup(ctx context.Context, registrantDB *models.Registrant, revision uint64, skipRevisionCheck bool) error {
+	ctx = logging.AppendCtx(ctx, slog.String("registrant_uid", registrantDB.UID))
+
+	// Delete the registrant from the database
+	var err error
+	if skipRevisionCheck {
+		// Use revision 0 to skip revision checking for bulk cleanup operations
+		err = s.RegistrantRepository.Delete(ctx, registrantDB.UID, 0)
+	} else {
+		err = s.RegistrantRepository.Delete(ctx, registrantDB.UID, revision)
+	}
+
+	if err != nil {
+		if errors.Is(err, domain.ErrRevisionMismatch) && !skipRevisionCheck {
+			slog.WarnContext(ctx, "revision mismatch", logging.ErrKey, err)
+			return domain.ErrRevisionMismatch
+		}
+		if errors.Is(err, domain.ErrRegistrantNotFound) {
+			// If skipping revision check, this is expected during cleanup
+			if skipRevisionCheck {
+				slog.DebugContext(ctx, "registrant already deleted, skipping")
+				return nil
+			}
+			slog.WarnContext(ctx, "registrant not found", logging.ErrKey, err)
+			return domain.ErrRegistrantNotFound
+		}
+		slog.ErrorContext(ctx, "error deleting registrant", logging.ErrKey, err)
+		return domain.ErrInternal
+	}
+
+	slog.DebugContext(ctx, "deleted registrant")
+
+	// Send indexing delete message for the registrant
+	err = s.MessageBuilder.SendDeleteIndexMeetingRegistrant(ctx, registrantDB.UID)
+	if err != nil {
+		slog.ErrorContext(ctx, "error sending delete indexing message for registrant", logging.ErrKey, err, logging.PriorityCritical())
+		// Continue with cleanup even if indexing fails
+	}
+
+	if registrantDB.Username != "" {
+		// Send a message about the deleted registrant to the fga-sync service
+		err = s.MessageBuilder.SendRemoveMeetingRegistrantAccess(ctx, models.MeetingRegistrantAccessMessage{
+			UID:        registrantDB.UID,
+			Username:   registrantDB.Username,
+			MeetingUID: registrantDB.MeetingUID,
+			Host:       registrantDB.Host,
+		})
+		if err != nil {
+			slog.ErrorContext(ctx, "error sending message about deleted registrant", logging.ErrKey, err, logging.PriorityCritical())
+			// Continue - this is cleanup, don't fail the entire operation
+		}
+	} else {
+		// This can happen when the registrant is not an LF user but rather a guest user.
+		slog.DebugContext(ctx, "no username for registrant, skipping access message")
+	}
+
+	return nil
+}
+
 // DeleteMeetingRegistrant deletes a registrant from a meeting
 func (s *MeetingsService) DeleteMeetingRegistrant(ctx context.Context, payload *meetingsvc.DeleteMeetingRegistrantPayload) error {
 	if !s.ServiceReady() {
@@ -438,44 +499,6 @@ func (s *MeetingsService) DeleteMeetingRegistrant(ctx context.Context, payload *
 		return domain.ErrInternal
 	}
 
-	// Delete the registrant with revision check
-	err = s.RegistrantRepository.Delete(ctx, registrantUID, revision)
-	if err != nil {
-		if errors.Is(err, domain.ErrRevisionMismatch) {
-			slog.WarnContext(ctx, "revision mismatch", logging.ErrKey, err)
-			return domain.ErrRevisionMismatch
-		}
-		if errors.Is(err, domain.ErrRegistrantNotFound) {
-			slog.WarnContext(ctx, "registrant not found", logging.ErrKey, err)
-			return domain.ErrRegistrantNotFound
-		}
-		slog.ErrorContext(ctx, "error deleting registrant", logging.ErrKey, err)
-		return domain.ErrInternal
-	}
-
-	slog.DebugContext(ctx, "deleted registrant")
-
-	// Send indexing delete message for the registrant
-	err = s.MessageBuilder.SendDeleteIndexMeetingRegistrant(ctx, registrantDB.UID)
-	if err != nil {
-		slog.ErrorContext(ctx, "error sending delete indexing message for registrant", logging.ErrKey, err, logging.PriorityCritical())
-	}
-
-	if registrantDB.Username != "" {
-		// Send a message about the deleted registrant to the fga-sync service
-		err = s.MessageBuilder.SendRemoveMeetingRegistrantAccess(ctx, models.MeetingRegistrantAccessMessage{
-			UID:        registrantDB.UID,
-			Username:   registrantDB.Username,
-			MeetingUID: registrantDB.MeetingUID,
-			Host:       registrantDB.Host,
-		})
-		if err != nil {
-			slog.ErrorContext(ctx, "error sending message about deleted registrant", logging.ErrKey, err, logging.PriorityCritical())
-		}
-	} else {
-		// This can happen when the registrant is not an LF user but rather a guest user.
-		slog.DebugContext(ctx, "no username for registrant, skipping access message")
-	}
-
-	return nil
+	// Use the helper to delete the registrant with cleanup
+	return s.deleteRegistrantWithCleanup(ctx, registrantDB, revision, false)
 }

--- a/internal/service/registrant_operations_test.go
+++ b/internal/service/registrant_operations_test.go
@@ -607,3 +607,128 @@ func TestMeetingsService_DeleteMeetingRegistrant(t *testing.T) {
 		})
 	}
 }
+
+func TestMeetingsService_deleteRegistrantWithCleanup(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	tests := []struct {
+		name              string
+		registrant        *models.Registrant
+		revision          uint64
+		skipRevisionCheck bool
+		setupMocks        func(*domain.MockRegistrantRepository, *domain.MockMessageBuilder)
+		wantErr           bool
+		expectedErr       error
+	}{
+		{
+			name: "successful cleanup with revision check",
+			registrant: &models.Registrant{
+				UID:        "registrant-1",
+				MeetingUID: "meeting-1",
+				Email:      "user@example.com",
+				Username:   "user123",
+				Host:       false,
+				CreatedAt:  &now,
+				UpdatedAt:  &now,
+			},
+			revision:          5,
+			skipRevisionCheck: false,
+			setupMocks: func(mockRegistrantRepo *domain.MockRegistrantRepository, mockBuilder *domain.MockMessageBuilder) {
+				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(5)).Return(nil)
+				mockBuilder.On("SendDeleteIndexMeetingRegistrant", mock.Anything, "registrant-1").Return(nil)
+				mockBuilder.On("SendRemoveMeetingRegistrantAccess", mock.Anything, mock.MatchedBy(func(msg models.MeetingRegistrantAccessMessage) bool {
+					return msg.UID == "registrant-1" && msg.Username == "user123" && msg.MeetingUID == "meeting-1" && msg.Host == false
+				})).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "successful cleanup skipping revision check",
+			registrant: &models.Registrant{
+				UID:        "registrant-2",
+				MeetingUID: "meeting-2",
+				Email:      "user2@example.com",
+				Username:   "user456",
+				Host:       true,
+				CreatedAt:  &now,
+				UpdatedAt:  &now,
+			},
+			revision:          10,
+			skipRevisionCheck: true,
+			setupMocks: func(mockRegistrantRepo *domain.MockRegistrantRepository, mockBuilder *domain.MockMessageBuilder) {
+				// When skipping revision check, it uses revision 0
+				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-2", uint64(0)).Return(nil)
+				mockBuilder.On("SendDeleteIndexMeetingRegistrant", mock.Anything, "registrant-2").Return(nil)
+				mockBuilder.On("SendRemoveMeetingRegistrantAccess", mock.Anything, mock.MatchedBy(func(msg models.MeetingRegistrantAccessMessage) bool {
+					return msg.UID == "registrant-2" && msg.Username == "user456" && msg.MeetingUID == "meeting-2" && msg.Host == true
+				})).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "registrant without username (guest user)",
+			registrant: &models.Registrant{
+				UID:        "guest-registrant",
+				MeetingUID: "meeting-3",
+				Email:      "guest@example.com",
+				Username:   "", // No username - guest user
+				Host:       false,
+				CreatedAt:  &now,
+				UpdatedAt:  &now,
+			},
+			revision:          1,
+			skipRevisionCheck: false,
+			setupMocks: func(mockRegistrantRepo *domain.MockRegistrantRepository, mockBuilder *domain.MockMessageBuilder) {
+				mockRegistrantRepo.On("Delete", mock.Anything, "guest-registrant", uint64(1)).Return(nil)
+				mockBuilder.On("SendDeleteIndexMeetingRegistrant", mock.Anything, "guest-registrant").Return(nil)
+				// No access message expected for guest users
+			},
+			wantErr: false,
+		},
+		{
+			name: "registrant already deleted with skip revision check (should not error)",
+			registrant: &models.Registrant{
+				UID:        "already-deleted",
+				MeetingUID: "meeting-4",
+				Email:      "deleted@example.com",
+				Username:   "deleteduser",
+				Host:       false,
+				CreatedAt:  &now,
+				UpdatedAt:  &now,
+			},
+			revision:          0,
+			skipRevisionCheck: true,
+			setupMocks: func(mockRegistrantRepo *domain.MockRegistrantRepository, mockBuilder *domain.MockMessageBuilder) {
+				// Registrant already deleted
+				mockRegistrantRepo.On("Delete", mock.Anything, "already-deleted", uint64(0)).Return(domain.ErrRegistrantNotFound)
+			},
+			wantErr: false, // Should not error when skipRevisionCheck is true
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, mockMeetingRepo, mockBuilder, _ := setupServiceForTesting()
+			mockRegistrantRepo := &domain.MockRegistrantRepository{}
+			service.RegistrantRepository = mockRegistrantRepo
+
+			tt.setupMocks(mockRegistrantRepo, mockBuilder)
+
+			err := service.deleteRegistrantWithCleanup(ctx, tt.registrant, tt.revision, tt.skipRevisionCheck)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockMeetingRepo.AssertExpectations(t)
+			mockRegistrantRepo.AssertExpectations(t)
+			mockBuilder.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements meeting deletion event handling via NATS messaging
- Adds automatic cleanup of all associated registrants when a meeting is deleted
- Fixes NATS key encoding issues in registrant repository

## Changes Made
- **New message handler**: `HandleMeetingDeleted` processes meeting deletion events
- **Concurrent cleanup**: Registrants are cleaned up concurrently with rate limiting (10 goroutines max)
- **Enhanced messaging**: Support for both fire-and-forget and request-reply NATS messages
- **Bug fix**: Fixed NATS key encoding in `deleteIndices` method to prevent "invalid key" errors
- **Validation**: Added empty email handling to prevent invalid NATS keys

## Message Flow
1. Meeting deletion triggers `MeetingDeletedMessage` publication
2. Service subscribes to `lfx.meetings-api.meeting_deleted` subject
3. Handler retrieves all meeting registrants
4. Concurrent goroutines delete registrants and send cleanup messages:
   - Index deletion messages for search services
   - Access removal messages for permission services

## Technical Details
- Uses semaphore pattern to limit concurrent operations
- Proper error handling with detailed logging
- Maintains data consistency during cleanup operations
- Backwards compatible with existing functionality

## Test Coverage
- Comprehensive unit tests for all scenarios
- Error handling and edge case coverage
- Integration tests for end-to-end flows
- Mock implementations for external dependencies

## Related
- Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-324

🤖 Generated with [Claude Code](https://claude.ai/code)