### PR TITLE
Bump chart version

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "latest"


### PR DESCRIPTION
This pull request includes a minor version bump for the `lfx-v2-meeting-service` Helm chart to reflect the latest changes.

* Increased the chart version in `charts/lfx-v2-meeting-service/Chart.yaml` from `0.3.1` to `0.3.2`.