### PR TITLE
[LFXV2-486]: Enhance email templates and ICS files with comprehensive meeting information

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL=
 # Development Settings
 SKIP_ETAG_VALIDATION=true
 
+# LFX Environment Configuration
+# Controls which LFX app domain is used for meeting URLs
+# Options: dev, staging, prod (defaults to prod if not set)
+LFX_ENVIRONMENT=dev
+
 # Zoom Integration
 # Required for creating and managing Zoom meetings when platform="Zoom"
 # Get these values from 1Password.

--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ The service can be configured via environment variables:
 | `JWT_AUDIENCE` | JWT token audience | `lfx-v2-meeting-service` |
 | `SKIP_ETAG_VALIDATION` | Skip ETag validation (dev only) | `false` |
 | `JWT_AUTH_DISABLED_MOCK_LOCAL_PRINCIPAL` | Mock principal for local dev (dev only) | `""` |
+| `LFX_ENVIRONMENT` | LFX app domain environment (dev, staging, prod) | `prod` |
 
 ### Zoom Integration Configuration
 

--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.4.7
+version: 0.4.8
 appVersion: "latest"

--- a/charts/lfx-v2-meeting-service/values.yaml
+++ b/charts/lfx-v2-meeting-service/values.yaml
@@ -72,6 +72,9 @@ app:
     # ZOOM_WEBHOOK_SECRET_TOKEN is optional
     ZOOM_WEBHOOK_SECRET_TOKEN:
       value: null
+    # LFX_ENVIRONMENT is optional (dev, staging, prod) - defaults to prod if not set
+    LFX_ENVIRONMENT:
+      value: prod
 
 # traefik is the configuration for Traefik Gateway API routing
 traefik:

--- a/cmd/meeting-api/config.go
+++ b/cmd/meeting-api/config.go
@@ -24,6 +24,7 @@ type environment struct {
 	NatsURL            string
 	Port               string
 	SkipEtagValidation bool
+	LFXEnvironment     string
 	EmailConfig        emailConfig
 }
 
@@ -81,10 +82,24 @@ func parseEnv() environment {
 		skipEtagValidation = true
 	}
 
+	lfxEnvironmentRaw := os.Getenv("LFX_ENVIRONMENT")
+	var lfxEnvironment string
+	switch lfxEnvironmentRaw {
+	case "dev", "development":
+		lfxEnvironment = "dev"
+	case "staging", "stg", "stage":
+		lfxEnvironment = "staging"
+	case "prod", "production":
+		lfxEnvironment = "prod"
+	default:
+		lfxEnvironment = "prod" // Default to production
+	}
+
 	return environment{
 		NatsURL:            natsURL,
 		Port:               port,
 		SkipEtagValidation: skipEtagValidation,
+		LFXEnvironment:     lfxEnvironment,
 		EmailConfig:        parseEmailConfig(),
 	}
 }

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -70,6 +70,7 @@ func main() {
 	// Initialize services
 	serviceConfig := service.ServiceConfig{
 		SkipEtagValidation: env.SkipEtagValidation,
+		LFXEnvironment:     env.LFXEnvironment,
 	}
 	messageBuilder := messaging.NewMessageBuilder(natsConn)
 	authService := service.NewAuthService(jwtAuth)

--- a/internal/domain/email.go
+++ b/internal/domain/email.go
@@ -29,6 +29,7 @@ type EmailInvitation struct {
 	Description    string
 	JoinLink       string
 	ProjectName    string             // Optional project name for context
+	Platform       string             // Meeting platform (e.g., "Zoom")
 	MeetingID      string             // Zoom meeting ID for dial-in
 	Passcode       string             // Zoom passcode
 	Recurrence     *models.Recurrence // Recurrence pattern for ICS
@@ -63,6 +64,7 @@ type EmailUpdatedInvitation struct {
 	Description    string
 	JoinLink       string
 	ProjectName    string             // Optional project name for context
+	Platform       string             // Meeting platform (e.g., "Zoom")
 	MeetingID      string             // Zoom meeting ID for dial-in
 	Passcode       string             // Zoom passcode
 	Recurrence     *models.Recurrence // Recurrence pattern for ICS

--- a/internal/handlers/meeting_handlers.go
+++ b/internal/handlers/meeting_handlers.go
@@ -381,7 +381,7 @@ func (s *MeetingHandler) meetingUpdatedInvitations(ctx context.Context, msg mode
 				Duration:       meeting.Duration,
 				Timezone:       meeting.Timezone,
 				Description:    meeting.Description,
-				JoinLink:       constants.GenerateLFXMeetingURL(meeting.UID, meeting.Password),
+				JoinLink:       constants.GenerateLFXMeetingURL(meeting.UID, meeting.Password, s.registrantService.Config.LFXEnvironment),
 				Platform:       meeting.Platform,
 				MeetingID:      meetingID,
 				Passcode:       passcode,

--- a/internal/handlers/meeting_handlers.go
+++ b/internal/handlers/meeting_handlers.go
@@ -382,6 +382,7 @@ func (s *MeetingHandler) meetingUpdatedInvitations(ctx context.Context, msg mode
 				Timezone:       meeting.Timezone,
 				Description:    meeting.Description,
 				JoinLink:       constants.GenerateLFXMeetingURL(meeting.UID, meeting.Password),
+				Platform:       meeting.Platform,
 				MeetingID:      meetingID,
 				Passcode:       passcode,
 				Recurrence:     meeting.Recurrence,

--- a/internal/infrastructure/email/ics.go
+++ b/internal/infrastructure/email/ics.go
@@ -469,7 +469,7 @@ func buildDescription(description, meetingID, passcode, joinLink string, startTi
 		desc.WriteString("Dial-in Options:\n")
 		desc.WriteString("=========================\n\n")
 		desc.WriteString("Find your local number:\n")
-		desc.WriteString("https://zoom.us/u/abcdefg\n\n")
+		desc.WriteString("https://zoom.us/zoomconference\n\n")
 		desc.WriteString("After dialing, enter Meeting ID: ")
 		desc.WriteString(meetingID)
 		desc.WriteString("#\n")

--- a/internal/infrastructure/email/ics.go
+++ b/internal/infrastructure/email/ics.go
@@ -52,6 +52,7 @@ type ICSMeetingInvitationParams struct {
 	MeetingID      string
 	Passcode       string
 	RecipientEmail string
+	ProjectName    string
 	Recurrence     *models.Recurrence
 }
 
@@ -108,7 +109,7 @@ func (g *ICSGenerator) GenerateMeetingInvitationICS(param ICSMeetingInvitationPa
 	ics.WriteString(fmt.Sprintf("SUMMARY:%s\r\n", escapeICSText(param.MeetingTitle)))
 
 	// Build enhanced description with meeting details
-	descriptionText := buildDescription(param.Description, param.MeetingID, param.Passcode, param.JoinLink, param.StartTime, param.Duration, param.Timezone, param.Recurrence)
+	descriptionText := buildDescription(param.Description, param.MeetingID, param.Passcode, param.JoinLink, param.ProjectName, param.StartTime, param.Duration, param.Timezone, param.Recurrence)
 	ics.WriteString(fmt.Sprintf("DESCRIPTION:%s\r\n", escapeICSText(descriptionText)))
 
 	// Location (Zoom URL) - only add if join link exists
@@ -167,6 +168,7 @@ type ICSMeetingUpdateParams struct {
 	MeetingID      string
 	Passcode       string
 	RecipientEmail string
+	ProjectName    string
 	Recurrence     *models.Recurrence
 	Sequence       int // Incremented sequence number for updates
 }
@@ -224,7 +226,7 @@ func (g *ICSGenerator) GenerateMeetingUpdateICS(params ICSMeetingUpdateParams) (
 	ics.WriteString(fmt.Sprintf("SUMMARY:%s\r\n", escapeICSText(params.MeetingTitle)))
 
 	// Build enhanced description with meeting details
-	descriptionText := buildDescription(params.Description, params.MeetingID, params.Passcode, params.JoinLink, params.StartTime, params.Duration, params.Timezone, params.Recurrence)
+	descriptionText := buildDescription(params.Description, params.MeetingID, params.Passcode, params.JoinLink, params.ProjectName, params.StartTime, params.Duration, params.Timezone, params.Recurrence)
 	ics.WriteString(fmt.Sprintf("DESCRIPTION:%s\r\n", escapeICSText(descriptionText)))
 
 	// Location (Zoom URL) - only add if join link exists
@@ -413,8 +415,15 @@ func getWeekdayName(weekday int) string {
 }
 
 // buildDescription builds the enhanced description with meeting details
-func buildDescription(description, meetingID, passcode, joinLink string, startTime time.Time, duration int, timezone string, recurrence *models.Recurrence) string {
+func buildDescription(description, meetingID, passcode, joinLink, projectName string, startTime time.Time, duration int, timezone string, recurrence *models.Recurrence) string {
 	var desc strings.Builder
+
+	// Add project information if available
+	if projectName != "" {
+		desc.WriteString("Project: ")
+		desc.WriteString(projectName)
+		desc.WriteString("\n\n")
+	}
 
 	// Add original description
 	if description != "" {

--- a/internal/infrastructure/email/ics_test.go
+++ b/internal/infrastructure/email/ics_test.go
@@ -31,6 +31,7 @@ func TestICSGenerator_GenerateMeetingICS(t *testing.T) {
 			MeetingID:      "123456789",
 			Passcode:       "abc123",
 			RecipientEmail: "user@example.com",
+			ProjectName:    "Test Project",
 			Recurrence:     nil,
 		})
 
@@ -69,6 +70,7 @@ func TestICSGenerator_GenerateMeetingICS(t *testing.T) {
 			MeetingID:      "987654321",
 			Passcode:       "xyz789",
 			RecipientEmail: "team@example.com",
+			ProjectName:    "",
 			Recurrence:     recurrence,
 		})
 
@@ -96,6 +98,7 @@ func TestICSGenerator_GenerateMeetingICS(t *testing.T) {
 			MeetingID:      "555555555",
 			Passcode:       "",
 			RecipientEmail: "group@example.com",
+			ProjectName:    "",
 			Recurrence:     recurrence,
 		})
 
@@ -122,6 +125,7 @@ func TestICSGenerator_GenerateMeetingICS(t *testing.T) {
 			MeetingID:      "",
 			Passcode:       "",
 			RecipientEmail: "manager@example.com",
+			ProjectName:    "",
 			Recurrence:     recurrence,
 		})
 
@@ -150,6 +154,7 @@ func TestICSGenerator_GenerateMeetingICS(t *testing.T) {
 			MeetingID:      "111111111",
 			Passcode:       "secure",
 			RecipientEmail: "board@example.com",
+			ProjectName:    "",
 			Recurrence:     recurrence,
 		})
 
@@ -169,6 +174,7 @@ func TestICSGenerator_GenerateMeetingICS(t *testing.T) {
 			MeetingID:      "",
 			Passcode:       "",
 			RecipientEmail: "office@example.com",
+			ProjectName:    "",
 			Recurrence:     nil,
 		})
 
@@ -335,12 +341,14 @@ func TestBuildDescription(t *testing.T) {
 			"123456789",
 			"abc123",
 			"https://zoom.us/j/123456789",
+			"Test Project",
 			startTime,
 			60,
 			"America/New_York",
 			recurrence,
 		)
 
+		assert.Contains(t, desc, "Project: Test Project")
 		assert.Contains(t, desc, "Original description")
 		assert.Contains(t, desc, "Meeting ID: 123456789")
 		assert.Contains(t, desc, "Passcode: abc123")
@@ -358,6 +366,7 @@ func TestBuildDescription(t *testing.T) {
 			"987654321",
 			"",
 			"https://zoom.us/j/987654321",
+			"",
 			startTime,
 			30,
 			"UTC",
@@ -374,6 +383,7 @@ func TestBuildDescription(t *testing.T) {
 	t.Run("without meeting details", func(t *testing.T) {
 		desc := buildDescription(
 			"Simple meeting",
+			"",
 			"",
 			"",
 			"",

--- a/internal/infrastructure/email/smtp_service.go
+++ b/internal/infrastructure/email/smtp_service.go
@@ -97,6 +97,7 @@ func (s *SMTPService) SendRegistrantInvitation(ctx context.Context, invitation d
 		MeetingID:      invitation.MeetingID,
 		Passcode:       invitation.Passcode,
 		RecipientEmail: invitation.RecipientEmail,
+		ProjectName:    invitation.ProjectName,
 		Recurrence:     invitation.Recurrence,
 	})
 	if err != nil {
@@ -235,6 +236,7 @@ func (s *SMTPService) SendRegistrantUpdatedInvitation(ctx context.Context, updat
 			MeetingID:      updatedInvitation.MeetingID,
 			Passcode:       updatedInvitation.Passcode,
 			RecipientEmail: updatedInvitation.RecipientEmail,
+			ProjectName:    updatedInvitation.ProjectName,
 			Recurrence:     updatedInvitation.Recurrence,
 			Sequence:       1, // Incremented sequence for updates
 		})

--- a/internal/infrastructure/email/templates/meeting_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_invitation.html
@@ -129,6 +129,12 @@
                 <span class="detail-label">Time Zone:</span>
                 {{.Timezone}}
             </div>
+            {{if .Recurrence}}
+            <div class="detail-row">
+                <span class="detail-label">Recurrence:</span>
+                {{formatRecurrence .Recurrence}}
+            </div>
+            {{end}}
         </div>
 
         {{if .Description}}

--- a/internal/infrastructure/email/templates/meeting_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_invitation.html
@@ -2,6 +2,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,43 +19,51 @@
             padding: 20px;
             background-color: #f5f5f5;
         }
+
         .container {
             background-color: white;
             border-radius: 8px;
             padding: 30px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
+
         .header {
             border-bottom: 2px solid #0068c8;
             padding-bottom: 20px;
             margin-bottom: 30px;
         }
+
         h1 {
             color: #0068c8;
             font-size: 24px;
             margin: 0;
         }
+
         .meeting-details {
             background-color: #f8f9fa;
             border-left: 4px solid #0068c8;
             padding: 20px;
             margin: 20px 0;
         }
+
         .detail-row {
             margin: 10px 0;
         }
+
         .detail-label {
             font-weight: bold;
             color: #555;
             display: inline-block;
-            width: 100px;
+            width: 140px;
         }
+
         .description {
             margin: 20px 0;
             padding: 15px;
             background-color: #fafafa;
             border-radius: 4px;
         }
+
         .join-button {
             display: inline-block;
             background-color: #0068c8;
@@ -65,9 +74,11 @@
             font-weight: bold;
             margin: 20px 0;
         }
+
         .join-button:hover {
             background-color: #0056a8;
         }
+
         .footer {
             margin-top: 30px;
             padding-top: 20px;
@@ -75,9 +86,11 @@
             font-size: 14px;
             color: #666;
         }
+
         .center {
             text-align: center;
         }
+
         .calendar-notice {
             margin-top: 20px;
             padding: 15px;
@@ -87,16 +100,18 @@
         }
     </style>
 </head>
+
 <body>
     <div class="container">
         <div class="header">
             <h1>Meeting Invitation</h1>
         </div>
-        
+
         <p>Dear {{if .RecipientName}}{{.RecipientName}}{{else}}Attendee{{end}},</p>
-        
-        <p>You have been invited to the following meeting{{if .ProjectName}} for <strong>{{.ProjectName}}</strong>{{end}}:</p>
-        
+
+        <p>You have been invited to the following meeting{{if .ProjectName}} for
+            <strong>{{.ProjectName}}</strong>{{end}}:</p>
+
         <div class="meeting-details">
             <div class="detail-row">
                 <span class="detail-label">Meeting:</span>
@@ -115,41 +130,65 @@
                 {{.Timezone}}
             </div>
         </div>
-        
+
         {{if .Description}}
         <div class="description">
             <strong>Description:</strong><br>
             {{.Description}}
         </div>
         {{end}}
-        
+
         {{if .JoinLink}}
         <div class="center">
             <a href="{{.JoinLink}}" class="join-button">Join Meeting</a>
         </div>
-        
+
         <p><small>Or copy and paste this link into your browser:</small><br>
-        <a href="{{.JoinLink}}">{{.JoinLink}}</a></p>
-        
+            <a href="{{.JoinLink}}">{{.JoinLink}}</a>
+        </p>
+
         {{if .MeetingID}}
         <p><small><strong>Meeting ID:</strong> {{.MeetingID}}<br>
-        {{if .Passcode}}<strong>Passcode:</strong> {{.Passcode}}{{end}}</small></p>
+                {{if .Passcode}}<strong>Passcode:</strong> {{.Passcode}}{{end}}</small></p>
+
+        {{if eq .Platform "Zoom"}}
+        <!-- Dial-in Options for Zoom -->
+        <div class="meeting-details">
+            <strong>📞 Zoom Dial-in Options</strong>
+            <div class="detail-row">
+                <span class="detail-label">Find your local number:</span>
+                <a href="https://zoom.us/zoomconference" target="_blank">https://zoom.us/zoomconference</a>
+            </div>
+            <div class="detail-row">
+                <span class="detail-label">After dialing:</span>
+                <small>Enter Meeting ID: <strong>{{.MeetingID}}#</strong></small>
+            </div>
+            {{if .Passcode}}
+            <div class="detail-row">
+                <span class="detail-label">Then enter:</span>
+                <small>Passcode: <strong>{{.Passcode}}#</strong></small>
+            </div>
+            {{end}}
+        </div>
+        {{end}}
         {{end}}
         {{else}}
         <p><em>Meeting link will be provided closer to the meeting time.</em></p>
         {{end}}
-        
+
         {{if .ICSAttachment}}
         <p class="calendar-notice">
             <strong>📅 Calendar Event Attached</strong><br>
-            A calendar file (.ics) is attached to this email. Open it to automatically add this meeting to your calendar application.
+            A calendar file (.ics) is attached to this email. Open it to automatically add this meeting to your calendar
+            application.
         </p>
         {{end}}
-        
+
         <div class="footer">
             <p>This is an automated email from the Linux Foundation Meeting Service.<br>
-            Please do not reply to this email.</p>
+                Please do not reply to this email.</p>
         </div>
     </div>
 </body>
+
 </html>

--- a/internal/infrastructure/email/templates/meeting_invitation.txt
+++ b/internal/infrastructure/email/templates/meeting_invitation.txt
@@ -13,7 +13,8 @@ Meeting Details:
 Meeting: {{.MeetingTitle}}
 Date & Time: {{formatTime .StartTime .Timezone}}
 Duration: {{formatDuration .Duration}}
-Time Zone: {{.Timezone}}
+Time Zone: {{.Timezone}}{{if .Recurrence}}
+Recurrence: {{formatRecurrence .Recurrence}}{{end}}
 
 {{if .Description}}Description:
 {{.Description}}

--- a/internal/infrastructure/email/templates/meeting_invitation.txt
+++ b/internal/infrastructure/email/templates/meeting_invitation.txt
@@ -23,6 +23,13 @@ Time Zone: {{.Timezone}}
 {{if .MeetingID}}
 Meeting ID: {{.MeetingID}}{{if .Passcode}}
 Passcode: {{.Passcode}}{{end}}
+{{if eq .Platform "Zoom"}}
+
+📞 Zoom Dial-in Options:
+Find your local number: https://zoom.us/zoomconference
+After dialing: Enter Meeting ID: {{.MeetingID}}#{{if .Passcode}}
+Then enter: Passcode: {{.Passcode}}#{{end}}
+{{end}}
 {{end}}{{else}}Meeting link will be provided closer to the meeting time.
 {{end}}
 {{if .ICSAttachment}}

--- a/internal/infrastructure/email/templates/meeting_updated_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_updated_invitation.html
@@ -173,6 +173,12 @@
                 <span class="detail-label">Time Zone:</span>
                 {{.Timezone}}
             </div>
+            {{if .Recurrence}}
+            <div class="detail-row">
+                <span class="detail-label">Recurrence:</span>
+                {{formatRecurrence .Recurrence}}
+            </div>
+            {{end}}
         </div>
 
         {{if .Description}}

--- a/internal/infrastructure/email/templates/meeting_updated_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_updated_invitation.html
@@ -2,6 +2,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,22 +19,26 @@
             padding: 20px;
             background-color: #f5f5f5;
         }
+
         .container {
             background-color: white;
             border-radius: 8px;
             padding: 30px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
+
         .header {
             border-bottom: 2px solid #0068c8;
             padding-bottom: 20px;
             margin-bottom: 30px;
         }
+
         h1 {
             color: #0068c8;
             font-size: 24px;
             margin: 0;
         }
+
         .update-notice {
             background-color: #fff3cd;
             border: 1px solid #ffeeba;
@@ -41,45 +46,54 @@
             padding: 15px;
             margin-bottom: 20px;
         }
+
         .update-notice h2 {
             color: #856404;
             margin-top: 0;
             font-size: 18px;
         }
+
         .changes-list {
             background-color: #f8f9fa;
             border-left: 4px solid #0068c8;
             padding: 15px;
             margin: 15px 0;
         }
+
         .change-item {
             margin-bottom: 8px;
         }
+
         .change-label {
             font-weight: bold;
             color: #0068c8;
         }
+
         .meeting-details {
             background-color: #f8f9fa;
             border-left: 4px solid #0068c8;
             padding: 20px;
             margin: 20px 0;
         }
+
         .detail-row {
             margin: 10px 0;
         }
+
         .detail-label {
             font-weight: bold;
             color: #555;
             display: inline-block;
-            width: 100px;
+            width: 140px;
         }
+
         .description {
             margin: 20px 0;
             padding: 15px;
             background-color: #fafafa;
             border-radius: 4px;
         }
+
         .join-button {
             display: inline-block;
             background-color: #0068c8;
@@ -90,9 +104,11 @@
             font-weight: bold;
             margin: 20px 0;
         }
+
         .join-button:hover {
             background-color: #0056a8;
         }
+
         .footer {
             margin-top: 30px;
             padding-top: 20px;
@@ -100,9 +116,11 @@
             font-size: 14px;
             color: #666;
         }
+
         .center {
             text-align: center;
         }
+
         .calendar-update-notice {
             margin-top: 20px;
             padding: 15px;
@@ -112,17 +130,19 @@
         }
     </style>
 </head>
+
 <body>
     <div class="container">
         <div class="header">
             <h1>Meeting Updated</h1>
         </div>
-        
+
         <p>Dear {{if .RecipientName}}{{.RecipientName}}{{else}}Attendee{{end}},</p>
-        
+
         <div class="update-notice">
             <h2>Meeting Details Have Been Updated</h2>
-            <p>The meeting "{{.MeetingTitle}}" has been updated{{if .ProjectName}} for <strong>{{.ProjectName}}</strong>{{end}}.</p>
+            <p>The meeting "{{.MeetingTitle}}" has been updated{{if .ProjectName}} for
+                <strong>{{.ProjectName}}</strong>{{end}}.</p>
         </div>
 
         {{if .Changes}}
@@ -135,7 +155,7 @@
             {{end}}
         </div>
         {{end}}
-        
+
         <div class="meeting-details">
             <div class="detail-row">
                 <span class="detail-label">Meeting:</span>
@@ -154,41 +174,65 @@
                 {{.Timezone}}
             </div>
         </div>
-        
+
         {{if .Description}}
         <div class="description">
             <strong>Description:</strong><br>
             {{.Description}}
         </div>
         {{end}}
-        
+
         {{if .JoinLink}}
         <div class="center">
             <a href="{{.JoinLink}}" class="join-button">Join Meeting</a>
         </div>
-        
+
         <p><small>Or copy and paste this link into your browser:</small><br>
-        <a href="{{.JoinLink}}">{{.JoinLink}}</a></p>
-        
+            <a href="{{.JoinLink}}">{{.JoinLink}}</a>
+        </p>
+
         {{if .MeetingID}}
         <p><small><strong>Meeting ID:</strong> {{.MeetingID}}<br>
-        {{if .Passcode}}<strong>Passcode:</strong> {{.Passcode}}{{end}}</small></p>
+                {{if .Passcode}}<strong>Passcode:</strong> {{.Passcode}}{{end}}</small></p>
+
+        {{if eq .Platform "Zoom"}}
+        <!-- Dial-in Options for Zoom -->
+        <div class="meeting-details">
+            <strong>📞 Zoom Dial-in Options</strong>
+            <div class="detail-row">
+                <span class="detail-label">Find your local number:</span>
+                <a href="https://zoom.us/zoomconference" target="_blank">https://zoom.us/zoomconference</a>
+            </div>
+            <div class="detail-row">
+                <span class="detail-label">After dialing:</span>
+                <small>Enter Meeting ID: <strong>{{.MeetingID}}#</strong></small>
+            </div>
+            {{if .Passcode}}
+            <div class="detail-row">
+                <span class="detail-label">Then enter:</span>
+                <small>Passcode: <strong>{{.Passcode}}#</strong></small>
+            </div>
+            {{end}}
+        </div>
+        {{end}}
         {{end}}
         {{else}}
         <p><em>Meeting link will be provided closer to the meeting time.</em></p>
         {{end}}
-        
+
         {{if .ICSAttachment}}
         <p class="calendar-update-notice">
             <strong>📅 Calendar Event Updated</strong><br>
-            An updated calendar file (.ics) is attached to this email. Open it to automatically update this meeting in your calendar application.
+            An updated calendar file (.ics) is attached to this email. Open it to automatically update this meeting in
+            your calendar application.
         </p>
         {{end}}
-        
+
         <div class="footer">
             <p>This is an automated email from the Linux Foundation Meeting Service.<br>
-            Please do not reply to this email.</p>
+                Please do not reply to this email.</p>
         </div>
     </div>
 </body>
+
 </html>

--- a/internal/infrastructure/email/templates/meeting_updated_invitation.txt
+++ b/internal/infrastructure/email/templates/meeting_updated_invitation.txt
@@ -17,7 +17,8 @@ The meeting "{{.MeetingTitle}}" has been updated{{if .ProjectName}} for {{.Proje
 Meeting: {{.MeetingTitle}}
 Date & Time: {{formatTime .StartTime .Timezone}}
 Duration: {{formatDuration .Duration}}
-Time Zone: {{.Timezone}}
+Time Zone: {{.Timezone}}{{if .Recurrence}}
+Recurrence: {{formatRecurrence .Recurrence}}{{end}}
 
 {{if .Description}}Description:
 {{.Description}}

--- a/internal/infrastructure/email/templates/meeting_updated_invitation.txt
+++ b/internal/infrastructure/email/templates/meeting_updated_invitation.txt
@@ -27,6 +27,13 @@ Time Zone: {{.Timezone}}
 {{if .MeetingID}}
 Meeting ID: {{.MeetingID}}{{if .Passcode}}
 Passcode: {{.Passcode}}{{end}}
+{{if eq .Platform "Zoom"}}
+
+📞 Zoom Dial-in Options:
+Find your local number: https://zoom.us/zoomconference
+After dialing: Enter Meeting ID: {{.MeetingID}}#{{if .Passcode}}
+Then enter: Passcode: {{.Passcode}}#{{end}}
+{{end}}
 {{end}}{{else}}Meeting link will be provided closer to the meeting time.
 {{end}}
 {{if .ICSAttachment}}

--- a/internal/service/meeting_registrant_service.go
+++ b/internal/service/meeting_registrant_service.go
@@ -499,7 +499,7 @@ func (s *MeetingRegistrantService) sendRegistrantInvitationEmail(ctx context.Con
 		Duration:       meetingDB.Duration,
 		Timezone:       meetingDB.Timezone,
 		Description:    meetingDB.Description,
-		JoinLink:       constants.GenerateLFXMeetingURL(meetingDB.UID, meetingDB.Password),
+		JoinLink:       constants.GenerateLFXMeetingURL(meetingDB.UID, meetingDB.Password, s.Config.LFXEnvironment),
 		ProjectName:    projectName,
 		Platform:       meetingDB.Platform,
 		MeetingID:      meetingID,

--- a/internal/service/meeting_registrant_service.go
+++ b/internal/service/meeting_registrant_service.go
@@ -501,6 +501,7 @@ func (s *MeetingRegistrantService) sendRegistrantInvitationEmail(ctx context.Con
 		Description:    meetingDB.Description,
 		JoinLink:       constants.GenerateLFXMeetingURL(meetingDB.UID, meetingDB.Password),
 		ProjectName:    projectName,
+		Platform:       meetingDB.Platform,
 		MeetingID:      meetingID,
 		Passcode:       passcode,
 		Recurrence:     meetingDB.Recurrence,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,4 +11,6 @@ type Service interface {
 type ServiceConfig struct {
 	// SkipEtagValidation is a flag to skip the Etag validation - only meant for local development.
 	SkipEtagValidation bool
+	// LFXEnvironment is the environment name for LFX app domain generation.
+	LFXEnvironment string
 }

--- a/pkg/constants/http.go
+++ b/pkg/constants/http.go
@@ -46,13 +46,34 @@ type contextEtag string
 // ETagContextID is the context ID for the ETag
 const ETagContextID contextEtag = "etag"
 
-// LFX Application URLs
+// LFX app domain constants
 const (
-	// LFXAppDomain is the base domain for the LFX web application
-	LFXAppDomain string = "app.lfx.dev"
+	// LFXDomainDev is the development domain
+	LFXDomainDev = "app.dev.lfx.dev"
+	// LFXDomainStaging is the staging domain
+	LFXDomainStaging = "app.staging.lfx.dev"
+	// LFXDomainProd is the production domain
+	LFXDomainProd = "app.lfx.dev"
 )
 
+// GetLFXAppDomain returns the appropriate LFX app domain based on the environment
+// Environment should be one of: "dev", "staging", "prod"
+func GetLFXAppDomain(environment string) string {
+	switch environment {
+	case "dev":
+		return LFXDomainDev
+	case "staging":
+		return LFXDomainStaging
+	case "prod":
+		return LFXDomainProd
+	default:
+		// Default to production domain if environment is not one of the expected values
+		return LFXDomainProd
+	}
+}
+
 // GenerateLFXMeetingURL generates the LFX app meeting URL with the given meeting UID and password
-func GenerateLFXMeetingURL(meetingUID, password string) string {
-	return fmt.Sprintf("https://%s/meetings/%s?password=%s", LFXAppDomain, meetingUID, url.QueryEscape(password))
+func GenerateLFXMeetingURL(meetingUID, password, environment string) string {
+	domain := GetLFXAppDomain(environment)
+	return fmt.Sprintf("https://%s/meetings/%s?password=%s", domain, meetingUID, url.QueryEscape(password))
 }

--- a/pkg/constants/http_test.go
+++ b/pkg/constants/http_test.go
@@ -159,48 +159,104 @@ func TestContextMappingConsistency(t *testing.T) {
 func TestGenerateLFXMeetingURL(t *testing.T) {
 	tests := []struct {
 		name        string
+		envValue    string
 		meetingUID  string
 		password    string
 		expectedURL string
 	}{
 		{
-			name:        "valid meeting URL",
+			name:        "valid meeting URL production",
+			envValue:    "prod",
 			meetingUID:  "123e4567-e89b-12d3-a456-426614174000",
 			password:    "456e7890-e89b-12d3-a456-426614174001",
-			expectedURL: "https://app.lfx.dev/meetings/123e4567-e89b-12d3-a456-426614174000?password=456e7890-e89b-12d3-a456-426614174001",
+			expectedURL: "https://" + LFXDomainProd + "/meetings/123e4567-e89b-12d3-a456-426614174000?password=456e7890-e89b-12d3-a456-426614174001",
+		},
+		{
+			name:        "valid meeting URL development",
+			envValue:    "dev",
+			meetingUID:  "123e4567-e89b-12d3-a456-426614174000",
+			password:    "456e7890-e89b-12d3-a456-426614174001",
+			expectedURL: "https://" + LFXDomainDev + "/meetings/123e4567-e89b-12d3-a456-426614174000?password=456e7890-e89b-12d3-a456-426614174001",
+		},
+		{
+			name:        "valid meeting URL staging",
+			envValue:    "staging",
+			meetingUID:  "123e4567-e89b-12d3-a456-426614174000",
+			password:    "456e7890-e89b-12d3-a456-426614174001",
+			expectedURL: "https://" + LFXDomainStaging + "/meetings/123e4567-e89b-12d3-a456-426614174000?password=456e7890-e89b-12d3-a456-426614174001",
 		},
 		{
 			name:        "empty values",
+			envValue:    "",
 			meetingUID:  "",
 			password:    "",
-			expectedURL: "https://app.lfx.dev/meetings/?password=",
+			expectedURL: "https://" + LFXDomainProd + "/meetings/?password=",
 		},
 		{
 			name:        "special characters in password",
+			envValue:    "",
 			meetingUID:  "meeting-123",
 			password:    "pass@#$%",
-			expectedURL: "https://app.lfx.dev/meetings/meeting-123?password=pass%40%23%24%25",
+			expectedURL: "https://" + LFXDomainProd + "/meetings/meeting-123?password=pass%40%23%24%25",
 		},
 		{
 			name:        "password with spaces",
+			envValue:    "",
 			meetingUID:  "meeting-456",
 			password:    "password with spaces",
-			expectedURL: "https://app.lfx.dev/meetings/meeting-456?password=password+with+spaces",
+			expectedURL: "https://" + LFXDomainProd + "/meetings/meeting-456?password=password+with+spaces",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GenerateLFXMeetingURL(tt.meetingUID, tt.password)
+			result := GenerateLFXMeetingURL(tt.meetingUID, tt.password, tt.envValue)
 			if result != tt.expectedURL {
-				t.Errorf("GenerateLFXMeetingURL() = %q, expected %q", result, tt.expectedURL)
+				t.Errorf("GenerateLFXMeetingURL(%q, %q, %q) = %q, expected %q", tt.meetingUID, tt.password, tt.envValue, result, tt.expectedURL)
 			}
 		})
 	}
 }
 
-func TestLFXAppDomainConstant(t *testing.T) {
-	if LFXAppDomain != "app.lfx.dev" {
-		t.Errorf("LFXAppDomain should be 'app.lfx.dev', got %q", LFXAppDomain)
+func TestGetLFXAppDomain(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		expectedURL string
+	}{
+		{
+			name:        "development environment",
+			envValue:    "dev",
+			expectedURL: LFXDomainDev,
+		},
+		{
+			name:        "staging environment",
+			envValue:    "staging",
+			expectedURL: LFXDomainStaging,
+		},
+		{
+			name:        "production environment",
+			envValue:    "prod",
+			expectedURL: LFXDomainProd,
+		},
+		{
+			name:        "empty environment defaults to production",
+			envValue:    "",
+			expectedURL: LFXDomainProd,
+		},
+		{
+			name:        "unknown environment defaults to production",
+			envValue:    "unknown",
+			expectedURL: LFXDomainProd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetLFXAppDomain(tt.envValue)
+			if result != tt.expectedURL {
+				t.Errorf("GetLFXAppDomain(%q) = %q, expected %q", tt.envValue, result, tt.expectedURL)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add Zoom dial-in instructions to email invitation templates with conditional display based on platform
- Include recurrence information in email templates matching ICS file format
- Add project information to ICS file descriptions for consistency with email templates
- Implement environment-specific LFX app domain support (dev/staging/prod)
- Improve email template styling and responsiveness

## Related Jira Ticket
https://linuxfoundation.atlassian.net/browse/LFXV2-486

## Test plan
- [x] Verify email templates render correctly with Zoom dial-in instructions
- [x] Confirm recurrence information displays properly in email bodies
- [x] Test project information appears in ICS file descriptions
- [x] Validate environment-specific domain resolution
- [x] Ensure all unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)