### PR TITLE
[LFXV2-516] Fix cancelled invitation issue after meeting deletion

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.4.8
+version: 0.4.9
 appVersion: "latest"

--- a/internal/domain/models/messaging.go
+++ b/internal/domain/models/messaging.go
@@ -171,7 +171,8 @@ type MeetingRegistrantAccessMessage struct {
 // MeetingDeletedMessage is the schema for the message sent when a meeting is deleted.
 // This message is used internally to trigger cleanup of all associated registrants.
 type MeetingDeletedMessage struct {
-	MeetingUID string `json:"meeting_uid"`
+	MeetingUID string       `json:"meeting_uid"`
+	Meeting    *MeetingBase `json:"meeting"`
 }
 
 // MeetingCreatedMessage is the schema for the message sent when a meeting is created.

--- a/internal/handlers/committee_handlers.go
+++ b/internal/handlers/committee_handlers.go
@@ -423,7 +423,7 @@ func (h *CommitteeHandlers) tryRemoveMemberFromMeeting(ctx context.Context, meet
 	isPublicMeeting := meeting.IsPublic()
 	err := h.committeeSyncService.RemoveCommitteeMemberFromMeeting(
 		ctx,
-		meeting.UID,
+		meeting,
 		member.CommitteeUID,
 		member.Email,
 		isPublicMeeting,

--- a/internal/handlers/meeting_handlers.go
+++ b/internal/handlers/meeting_handlers.go
@@ -172,6 +172,12 @@ func (s *MeetingHandler) HandleMeetingDeleted(ctx context.Context, msg domain.Me
 		return nil, fmt.Errorf("meeting UID is required")
 	}
 
+	meeting := meetingDeletedMsg.Meeting
+	if meeting == nil {
+		slog.WarnContext(ctx, "meeting object is missing in deletion message")
+		return nil, fmt.Errorf("meeting object is required")
+	}
+
 	ctx = logging.AppendCtx(ctx, slog.String("meeting_uid", meetingUID))
 	slog.InfoContext(ctx, "processing meeting deletion, cleaning up registrants")
 
@@ -195,7 +201,7 @@ func (s *MeetingHandler) HandleMeetingDeleted(ctx context.Context, msg domain.Me
 		reg := registrant // capture loop variable
 		tasks = append(tasks, func() error {
 			// Use the shared helper with skipRevisionCheck=true for bulk cleanup
-			err := s.registrantService.DeleteRegistrantWithCleanup(ctx, reg, 0, true)
+			err := s.registrantService.DeleteRegistrantWithCleanup(ctx, reg, meeting, 0, true)
 			if err != nil {
 				slog.ErrorContext(ctx, "error deleting registrant",
 					"registrant_uid", reg.UID,
@@ -259,7 +265,7 @@ func (s *MeetingHandler) HandleMeetingCreated(ctx context.Context, msg domain.Me
 		isPublicMeeting := meetingCreatedMsg.Base.IsPublic()
 		err := s.committeeSyncService.SyncCommittees(
 			ctx,
-			meetingCreatedMsg.MeetingUID,
+			meetingCreatedMsg.Base,
 			[]models.Committee{}, // No old committees for creation
 			meetingCreatedMsg.Base.Committees,
 			isPublicMeeting,
@@ -316,7 +322,7 @@ func (s *MeetingHandler) HandleMeetingUpdated(ctx context.Context, msg domain.Me
 		isPublicMeeting := meetingUpdatedMsg.UpdatedBase.IsPublic()
 		err = s.committeeSyncService.SyncCommittees(
 			ctx,
-			meetingUpdatedMsg.MeetingUID,
+			meetingUpdatedMsg.UpdatedBase,
 			meetingUpdatedMsg.PreviousBase.Committees,
 			meetingUpdatedMsg.UpdatedBase.Committees,
 			isPublicMeeting,

--- a/internal/handlers/meeting_handlers_test.go
+++ b/internal/handlers/meeting_handlers_test.go
@@ -96,7 +96,7 @@ func TestMeetingHandler_HandleMessage(t *testing.T) {
 		{
 			name:        "handle meeting deleted message",
 			subject:     models.MeetingDeletedSubject,
-			messageData: []byte(`{"meeting_uid":"meeting-to-delete"}`),
+			messageData: []byte(`{"meeting_uid":"meeting-to-delete","meeting":{"uid":"meeting-to-delete","project_uid":"project-123","title":"Meeting to Delete","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Meeting to be deleted"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				now := time.Now()
 				// Setup registrants for deletion
@@ -302,7 +302,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 		// Success cases
 		{
 			name:        "successfully delete single registrant",
-			messageData: []byte(`{"meeting_uid":"meeting-123"}`),
+			messageData: []byte(`{"meeting_uid":"meeting-123","meeting":{"uid":"meeting-123","project_uid":"project-123","title":"Test Meeting","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Test meeting description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				now := time.Now()
 				registrants := []*models.Registrant{
@@ -337,7 +337,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 		},
 		{
 			name:        "successfully delete multiple registrants",
-			messageData: []byte(`{"meeting_uid":"meeting-456"}`),
+			messageData: []byte(`{"meeting_uid":"meeting-456","meeting":{"uid":"meeting-456","project_uid":"project-456","title":"Test Meeting 2","start_time":"2023-12-01T11:00:00Z","duration":60,"timezone":"UTC","description":"Test meeting 2 description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				now := time.Now()
 				registrants := []*models.Registrant{
@@ -381,7 +381,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 		},
 		{
 			name:        "successfully handle meeting with no registrants",
-			messageData: []byte(`{"meeting_uid":"meeting-789"}`),
+			messageData: []byte(`{"meeting_uid":"meeting-789","meeting":{"uid":"meeting-789","project_uid":"project-789","title":"Test Meeting 3","start_time":"2023-12-01T12:00:00Z","duration":60,"timezone":"UTC","description":"Test meeting 3 description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-789").Return([]*models.Registrant{}, nil)
 				// No further mocks needed - no registrants to delete
@@ -398,14 +398,21 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 		},
 		{
 			name:        "empty meeting UID",
-			messageData: []byte(`{"meeting_uid":""}`),
+			messageData: []byte(`{"meeting_uid":"","meeting":{"uid":"","project_uid":"project-123","title":"Test Meeting","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Test meeting description"}}`),
+			setupMocks: func(*mocks.MockMeetingRepository, *mocks.MockRegistrantRepository, *mocks.MockMessageBuilder, *mocks.MockEmailService) {
+			},
+			expectError: true,
+		},
+		{
+			name:        "missing meeting object",
+			messageData: []byte(`{"meeting_uid":"meeting-123"}`),
 			setupMocks: func(*mocks.MockMeetingRepository, *mocks.MockRegistrantRepository, *mocks.MockMessageBuilder, *mocks.MockEmailService) {
 			},
 			expectError: true,
 		},
 		{
 			name:        "repository error when listing registrants",
-			messageData: []byte(`{"meeting_uid":"meeting-error"}`),
+			messageData: []byte(`{"meeting_uid":"meeting-error","meeting":{"uid":"meeting-error","project_uid":"project-error","title":"Error Meeting","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Error meeting description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-error").Return(
 					nil, domain.NewInternalError("internal error", nil),
@@ -415,7 +422,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 		},
 		{
 			name:        "partial deletion failure returns error",
-			messageData: []byte(`{"meeting_uid":"meeting-partial"}`),
+			messageData: []byte(`{"meeting_uid":"meeting-partial","meeting":{"uid":"meeting-partial","project_uid":"project-partial","title":"Partial Meeting","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Partial meeting description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				registrants := []*models.Registrant{
 					{

--- a/internal/service/committee_sync_service.go
+++ b/internal/service/committee_sync_service.go
@@ -58,7 +58,7 @@ func (s *CommitteeSyncService) ServiceReady() bool {
 // SyncCommittees synchronizes committee members between old and new committee configurations
 func (s *CommitteeSyncService) SyncCommittees(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	oldCommittees []models.Committee,
 	newCommittees []models.Committee,
 	isPublicMeeting bool,
@@ -72,7 +72,7 @@ func (s *CommitteeSyncService) SyncCommittees(
 	}
 
 	slog.InfoContext(ctx, "committee changes detected, processing member sync",
-		"meeting_uid", meetingUID,
+		"meeting_uid", meeting.UID,
 		"added_committees", len(changes.Added),
 		"removed_committees", len(changes.Removed),
 		"changed_committees", len(changes.Changed),
@@ -83,21 +83,21 @@ func (s *CommitteeSyncService) SyncCommittees(
 
 	// Handle added committees
 	if len(changes.Added) > 0 {
-		if err := s.addCommitteeMembers(ctx, meetingUID, changes.Added); err != nil {
+		if err := s.addCommitteeMembers(ctx, meeting.UID, changes.Added); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("failed to add committee members: %w", err))
 		}
 	}
 
 	// Handle removed committees
 	if len(changes.Removed) > 0 {
-		if err := s.removeCommitteeMembers(ctx, meetingUID, changes.Removed, isPublicMeeting); err != nil {
+		if err := s.removeCommitteeMembers(ctx, meeting, changes.Removed, isPublicMeeting); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("failed to remove committee members: %w", err))
 		}
 	}
 
 	// Handle changed committees
 	if len(changes.Changed) > 0 {
-		if err := s.updateCommitteeMembers(ctx, meetingUID, changes.Changed, isPublicMeeting); err != nil {
+		if err := s.updateCommitteeMembers(ctx, meeting, changes.Changed, isPublicMeeting); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("failed to update committee members: %w", err))
 		}
 	}
@@ -420,7 +420,7 @@ func (s *CommitteeSyncService) createRegistrantForCommitteeMember(
 // removeCommitteeMembers removes or converts committee members based on meeting visibility
 func (s *CommitteeSyncService) removeCommitteeMembers(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	committees []models.Committee,
 	isPublicMeeting bool,
 ) error {
@@ -434,7 +434,7 @@ func (s *CommitteeSyncService) removeCommitteeMembers(
 	}
 
 	slog.InfoContext(ctx, "removing committee members from meeting",
-		"meeting_uid", meetingUID,
+		"meeting_uid", meeting.UID,
 		"committee_count", len(committees),
 		"action", action,
 		"is_public_meeting", isPublicMeeting)
@@ -442,7 +442,7 @@ func (s *CommitteeSyncService) removeCommitteeMembers(
 	// Process each committee
 	var errors []error
 	for _, committee := range committees {
-		if err := s.removeCommitteeMembersFromMeeting(ctx, meetingUID, committee.UID, isPublicMeeting); err != nil {
+		if err := s.removeCommitteeMembersFromMeeting(ctx, meeting, committee.UID, isPublicMeeting); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -453,7 +453,7 @@ func (s *CommitteeSyncService) removeCommitteeMembers(
 	}
 
 	slog.InfoContext(ctx, "successfully processed committee member removal",
-		"meeting_uid", meetingUID,
+		"meeting_uid", meeting.UID,
 		"committee_count", len(committees))
 
 	return nil
@@ -462,14 +462,14 @@ func (s *CommitteeSyncService) removeCommitteeMembers(
 // removeCommitteeMembersFromMeeting removes members of a committee from a meeting
 func (s *CommitteeSyncService) removeCommitteeMembersFromMeeting(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	committeeUID string,
 	isPublicMeeting bool,
 ) error {
 	// Get all registrants for this meeting
-	registrants, err := s.registrantRepository.ListByMeeting(ctx, meetingUID)
+	registrants, err := s.registrantRepository.ListByMeeting(ctx, meeting.UID)
 	if err != nil {
-		return fmt.Errorf("failed to list registrants for meeting %s: %w", meetingUID, err)
+		return fmt.Errorf("failed to list registrants for meeting %s: %w", meeting.UID, err)
 	}
 
 	// Filter to committee members for this specific committee
@@ -496,7 +496,7 @@ func (s *CommitteeSyncService) removeCommitteeMembersFromMeeting(
 	// Process each registrant
 	var errors []error
 	for _, registrant := range committeeRegistrants {
-		if err := s.processCommitteeRegistrantRemoval(ctx, registrant, isPublicMeeting); err != nil {
+		if err := s.processCommitteeRegistrantRemoval(ctx, registrant, meeting, isPublicMeeting); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -517,6 +517,7 @@ func (s *CommitteeSyncService) removeCommitteeMembersFromMeeting(
 func (s *CommitteeSyncService) processCommitteeRegistrantRemoval(
 	ctx context.Context,
 	registrant *models.Registrant,
+	meeting *models.MeetingBase,
 	isPublicMeeting bool,
 ) error {
 	if isPublicMeeting {
@@ -524,7 +525,7 @@ func (s *CommitteeSyncService) processCommitteeRegistrantRemoval(
 		return s.convertRegistrantToDirect(ctx, registrant)
 	} else {
 		// Remove registrant entirely using registrant service (includes email notifications)
-		return s.registrantService.DeleteRegistrantWithCleanup(ctx, registrant, 0, true)
+		return s.registrantService.DeleteRegistrantWithCleanup(ctx, registrant, meeting, 0, true)
 	}
 }
 
@@ -566,7 +567,7 @@ func (s *CommitteeSyncService) convertRegistrantToDirect(
 // updateCommitteeMembers handles committees with changed voting statuses
 func (s *CommitteeSyncService) updateCommitteeMembers(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	changes []CommitteeChange,
 	isPublicMeeting bool,
 ) error {
@@ -575,12 +576,12 @@ func (s *CommitteeSyncService) updateCommitteeMembers(
 	}
 
 	slog.InfoContext(ctx, "updating committee members for voting status changes",
-		"meeting_uid", meetingUID,
+		"meeting_uid", meeting.UID,
 		"changed_committee_count", len(changes))
 
 	var errors []error
 	for _, change := range changes {
-		if err := s.updateCommitteeMembersForCommittee(ctx, meetingUID, change, isPublicMeeting); err != nil {
+		if err := s.updateCommitteeMembersForCommittee(ctx, meeting, change, isPublicMeeting); err != nil {
 			errors = append(errors, err)
 		}
 	}
@@ -595,7 +596,7 @@ func (s *CommitteeSyncService) updateCommitteeMembers(
 // updateCommitteeMembersForCommittee processes voting status changes for a single committee
 func (s *CommitteeSyncService) updateCommitteeMembersForCommittee(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	change CommitteeChange,
 	isPublicMeeting bool,
 ) error {
@@ -645,7 +646,7 @@ func (s *CommitteeSyncService) updateCommitteeMembersForCommittee(
 
 	// Add new eligible members
 	if len(membersToAdd) > 0 {
-		err := s.AddCommitteeMembersAsRegistrants(ctx, meetingUID, change.New.UID, membersToAdd)
+		err := s.AddCommitteeMembersAsRegistrants(ctx, meeting.UID, change.New.UID, membersToAdd)
 		if err != nil {
 			return fmt.Errorf("failed to add new eligible members: %w", err)
 		}
@@ -653,7 +654,7 @@ func (s *CommitteeSyncService) updateCommitteeMembersForCommittee(
 
 	// Remove no longer eligible members
 	if len(membersToRemove) > 0 {
-		err := s.removeSpecificCommitteeMembers(ctx, meetingUID, change.New.UID, membersToRemove, isPublicMeeting)
+		err := s.removeSpecificCommitteeMembers(ctx, meeting, change.New.UID, membersToRemove, isPublicMeeting)
 		if err != nil {
 			return fmt.Errorf("failed to remove no longer eligible members: %w", err)
 		}
@@ -665,13 +666,13 @@ func (s *CommitteeSyncService) updateCommitteeMembersForCommittee(
 // removeSpecificCommitteeMembers removes specific committee members by email
 func (s *CommitteeSyncService) removeSpecificCommitteeMembers(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	committeeUID string,
 	members []models.CommitteeMember,
 	isPublicMeeting bool,
 ) error {
 	// Get all registrants for this meeting
-	registrants, err := s.registrantRepository.ListByMeeting(ctx, meetingUID)
+	registrants, err := s.registrantRepository.ListByMeeting(ctx, meeting.UID)
 	if err != nil {
 		return fmt.Errorf("failed to list registrants: %w", err)
 	}
@@ -695,7 +696,7 @@ func (s *CommitteeSyncService) removeSpecificCommitteeMembers(
 
 	// Process removal for each registrant
 	for _, registrant := range registrantsToRemove {
-		err := s.processCommitteeRegistrantRemoval(ctx, registrant, isPublicMeeting)
+		err := s.processCommitteeRegistrantRemoval(ctx, registrant, meeting, isPublicMeeting)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to remove specific committee member",
 				"registrant_uid", registrant.UID,
@@ -711,15 +712,15 @@ func (s *CommitteeSyncService) removeSpecificCommitteeMembers(
 // by finding their registrant records and removing/converting them based on meeting visibility
 func (s *CommitteeSyncService) RemoveCommitteeMemberFromMeeting(
 	ctx context.Context,
-	meetingUID string,
+	meeting *models.MeetingBase,
 	committeeUID string,
 	memberEmail string,
 	isPublicMeeting bool,
 ) error {
 	// Get all registrants for this meeting
-	registrants, err := s.registrantRepository.ListByMeeting(ctx, meetingUID)
+	registrants, err := s.registrantRepository.ListByMeeting(ctx, meeting.UID)
 	if err != nil {
-		return fmt.Errorf("failed to list registrants for meeting %s: %w", meetingUID, err)
+		return fmt.Errorf("failed to list registrants for meeting %s: %w", meeting.UID, err)
 	}
 
 	// Find registrants that match this committee member
@@ -735,14 +736,14 @@ func (s *CommitteeSyncService) RemoveCommitteeMemberFromMeeting(
 
 	if len(matchingRegistrants) == 0 {
 		slog.DebugContext(ctx, "no matching committee registrants found for removal",
-			"meeting_uid", meetingUID,
+			"meeting_uid", meeting.UID,
 			"committee_uid", committeeUID,
 			"member_email", memberEmail)
 		return nil
 	}
 
 	slog.InfoContext(ctx, "found matching committee registrants for removal",
-		"meeting_uid", meetingUID,
+		"meeting_uid", meeting.UID,
 		"committee_uid", committeeUID,
 		"member_email", memberEmail,
 		"matching_registrants", len(matchingRegistrants),
@@ -750,7 +751,7 @@ func (s *CommitteeSyncService) RemoveCommitteeMemberFromMeeting(
 
 	// Process each matching registrant using existing private methods
 	for _, registrant := range matchingRegistrants {
-		err := s.processCommitteeRegistrantRemoval(ctx, registrant, isPublicMeeting)
+		err := s.processCommitteeRegistrantRemoval(ctx, registrant, meeting, isPublicMeeting)
 		if err != nil {
 			return fmt.Errorf("failed to process registrant removal for %s: %w", registrant.UID, err)
 		}

--- a/internal/service/meeting_registrant_service.go
+++ b/internal/service/meeting_registrant_service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -520,6 +521,11 @@ func (s *MeetingRegistrantService) sendRegistrantCancellationEmail(
 	registrant *models.Registrant,
 	meeting *models.MeetingBase,
 ) error {
+	if meeting == nil {
+		slog.WarnContext(ctx, "meeting object missing; unable to send cancellation email")
+		return errors.New("meeting object missing")
+	}
+
 	// Format recipient name
 	recipientName := fmt.Sprintf("%s %s", registrant.FirstName, registrant.LastName)
 	if recipientName == " " {

--- a/internal/service/meeting_registrant_service.go
+++ b/internal/service/meeting_registrant_service.go
@@ -345,16 +345,22 @@ func (s *MeetingRegistrantService) UpdateMeetingRegistrant(ctx context.Context, 
 
 // DeleteRegistrantWithCleanup is an internal helper that deletes a registrant and sends cleanup messages.
 // It can optionally skip revision checking when skipRevisionCheck is true (useful for bulk cleanup operations).
-func (s *MeetingRegistrantService) DeleteRegistrantWithCleanup(ctx context.Context, registrantDB *models.Registrant, revision uint64, skipRevisionCheck bool) error {
-	ctx = logging.AppendCtx(ctx, slog.String("registrant_uid", registrantDB.UID))
+func (s *MeetingRegistrantService) DeleteRegistrantWithCleanup(
+	ctx context.Context,
+	registrant *models.Registrant,
+	meeting *models.MeetingBase,
+	revision uint64,
+	skipRevisionCheck bool,
+) error {
+	ctx = logging.AppendCtx(ctx, slog.String("registrant_uid", registrant.UID))
 
 	// Delete the registrant from the database
 	var err error
 	if skipRevisionCheck {
 		// Use revision 0 to skip revision checking for bulk cleanup operations
-		err = s.RegistrantRepository.Delete(ctx, registrantDB.UID, 0)
+		err = s.RegistrantRepository.Delete(ctx, registrant.UID, 0)
 	} else {
-		err = s.RegistrantRepository.Delete(ctx, registrantDB.UID, revision)
+		err = s.RegistrantRepository.Delete(ctx, registrant.UID, revision)
 	}
 
 	if err != nil {
@@ -373,9 +379,9 @@ func (s *MeetingRegistrantService) DeleteRegistrantWithCleanup(ctx context.Conte
 
 	// Send indexing delete message for the registrant
 	functions = append(functions, func() error {
-		msgCtx := createRegistrantContext(ctx, registrantDB.UID, registrantDB.MeetingUID)
+		msgCtx := createRegistrantContext(ctx, registrant.UID, registrant.MeetingUID)
 
-		err := s.MessageBuilder.SendDeleteIndexMeetingRegistrant(msgCtx, registrantDB.UID)
+		err := s.MessageBuilder.SendDeleteIndexMeetingRegistrant(msgCtx, registrant.UID)
 		if err != nil {
 			slog.ErrorContext(msgCtx, "error sending delete indexing message for registrant", logging.ErrKey, err, logging.PriorityCritical())
 		}
@@ -383,15 +389,15 @@ func (s *MeetingRegistrantService) DeleteRegistrantWithCleanup(ctx context.Conte
 	})
 
 	// Send access removal message if the registrant has a username
-	if registrantDB.Username != "" {
+	if registrant.Username != "" {
 		functions = append(functions, func() error {
-			msgCtx := createRegistrantContext(ctx, registrantDB.UID, registrantDB.MeetingUID)
+			msgCtx := createRegistrantContext(ctx, registrant.UID, registrant.MeetingUID)
 
 			err := s.MessageBuilder.SendRemoveMeetingRegistrantAccess(msgCtx, models.MeetingRegistrantAccessMessage{
-				UID:        registrantDB.UID,
-				Username:   registrantDB.Username,
-				MeetingUID: registrantDB.MeetingUID,
-				Host:       registrantDB.Host,
+				UID:        registrant.UID,
+				Username:   registrant.Username,
+				MeetingUID: registrant.MeetingUID,
+				Host:       registrant.Host,
 			})
 			if err != nil {
 				slog.ErrorContext(msgCtx, "error sending message about deleted registrant", logging.ErrKey, err, logging.PriorityCritical())
@@ -405,9 +411,9 @@ func (s *MeetingRegistrantService) DeleteRegistrantWithCleanup(ctx context.Conte
 
 	// Send cancellation email to the registrant
 	functions = append(functions, func() error {
-		emailCtx := createRegistrantContext(ctx, registrantDB.UID, registrantDB.MeetingUID)
+		emailCtx := createRegistrantContext(ctx, registrant.UID, registrant.MeetingUID)
 
-		err := s.sendRegistrantCancellationEmail(emailCtx, registrantDB)
+		err := s.sendRegistrantCancellationEmail(emailCtx, registrant, meeting)
 		if err != nil {
 			slog.ErrorContext(emailCtx, "failed to send cancellation email", logging.ErrKey, err)
 		}
@@ -446,23 +452,20 @@ func (s *MeetingRegistrantService) DeleteMeetingRegistrant(ctx context.Context, 
 
 	ctx = logging.AppendCtx(ctx, slog.String("etag", strconv.FormatUint(revision, 10)))
 
-	// Check that meeting exists
-	exists, err := s.MeetingRepository.Exists(ctx, meetingUID)
+	// Get the meeting for cleanup process and to check for existence
+	meeting, err := s.MeetingRepository.GetBase(ctx, meetingUID)
 	if err != nil {
 		return err
 	}
-	if !exists {
-		return domain.NewNotFoundError("meeting not found", nil)
-	}
 
-	// Check that the registrant exists, but also get the registrant data for the access deletion message
-	registrantDB, err := s.RegistrantRepository.Get(ctx, registrantUID)
+	// Get the registrant for cleanup process and to check for existence
+	registrant, err := s.RegistrantRepository.Get(ctx, registrantUID)
 	if err != nil {
 		return err
 	}
 
 	// Use the helper to delete the registrant with cleanup
-	return s.DeleteRegistrantWithCleanup(ctx, registrantDB, revision, false)
+	return s.DeleteRegistrantWithCleanup(ctx, registrant, meeting, revision, false)
 }
 
 // sendRegistrantInvitationEmail sends an invitation email to a newly created registrant
@@ -512,13 +515,11 @@ func (s *MeetingRegistrantService) sendRegistrantInvitationEmail(ctx context.Con
 }
 
 // sendRegistrantCancellationEmail sends a cancellation email to a deleted registrant
-func (s *MeetingRegistrantService) sendRegistrantCancellationEmail(ctx context.Context, registrant *models.Registrant) error {
-	// Get meeting details for the email
-	meetingDB, err := s.MeetingRepository.GetBase(ctx, registrant.MeetingUID)
-	if err != nil {
-		return fmt.Errorf("failed to get meeting details: %w", err)
-	}
-
+func (s *MeetingRegistrantService) sendRegistrantCancellationEmail(
+	ctx context.Context,
+	registrant *models.Registrant,
+	meeting *models.MeetingBase,
+) error {
 	// Format recipient name
 	recipientName := fmt.Sprintf("%s %s", registrant.FirstName, registrant.LastName)
 	if recipientName == " " {
@@ -526,21 +527,21 @@ func (s *MeetingRegistrantService) sendRegistrantCancellationEmail(ctx context.C
 	}
 
 	// Get project name
-	projectName, _ := s.MessageBuilder.GetProjectName(ctx, meetingDB.ProjectUID)
+	projectName, _ := s.MessageBuilder.GetProjectName(ctx, meeting.ProjectUID)
 
 	// Create email cancellation
 	cancellation := domain.EmailCancellation{
-		MeetingUID:     meetingDB.UID,
+		MeetingUID:     meeting.UID,
 		RecipientEmail: registrant.Email,
 		RecipientName:  recipientName,
-		MeetingTitle:   meetingDB.Title,
-		StartTime:      meetingDB.StartTime,
-		Duration:       meetingDB.Duration,
-		Timezone:       meetingDB.Timezone,
-		Description:    meetingDB.Description,
+		MeetingTitle:   meeting.Title,
+		StartTime:      meeting.StartTime,
+		Duration:       meeting.Duration,
+		Timezone:       meeting.Timezone,
+		Description:    meeting.Description,
 		ProjectName:    projectName,
 		Reason:         "Your registration has been removed from this meeting.",
-		Recurrence:     meetingDB.Recurrence,
+		Recurrence:     meeting.Recurrence,
 	}
 
 	// Send the email

--- a/internal/service/meeting_service.go
+++ b/internal/service/meeting_service.go
@@ -706,6 +706,7 @@ func (s *MeetingService) DeleteMeeting(ctx context.Context, uid string, revision
 	// Send meeting deletion message to trigger registrant cleanup
 	err = s.MessageBuilder.SendMeetingDeleted(ctx, models.MeetingDeletedMessage{
 		MeetingUID: uid,
+		Meeting:    meetingDB,
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "error sending meeting deleted message", logging.ErrKey, err, logging.PriorityCritical())


### PR DESCRIPTION
## Summary
- Fixes issue where cancelled invitations couldn't be sent after meeting deletion
- Includes full MeetingBase object in MeetingDeletedMessage to avoid refetching deleted meeting
- Updates handlers and services to use provided meeting object instead of database lookups

## Changes Made
- **Updated MeetingDeletedMessage**: Added `Meeting` field with full `MeetingBase` object
- **Modified DeleteMeeting**: Now passes the meeting object in deletion message before deleting
- **Fixed meeting deletion handler**: Uses provided meeting object instead of trying to fetch deleted meeting
- **Updated DeleteRegistrantWithCleanup**: Accepts meeting parameter for cancellation emails
- **Enhanced committee sync service**: Pass meeting objects instead of UIDs throughout the system
- **Comprehensive test updates**: All test cases updated to include meeting object in messages

## Test Plan
- [x] Unit tests pass with updated message structure
- [x] Integration tests verify cancellation emails are sent properly
- [x] Committee sync operations work correctly with meeting objects
- [x] Error handling for missing meeting object in messages

## Related Issue
Closes: LFXV2-516

🤖 Generated with [Claude Code](https://claude.ai/code)