### PR TITLE
[LFXV2-569] Make email FROM display name dynamic based on project name

### DIFF
--- a/internal/infrastructure/email/message_test.go
+++ b/internal/infrastructure/email/message_test.go
@@ -44,7 +44,7 @@ func TestBuildEmailMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			message := buildEmailMessage(tt.recipient, tt.subject, tt.htmlContent, tt.textContent, config)
 
-			assert.Contains(t, message, "From: noreply@example.com")
+			assert.Contains(t, message, "From: LFX One Meetings <noreply@example.com>")
 			assert.Contains(t, message, fmt.Sprintf("To: %s", tt.recipient))
 			assert.Contains(t, message, fmt.Sprintf("Subject: %s", tt.subject))
 			assert.Contains(t, message, "MIME-Version: 1.0")

--- a/internal/infrastructure/email/smtp_service.go
+++ b/internal/infrastructure/email/smtp_service.go
@@ -142,7 +142,10 @@ func (s *SMTPService) SendRegistrantInvitation(ctx context.Context, invitation d
 
 	// Build and send the email with attachment
 	subject := fmt.Sprintf("Invitation: %s", invitation.MeetingTitle)
-	message := buildEmailMessageWithAttachment(invitation.RecipientEmail, subject, htmlContent, textContent, attachment, s.config)
+	metadata := &EmailMetadata{
+		ProjectName: invitation.ProjectName,
+	}
+	message := buildEmailMessageWithAttachment(invitation.RecipientEmail, subject, htmlContent, textContent, attachment, metadata, s.config)
 	err = sendEmailMessage(invitation.RecipientEmail, message, s.config)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to send invitation email", logging.ErrKey, err)
@@ -210,6 +213,9 @@ func (s *SMTPService) SendRegistrantCancellation(ctx context.Context, cancellati
 		TextContent: textContent,
 		Attachment:  attachment,
 		Config:      s.config,
+		Metadata: &EmailMetadata{
+			ProjectName: cancellation.ProjectName,
+		},
 	})
 	err = sendEmailMessage(cancellation.RecipientEmail, message, s.config)
 	if err != nil {
@@ -283,6 +289,9 @@ func (s *SMTPService) SendRegistrantUpdatedInvitation(ctx context.Context, updat
 		TextContent: textContent,
 		Attachment:  attachment,
 		Config:      s.config,
+		Metadata: &EmailMetadata{
+			ProjectName: updatedInvitation.ProjectName,
+		},
 	})
 
 	err = sendEmailMessage(updatedInvitation.RecipientEmail, message, s.config)
@@ -325,6 +334,9 @@ func (s *SMTPService) SendSummaryNotification(ctx context.Context, notification 
 		TextContent: textContent,
 		Attachment:  nil, // No attachments for summary notifications
 		Config:      s.config,
+		Metadata: &EmailMetadata{
+			ProjectName: notification.ProjectName,
+		},
 	})
 
 	err = sendEmailMessage(notification.RecipientEmail, message, s.config)


### PR DESCRIPTION
## Summary
- Makes email FROM display name dynamic based on the project name of the meeting
- Emails will now show as coming from "<Project Name> Meetings" instead of just "meetings"
- Falls back to "LFX One Meetings" when no project name is provided

## Problem
Previously, emails were showing as coming from "meetings" (taking the local part of meetings@lfx.linuxfoundation.org), which was not very descriptive or project-specific. Users would see a generic "meetings" sender instead of a more meaningful project-specific name.

## Solution
- Added `EmailMetadata` struct to cleanly pass supplementary email information
- Updated the FROM header generation to dynamically use the project name when available
- Modified all email sending methods to pass the project metadata
- Updated `buildEmailMessageWithAttachment` to accept metadata parameter

## Technical Details
- The FROM header now formats as: `<Project Name> Meetings <email@domain.com>`
- When no project name is provided, defaults to: `LFX One Meetings <email@domain.com>`
- Clean separation of concerns by using EmailMetadata struct for supplementary data

## Test Plan
- [x] Code compiles successfully (`make build`)
- [x] Unit tests pass
- [x] Test email sending with a project that has a name
- [x] Test email sending without a project name (verify fallback)
- [x] Verify email clients display the correct FROM name

## Manual Testing

<img width="542" height="136" alt="Screenshot 2025-09-24 at 9 04 36 AM" src="https://github.com/user-attachments/assets/a520fd83-afbc-4eee-a08e-0ce3b94b5058" />
<img width="1403" height="63" alt="Screenshot 2025-09-24 at 9 04 48 AM" src="https://github.com/user-attachments/assets/f8c472ae-d557-4fbf-ba9e-0546be0f1822" />


## Ticket
[LFXV2-569](https://linuxfoundation.atlassian.net/browse/LFXV2-569)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-569]: https://linuxfoundation.atlassian.net/browse/LFXV2-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ