### PR TITLE
Bump chart version to 0.4.0

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.3.13
+version: 0.4.0
 appVersion: "latest"


### PR DESCRIPTION
This pull request updates the Helm chart version for the `lfx-v2-meeting-service` to `0.4.0` to reflect recent changes or improvements.

* Bumped the `version` field in `charts/lfx-v2-meeting-service/Chart.yaml` from `0.3.13` to `0.4.0`.