### PR TITLE
Fix indexing data from event handler where there is no authorization header set

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "latest"

--- a/internal/infrastructure/messaging/nats_messaging.go
+++ b/internal/infrastructure/messaging/nats_messaging.go
@@ -62,6 +62,11 @@ func (m *MessageBuilder) sendIndexerMessage(ctx context.Context, subject string,
 	headers := make(map[string]string)
 	if authorization, ok := ctx.Value(constants.AuthorizationContextID).(string); ok {
 		headers[constants.AuthorizationHeader] = authorization
+	} else {
+		// Fallback for system-generated events (webhooks, etc.) that don't have user auth context
+		// This is just a dummy value so that the indexer service can still process the message,
+		// given that it requires an authorization header.
+		headers[constants.AuthorizationHeader] = "Bearer meeting-service"
 	}
 	if principal, ok := ctx.Value(constants.PrincipalContextID).(string); ok {
 		headers[constants.XOnBehalfOfHeader] = principal


### PR DESCRIPTION
This pull request includes a minor version bump for the Helm chart and an improvement to the messaging logic to ensure system-generated events are properly authorized. The most important changes are:

Helm chart update:

* Bumped the `version` field in `charts/lfx-v2-meeting-service/Chart.yaml` from `0.4.1` to `0.4.2` to reflect the latest changes.

Messaging and authorization:

* Updated the `sendIndexerMessage` function in `internal/infrastructure/messaging/nats_messaging.go` to provide a fallback dummy authorization header (`Bearer meeting-service`) for system-generated events (such as webhooks) that don't have a user auth context, ensuring the indexer service can process these messages.