### PR TITLE
[LFXV2-451] Fix registrant type handling for direct and committee registrants

### DIFF
--- a/cmd/meeting-api/service/request_converters.go
+++ b/cmd/meeting-api/service/request_converters.go
@@ -203,6 +203,7 @@ func ConvertCreateRegistrantPayloadToDomain(goaRegistrant *meetingservice.Create
 		FirstName:          utils.StringValue(goaRegistrant.FirstName),
 		LastName:           utils.StringValue(goaRegistrant.LastName),
 		Host:               utils.BoolValue(goaRegistrant.Host),
+		Type:               models.RegistrantTypeDirect, // Creating a registrant via the API must be direct type
 		JobTitle:           utils.StringValue(goaRegistrant.JobTitle),
 		OccurrenceID:       utils.StringValue(goaRegistrant.OccurrenceID),
 		OrgName:            utils.StringValue(goaRegistrant.OrgName),
@@ -227,6 +228,7 @@ func ConvertUpdateRegistrantPayloadToDomain(payload *meetingservice.UpdateMeetin
 		FirstName:          utils.StringValue(payload.FirstName),
 		LastName:           utils.StringValue(payload.LastName),
 		Host:               utils.BoolValue(payload.Host),
+		Type:               "", // This will be populated by the service because it depends on the existing value for the registrant
 		JobTitle:           utils.StringValue(payload.JobTitle),
 		OccurrenceID:       utils.StringValue(payload.OccurrenceID),
 		OrgName:            utils.StringValue(payload.OrgName),

--- a/internal/domain/mocks/registrant_repository.go
+++ b/internal/domain/mocks/registrant_repository.go
@@ -73,6 +73,14 @@ func (m *MockRegistrantRepository) ExistsByMeetingAndEmail(ctx context.Context, 
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockRegistrantRepository) GetByMeetingAndEmail(ctx context.Context, meetingUID, email string) (*models.Registrant, uint64, error) {
+	args := m.Called(ctx, meetingUID, email)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(uint64), args.Error(2)
+	}
+	return args.Get(0).(*models.Registrant), args.Get(1).(uint64), args.Error(2)
+}
+
 // NewMockRegistrantRepository creates a new mock registrant repository for testing
 func NewMockRegistrantRepository(t interface{ Cleanup(func()) }) *MockRegistrantRepository {
 	return &MockRegistrantRepository{}

--- a/internal/domain/models/registrant_conversions.go
+++ b/internal/domain/models/registrant_conversions.go
@@ -33,7 +33,6 @@ func MergeUpdateRegistrantRequest(reqRegistrant *Registrant, existingRegistrant 
 		FirstName:    utils.CoalesceString(reqRegistrant.FirstName, existingRegistrant.FirstName),
 		LastName:     utils.CoalesceString(reqRegistrant.LastName, existingRegistrant.LastName),
 		Host:         reqRegistrant.Host,
-		Type:         existingRegistrant.Type, // Preserve existing type
 		JobTitle:     utils.CoalesceString(reqRegistrant.JobTitle, existingRegistrant.JobTitle),
 		OccurrenceID: utils.CoalesceString(reqRegistrant.OccurrenceID, existingRegistrant.OccurrenceID),
 		OrgName:      utils.CoalesceString(reqRegistrant.OrgName, existingRegistrant.OrgName),
@@ -41,6 +40,16 @@ func MergeUpdateRegistrantRequest(reqRegistrant *Registrant, existingRegistrant 
 		Username:     utils.CoalesceString(reqRegistrant.Username, existingRegistrant.Username),
 		CreatedAt:    existingRegistrant.CreatedAt,
 		UpdatedAt:    &now,
+	}
+
+	// Set optional fields
+	registrant.Type = existingRegistrant.Type
+	if reqRegistrant.Type != "" {
+		registrant.Type = reqRegistrant.Type
+	}
+	registrant.CommitteeUID = existingRegistrant.CommitteeUID
+	if reqRegistrant.CommitteeUID != nil {
+		registrant.CommitteeUID = reqRegistrant.CommitteeUID
 	}
 
 	// TODO: get the actual values from the system once there is an org service

--- a/internal/domain/models/registrant_conversions.go
+++ b/internal/domain/models/registrant_conversions.go
@@ -33,6 +33,7 @@ func MergeUpdateRegistrantRequest(reqRegistrant *Registrant, existingRegistrant 
 		FirstName:    utils.CoalesceString(reqRegistrant.FirstName, existingRegistrant.FirstName),
 		LastName:     utils.CoalesceString(reqRegistrant.LastName, existingRegistrant.LastName),
 		Host:         reqRegistrant.Host,
+		Type:         existingRegistrant.Type, // Preserve existing type
 		JobTitle:     utils.CoalesceString(reqRegistrant.JobTitle, existingRegistrant.JobTitle),
 		OccurrenceID: utils.CoalesceString(reqRegistrant.OccurrenceID, existingRegistrant.OccurrenceID),
 		OrgName:      utils.CoalesceString(reqRegistrant.OrgName, existingRegistrant.OrgName),

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -52,6 +52,7 @@ type RegistrantRepository interface {
 	// Bulk operations
 	ListByMeeting(ctx context.Context, meetingUID string) ([]*models.Registrant, error)
 	ListByEmail(ctx context.Context, email string) ([]*models.Registrant, error)
+	GetByMeetingAndEmail(ctx context.Context, meetingUID, email string) (*models.Registrant, uint64, error)
 }
 
 // PastMeetingRepository defines the interface for past meeting storage operations.

--- a/internal/service/committee_sync_service.go
+++ b/internal/service/committee_sync_service.go
@@ -308,6 +308,48 @@ func (s *CommitteeSyncService) AddCommitteeMembersAsRegistrants(
 	return nil
 }
 
+// updateRegistrantToCommitteeType updates an existing registrant to committee type
+func (s *CommitteeSyncService) updateRegistrantToCommitteeType(
+	ctx context.Context,
+	existingRegistrant *models.Registrant,
+	revision uint64,
+	committeeUID string,
+) error {
+	// Check if registrant is already a committee type
+	if existingRegistrant.Type == models.RegistrantTypeCommittee {
+		slog.DebugContext(ctx, "registrant already has committee type",
+			"meeting_uid", existingRegistrant.MeetingUID,
+			"registrant_uid", existingRegistrant.UID,
+			"email", existingRegistrant.Email,
+			"committee_uid", committeeUID)
+		return nil
+	}
+
+	// Update only the type and committee UID
+	existingRegistrant.Type = models.RegistrantTypeCommittee
+	existingRegistrant.CommitteeUID = &committeeUID
+
+	// Update the registrant in the repository
+	err := s.registrantRepository.Update(ctx, existingRegistrant, revision)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to update registrant to committee type",
+			"meeting_uid", existingRegistrant.MeetingUID,
+			"registrant_uid", existingRegistrant.UID,
+			"email", existingRegistrant.Email,
+			"committee_uid", committeeUID,
+			logging.ErrKey, err)
+		return fmt.Errorf("failed to update registrant to committee type: %w", err)
+	}
+
+	slog.InfoContext(ctx, "updated registrant to committee type",
+		"meeting_uid", existingRegistrant.MeetingUID,
+		"registrant_uid", existingRegistrant.UID,
+		"email", existingRegistrant.Email,
+		"committee_uid", committeeUID)
+
+	return nil
+}
+
 // createRegistrantForCommitteeMember creates a registrant record for a committee member
 func (s *CommitteeSyncService) createRegistrantForCommitteeMember(
 	ctx context.Context,
@@ -315,22 +357,19 @@ func (s *CommitteeSyncService) createRegistrantForCommitteeMember(
 	committeeUID string,
 	member models.CommitteeMember,
 ) error {
-	// Check if registrant already exists by email to avoid duplicates
-	exists, err := s.registrantRepository.ExistsByMeetingAndEmail(ctx, meetingUID, member.Email)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to check registrant existence",
+	// Check if registrant already exists by email
+	existingRegistrant, revision, err := s.registrantRepository.GetByMeetingAndEmail(ctx, meetingUID, member.Email)
+	if err != nil && err != domain.ErrRegistrantNotFound {
+		slog.ErrorContext(ctx, "failed to check for existing registrant",
 			"meeting_uid", meetingUID,
 			"email", member.Email,
 			logging.ErrKey, err)
-		return fmt.Errorf("failed to check registrant existence: %w", err)
+		return fmt.Errorf("failed to check for existing registrant: %w", err)
 	}
 
-	if exists {
-		slog.DebugContext(ctx, "registrant already exists, skipping committee member",
-			"meeting_uid", meetingUID,
-			"email", member.Email,
-			"committee_uid", committeeUID)
-		return nil
+	if existingRegistrant != nil {
+		// Update existing registrant to committee type if needed
+		return s.updateRegistrantToCommitteeType(ctx, existingRegistrant, revision, committeeUID)
 	}
 
 	// Create registrant for committee member using registrant service (includes email invitations)


### PR DESCRIPTION
## Summary
- Fixed issue where registrant type was empty when creating registrants via API
- Added logic to update existing direct registrants to committee type when added through committee sync
- Improved efficiency by adding GetByMeetingAndEmail method that returns both registrant and revision

## Changes
- Set `Type` field to `RegistrantTypeDirect` when creating registrants via API
- Preserve existing type when updating registrants
- Added `GetByMeetingAndEmail` repository method to avoid multiple NATS calls
- Updated committee sync service to convert direct registrants to committee type when needed

## JIRA Ticket
[LFXV2-451](https://linuxfoundation.atlassian.net/browse/LFXV2-451)

## Test Plan
- [x] Create a registrant via API and verify type is set to "direct"
- [x] Add a committee with a member who is already a direct registrant
- [x] Verify the existing registrant is updated to committee type
- [x] Verify committee members who don't exist are created with committee type

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-451]: https://linuxfoundation.atlassian.net/browse/LFXV2-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ