### PR TITLE
feat: add indexer and FGA sync messaging for past meetings and participants

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "latest"

--- a/internal/handlers/zoom_webhook_handlers.go
+++ b/internal/handlers/zoom_webhook_handlers.go
@@ -401,6 +401,37 @@ func (s *ZoomWebhookHandler) handleMeetingStartedEvent(ctx context.Context, even
 		return fmt.Errorf("failed to update past meeting with new session: %w", err)
 	}
 
+	// Send indexing and FGA sync messages for the updated past meeting
+	// Use WorkerPool for concurrent message sending
+	pool := concurrent.NewWorkerPool(2)
+	messages := []func() error{
+		func() error {
+			// Send indexing message
+			return s.pastMeetingService.MessageBuilder.SendIndexPastMeeting(ctx, models.ActionUpdated, *pastMeeting)
+		},
+		func() error {
+			// Send FGA sync message for permissions
+			committees := make([]string, len(pastMeeting.Committees))
+			for i, committee := range pastMeeting.Committees {
+				committees[i] = committee.UID
+			}
+			isPublic := pastMeeting.Visibility == "public"
+
+			return s.pastMeetingService.MessageBuilder.SendUpdateAccessPastMeeting(ctx, models.PastMeetingAccessMessage{
+				UID:        pastMeeting.UID,
+				MeetingUID: pastMeeting.MeetingUID,
+				Public:     isPublic,
+				ProjectUID: pastMeeting.ProjectUID,
+				Committees: committees,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages for past meeting update", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
+	}
+
 	slog.DebugContext(ctx, "successfully updated past meeting with new session",
 		"past_meeting_uid", pastMeeting.UID,
 		"session_uid", newSession.UID,
@@ -853,6 +884,25 @@ func (s *ZoomWebhookHandler) createPastMeetingParticipants(ctx context.Context, 
 
 			err := s.pastMeetingParticipantService.PastMeetingParticipantRepository.Create(ctx, participant)
 
+			// Attempt to send indexing and access control messages.
+			// We should just log a warning if they fail, but continue with the rest of the processing.
+			errIndex := s.pastMeetingParticipantService.MessageBuilder.SendIndexPastMeetingParticipant(ctx, models.ActionCreated, *participant)
+			if errIndex != nil {
+				slog.WarnContext(ctx, "failed to send index past meeting participant message", logging.ErrKey, errIndex)
+			}
+
+			errAccess := s.pastMeetingParticipantService.MessageBuilder.SendPutPastMeetingParticipantAccess(ctx, models.PastMeetingParticipantAccessMessage{
+				UID:            participant.UID,
+				PastMeetingUID: participant.PastMeetingUID,
+				Username:       participant.Username,
+				Host:           participant.Host,
+				IsInvited:      participant.IsInvited,
+				IsAttended:     participant.IsAttended,
+			})
+			if errAccess != nil {
+				slog.WarnContext(ctx, "failed to send put past meeting participant access message", logging.ErrKey, errAccess)
+			}
+
 			// Use mutex to protect shared counters
 			mu.Lock()
 			defer mu.Unlock()
@@ -960,6 +1010,37 @@ func (s *ZoomWebhookHandler) updatePastMeetingSessionEndTime(ctx context.Context
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to update past meeting with session end time", logging.ErrKey, err)
 		return fmt.Errorf("failed to update past meeting: %w", err)
+	}
+
+	// Send indexing and FGA sync messages for the updated past meeting
+	// Use WorkerPool for concurrent message sending
+	pool := concurrent.NewWorkerPool(2)
+	messages := []func() error{
+		func() error {
+			// Send indexing message
+			return s.pastMeetingService.MessageBuilder.SendIndexPastMeeting(ctx, models.ActionUpdated, *pastMeeting)
+		},
+		func() error {
+			// Send FGA sync message for permissions
+			committees := make([]string, len(pastMeeting.Committees))
+			for i, committee := range pastMeeting.Committees {
+				committees[i] = committee.UID
+			}
+			isPublic := pastMeeting.Visibility == "public"
+
+			return s.pastMeetingService.MessageBuilder.SendUpdateAccessPastMeeting(ctx, models.PastMeetingAccessMessage{
+				UID:        pastMeeting.UID,
+				MeetingUID: pastMeeting.MeetingUID,
+				Public:     isPublic,
+				ProjectUID: pastMeeting.ProjectUID,
+				Committees: committees,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages for past meeting session update", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
 	}
 
 	slog.InfoContext(ctx, "successfully updated past meeting session end time",
@@ -1137,6 +1218,37 @@ func (s *ZoomWebhookHandler) createPastMeetingRecordWithSession(ctx context.Cont
 		return nil, fmt.Errorf("failed to create past meeting record: %w", err)
 	}
 
+	// Send indexing and FGA sync messages for the newly created past meeting
+	// Use WorkerPool for concurrent message sending
+	pool := concurrent.NewWorkerPool(2)
+	messages := []func() error{
+		func() error {
+			// Send indexing message
+			return s.pastMeetingService.MessageBuilder.SendIndexPastMeeting(ctx, models.ActionCreated, *pastMeeting)
+		},
+		func() error {
+			// Send FGA sync message for permissions
+			committees := make([]string, len(pastMeeting.Committees))
+			for i, committee := range pastMeeting.Committees {
+				committees[i] = committee.UID
+			}
+			isPublic := pastMeeting.Visibility == "public"
+
+			return s.pastMeetingService.MessageBuilder.SendUpdateAccessPastMeeting(ctx, models.PastMeetingAccessMessage{
+				UID:        pastMeeting.UID,
+				MeetingUID: pastMeeting.MeetingUID,
+				Public:     isPublic,
+				ProjectUID: pastMeeting.ProjectUID,
+				Committees: committees,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages for past meeting creation", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
+	}
+
 	successLogFields := []any{
 		"past_meeting_uid", pastMeeting.UID,
 		"meeting_uid", meeting.UID,
@@ -1203,6 +1315,29 @@ func (s *ZoomWebhookHandler) updateParticipantAttendance(ctx context.Context, pa
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to update participant attendance", logging.ErrKey, err)
 		return fmt.Errorf("failed to update participant: %w", err)
+	}
+
+	// Use WorkerPool for concurrent NATS message sending
+	pool := concurrent.NewWorkerPool(2) // 2 messages to send
+	messages := []func() error{
+		func() error {
+			return s.pastMeetingParticipantService.MessageBuilder.SendIndexPastMeetingParticipant(ctx, models.ActionUpdated, *participant)
+		},
+		func() error {
+			return s.pastMeetingParticipantService.MessageBuilder.SendPutPastMeetingParticipantAccess(ctx, models.PastMeetingParticipantAccessMessage{
+				UID:            participant.UID,
+				PastMeetingUID: participant.PastMeetingUID,
+				Username:       participant.Username,
+				Host:           participant.Host,
+				IsInvited:      participant.IsInvited,
+				IsAttended:     participant.IsAttended,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
 	}
 
 	slog.DebugContext(ctx, "successfully updated participant attendance and session",
@@ -1321,6 +1456,29 @@ func (s *ZoomWebhookHandler) updateParticipantSessionLeaveTime(
 		return fmt.Errorf("failed to update participant: %w", err)
 	}
 
+	// Use WorkerPool for concurrent NATS message sending
+	pool := concurrent.NewWorkerPool(2) // 2 messages to send
+	messages := []func() error{
+		func() error {
+			return s.pastMeetingParticipantService.MessageBuilder.SendIndexPastMeetingParticipant(ctx, models.ActionCreated, *participant)
+		},
+		func() error {
+			return s.pastMeetingParticipantService.MessageBuilder.SendPutPastMeetingParticipantAccess(ctx, models.PastMeetingParticipantAccessMessage{
+				UID:            participant.UID,
+				PastMeetingUID: participant.PastMeetingUID,
+				Username:       participant.Username,
+				Host:           participant.Host,
+				IsInvited:      participant.IsInvited,
+				IsAttended:     participant.IsAttended,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
+	}
+
 	slog.DebugContext(ctx, "successfully updated participant session leave time",
 		"participant_uid", participant.UID,
 		"session_uid", sessionUID,
@@ -1431,6 +1589,29 @@ func (s *ZoomWebhookHandler) createParticipantRecord(ctx context.Context, pastMe
 			logging.ErrKey, err,
 		)
 		return nil, fmt.Errorf("failed to create participant: %w", err)
+	}
+
+	// Use WorkerPool for concurrent NATS message sending
+	pool := concurrent.NewWorkerPool(2) // 2 messages to send
+	messages := []func() error{
+		func() error {
+			return s.pastMeetingParticipantService.MessageBuilder.SendIndexPastMeetingParticipant(ctx, models.ActionCreated, *newParticipant)
+		},
+		func() error {
+			return s.pastMeetingParticipantService.MessageBuilder.SendPutPastMeetingParticipantAccess(ctx, models.PastMeetingParticipantAccessMessage{
+				UID:            newParticipant.UID,
+				PastMeetingUID: newParticipant.PastMeetingUID,
+				Username:       newParticipant.Username,
+				Host:           newParticipant.Host,
+				IsInvited:      newParticipant.IsInvited,
+				IsAttended:     newParticipant.IsAttended,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
 	}
 
 	// Log success with appropriate details


### PR DESCRIPTION
## Summary
- Add indexing and FGA sync messages for past meeting creation and updates in Zoom webhook handlers
- Add indexing and FGA sync messages for past meeting participant creation and updates
- Ensure proper data indexing for search functionality and permission synchronization for access control

## Changes Made
### Past Meeting Messaging
- **createPastMeetingRecordWithSession**: Added indexing and FGA sync messages for new past meeting creation
- **handleMeetingStartedEvent**: Added indexing and FGA sync messages for session updates when existing meetings get new sessions
- **updatePastMeetingSessionEndTime**: Added indexing and FGA sync messages when meeting sessions are updated with end times

### Past Meeting Participant Messaging  
- **createPastMeetingParticipants**: Added indexing and FGA sync messages for bulk participant creation from registrants
- **updateParticipantAttendance**: Added indexing and FGA sync messages when participants join meetings and attendance is updated
- **createParticipantRecord**: Added indexing and FGA sync messages for individual participant creation from webhook events

## Technical Implementation
- Uses WorkerPool for concurrent message sending to improve performance
- Non-blocking design - messaging failures don't interrupt webhook processing  
- Proper error logging with warnings instead of failures for messaging issues
- Consistent message patterns across all creation and update operations

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Manual testing of Zoom webhook events to verify messages are sent
- [x] Verify indexer receives past meeting and participant data
- [x] Verify FGA sync receives proper permission updates

🤖 Generated with [Claude Code](https://claude.ai/code)