### PR TITLE
[LFXV2-530, LFXV2-581] Encapsulate service layer struct fields and improve clean architecture

### DIFF
--- a/cmd/meeting-api/api.go
+++ b/cmd/meeting-api/api.go
@@ -144,7 +144,7 @@ func (s *MeetingsAPI) JWTAuth(ctx context.Context, bearerToken string, _ *securi
 	}
 
 	// Parse the Heimdall-authorized principal from the token.
-	principal, err := s.authService.Auth.ParsePrincipal(ctx, bearerToken, slog.Default())
+	principal, err := s.authService.ParsePrincipal(ctx, bearerToken, slog.Default())
 	if err != nil {
 		return ctx, err
 	}

--- a/cmd/meeting-api/api_meeting_registrants.go
+++ b/cmd/meeting-api/api_meeting_registrants.go
@@ -17,7 +17,7 @@ func (s *MeetingsAPI) GetMeetingRegistrants(ctx context.Context, payload *meetin
 		return nil, handleError(domain.NewValidationError("validation failed"))
 	}
 
-	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, *payload.UID)
+	registrants, err := s.registrantService.ListMeetingRegistrants(ctx, *payload.UID)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/cmd/meeting-api/api_meetings.go
+++ b/cmd/meeting-api/api_meetings.go
@@ -13,7 +13,7 @@ import (
 
 // GetMeetings fetches all meetings
 func (s *MeetingsAPI) GetMeetings(ctx context.Context, payload *meetingsvc.GetMeetingsPayload) (*meetingsvc.GetMeetingsResult, error) {
-	meetings, err := s.meetingService.GetMeetings(ctx)
+	meetings, err := s.meetingService.ListMeetings(ctx)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/cmd/meeting-api/api_past_meeting_participants.go
+++ b/cmd/meeting-api/api_past_meeting_participants.go
@@ -18,7 +18,7 @@ func (s *MeetingsAPI) GetPastMeetingParticipants(ctx context.Context, payload *m
 		return nil, handleError(domain.NewValidationError("validation failed"))
 	}
 
-	participants, err := s.pastMeetingParticipantService.GetPastMeetingParticipants(ctx, *payload.UID)
+	participants, err := s.pastMeetingParticipantService.ListPastMeetingParticipants(ctx, *payload.UID)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/cmd/meeting-api/api_past_meetings.go
+++ b/cmd/meeting-api/api_past_meetings.go
@@ -18,7 +18,7 @@ func (s *MeetingsAPI) GetPastMeetings(ctx context.Context, payload *meetingsvc.G
 		return nil, handleError(domain.NewValidationError("validation failed"))
 	}
 
-	pastMeetings, err := s.pastMeetingService.GetPastMeetings(ctx)
+	pastMeetings, err := s.pastMeetingService.ListPastMeetings(ctx)
 	if err != nil {
 		return nil, handleError(err)
 	}

--- a/internal/handlers/committee_handlers.go
+++ b/internal/handlers/committee_handlers.go
@@ -265,7 +265,7 @@ func (h *CommitteeHandlers) HandleCommitteeMemberDeleted(ctx context.Context, ms
 // and adds the new member as a registrant if their voting status matches.
 func (h *CommitteeHandlers) addMemberToRelevantMeetings(ctx context.Context, memberMsg *models.CommitteeMember) error {
 	// Get meetings that contain this committee
-	meetings, _, err := h.meetingService.MeetingRepository.ListByCommittee(ctx, memberMsg.CommitteeUID)
+	meetings, _, err := h.meetingService.GetMeetingsByCommittee(ctx, memberMsg.CommitteeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list meetings by committee", logging.ErrKey, err)
 		return fmt.Errorf("failed to list meetings by committee: %w", err)
@@ -397,7 +397,7 @@ func (h *CommitteeHandlers) tryAddMemberToMeeting(ctx context.Context, meeting *
 // and removes or converts the member's registrant based on meeting visibility.
 func (h *CommitteeHandlers) removeMemberFromRelevantMeetings(ctx context.Context, member *models.CommitteeMember) error {
 	// Get meetings that contain this committee
-	meetings, _, err := h.meetingService.MeetingRepository.ListByCommittee(ctx, member.CommitteeUID)
+	meetings, _, err := h.meetingService.GetMeetingsByCommittee(ctx, member.CommitteeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list meetings by committee", logging.ErrKey, err)
 		return fmt.Errorf("failed to list meetings by committee: %w", err)

--- a/internal/handlers/committee_handlers.go
+++ b/internal/handlers/committee_handlers.go
@@ -265,7 +265,7 @@ func (h *CommitteeHandlers) HandleCommitteeMemberDeleted(ctx context.Context, ms
 // and adds the new member as a registrant if their voting status matches.
 func (h *CommitteeHandlers) addMemberToRelevantMeetings(ctx context.Context, memberMsg *models.CommitteeMember) error {
 	// Get meetings that contain this committee
-	meetings, _, err := h.meetingService.GetMeetingsByCommittee(ctx, memberMsg.CommitteeUID)
+	meetings, _, err := h.meetingService.ListMeetingsByCommittee(ctx, memberMsg.CommitteeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list meetings by committee", logging.ErrKey, err)
 		return fmt.Errorf("failed to list meetings by committee: %w", err)
@@ -397,7 +397,7 @@ func (h *CommitteeHandlers) tryAddMemberToMeeting(ctx context.Context, meeting *
 // and removes or converts the member's registrant based on meeting visibility.
 func (h *CommitteeHandlers) removeMemberFromRelevantMeetings(ctx context.Context, member *models.CommitteeMember) error {
 	// Get meetings that contain this committee
-	meetings, _, err := h.meetingService.GetMeetingsByCommittee(ctx, member.CommitteeUID)
+	meetings, _, err := h.meetingService.ListMeetingsByCommittee(ctx, member.CommitteeUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to list meetings by committee", logging.ErrKey, err)
 		return fmt.Errorf("failed to list meetings by committee: %w", err)

--- a/internal/handlers/meeting_handlers.go
+++ b/internal/handlers/meeting_handlers.go
@@ -181,7 +181,7 @@ func (s *MeetingHandler) HandleMeetingDeleted(ctx context.Context, msg domain.Me
 	slog.InfoContext(ctx, "processing meeting deletion, cleaning up registrants")
 
 	// Get all registrants for the meeting
-	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, meetingUID)
+	registrants, err := s.registrantService.ListMeetingRegistrants(ctx, meetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting registrants for deleted meeting", logging.ErrKey, err)
 		return nil, err
@@ -337,7 +337,7 @@ func (s *MeetingHandler) HandleMeetingUpdated(ctx context.Context, msg domain.Me
 
 func (s *MeetingHandler) meetingUpdatedInvitations(ctx context.Context, msg models.MeetingUpdatedMessage) error {
 	// Get all registrants for the meeting
-	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, msg.MeetingUID)
+	registrants, err := s.registrantService.ListMeetingRegistrants(ctx, msg.MeetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting registrants for updated meeting", logging.ErrKey, err)
 		return err

--- a/internal/handlers/meeting_handlers.go
+++ b/internal/handlers/meeting_handlers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
@@ -16,7 +15,6 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/service"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/concurrent"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/utils"
 )
@@ -125,7 +123,7 @@ func (s *MeetingHandler) handleMeetingGetAttribute(ctx context.Context, msg doma
 		return nil, err
 	}
 
-	meeting, err := s.meetingService.MeetingRepository.GetBase(ctx, meetingUID)
+	meeting, _, err := s.meetingService.GetMeetingBase(ctx, meetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting meeting from NATS KV", logging.ErrKey, err)
 		return nil, err
@@ -183,7 +181,7 @@ func (s *MeetingHandler) HandleMeetingDeleted(ctx context.Context, msg domain.Me
 	slog.InfoContext(ctx, "processing meeting deletion, cleaning up registrants")
 
 	// Get all registrants for the meeting
-	registrants, err := s.registrantService.RegistrantRepository.ListByMeeting(ctx, meetingUID)
+	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, meetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting registrants for deleted meeting", logging.ErrKey, err)
 		return nil, err
@@ -339,7 +337,7 @@ func (s *MeetingHandler) HandleMeetingUpdated(ctx context.Context, msg domain.Me
 
 func (s *MeetingHandler) meetingUpdatedInvitations(ctx context.Context, msg models.MeetingUpdatedMessage) error {
 	// Get all registrants for the meeting
-	registrants, err := s.registrantService.RegistrantRepository.ListByMeeting(ctx, msg.MeetingUID)
+	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, msg.MeetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting registrants for updated meeting", logging.ErrKey, err)
 		return err
@@ -351,7 +349,7 @@ func (s *MeetingHandler) meetingUpdatedInvitations(ctx context.Context, msg mode
 	}
 
 	// Get meeting details once for all email notifications
-	meeting, err := s.meetingService.MeetingRepository.GetBase(ctx, msg.MeetingUID)
+	meeting, _, err := s.meetingService.GetMeetingBase(ctx, msg.MeetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting meeting details for update notifications", logging.ErrKey, err)
 		return err
@@ -371,32 +369,8 @@ func (s *MeetingHandler) meetingUpdatedInvitations(ctx context.Context, msg mode
 	for _, registrant := range registrants {
 		reg := registrant // capture loop variable
 		tasks = append(tasks, func() error {
-
-			// Build recipient name from first and last name
-			var recipientName string
-			if reg.FirstName != "" || reg.LastName != "" {
-				recipientName = strings.TrimSpace(fmt.Sprintf("%s %s", reg.FirstName, reg.LastName))
-			}
-
-			// Send update notification email to registrant
-			updatedInvitation := domain.EmailUpdatedInvitation{
-				MeetingUID:     msg.MeetingUID,
-				RecipientEmail: reg.Email,
-				RecipientName:  recipientName,
-				MeetingTitle:   meeting.Title,
-				StartTime:      meeting.StartTime,
-				Duration:       meeting.Duration,
-				Timezone:       meeting.Timezone,
-				Description:    meeting.Description,
-				JoinLink:       constants.GenerateLFXMeetingURL(meeting.UID, meeting.Password, s.registrantService.Config.LFXEnvironment),
-				Platform:       meeting.Platform,
-				MeetingID:      meetingID,
-				Passcode:       passcode,
-				Recurrence:     meeting.Recurrence,
-				Changes:        msg.Changes,
-			}
-
-			err := s.registrantService.EmailService.SendRegistrantUpdatedInvitation(ctx, updatedInvitation)
+			// Use the registrant service method to send updated invitation
+			err := s.registrantService.SendRegistrantUpdatedInvitation(ctx, reg, meeting, msg.Changes, meetingID, passcode)
 			if err != nil {
 				slog.ErrorContext(ctx, "error sending update notification email",
 					"registrant_uid", reg.UID,

--- a/internal/handlers/meeting_handlers_test.go
+++ b/internal/handlers/meeting_handlers_test.go
@@ -30,22 +30,22 @@ func setupHandlerForTesting() (*MeetingHandler, *mocks.MockMeetingRepository, *m
 	}
 
 	occurrenceService := service.NewOccurrenceService()
-	meetingService := &service.MeetingService{
-		MeetingRepository: mockMeetingRepo,
-		MessageBuilder:    mockMessageBuilder,
-		PlatformRegistry:  mockPlatformRegistry,
-		OccurrenceService: occurrenceService,
-		Config:            config,
-	}
+	meetingService := service.NewMeetingService(
+		mockMeetingRepo,
+		mockMessageBuilder,
+		mockPlatformRegistry,
+		occurrenceService,
+		config,
+	)
 
-	registrantService := &service.MeetingRegistrantService{
-		MeetingRepository:    mockMeetingRepo,
-		RegistrantRepository: mockRegistrantRepo,
-		MessageBuilder:       mockMessageBuilder,
-		EmailService:         mockEmailService,
-		OccurrenceService:    occurrenceService,
-		Config:               config,
-	}
+	registrantService := service.NewMeetingRegistrantService(
+		mockMeetingRepo,
+		mockRegistrantRepo,
+		mockEmailService,
+		mockMessageBuilder,
+		occurrenceService,
+		config,
+	)
 
 	// Create a committee sync service for testing
 	committeeSyncService := service.NewCommitteeSyncService(

--- a/internal/handlers/meeting_handlers_test.go
+++ b/internal/handlers/meeting_handlers_test.go
@@ -112,7 +112,7 @@ func TestMeetingHandler_HandleMessage(t *testing.T) {
 						Host:       false,
 					},
 				}
-				// Mock for GetBase call in GetMeetingRegistrants service method
+				// Mock for GetBase call in ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-to-delete").Return(&models.MeetingBase{UID: "meeting-to-delete"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-to-delete").Return(registrants, nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil)
@@ -321,7 +321,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 						Host:       false,
 					},
 				}
-				// Mock for GetBase call in GetMeetingRegistrants service method
+				// Mock for GetBase call in ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-123").Return(&models.MeetingBase{UID: "meeting-123"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-123").Return(registrants, nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil)
@@ -365,7 +365,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 						Host:       false,
 					},
 				}
-				// Mock for GetBase call in GetMeetingRegistrants service method
+				// Mock for GetBase call in ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-456").Return(&models.MeetingBase{UID: "meeting-456"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-456").Return(registrants, nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil)
@@ -394,7 +394,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 			name:        "successfully handle meeting with no registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-789","meeting":{"uid":"meeting-789","project_uid":"project-789","title":"Test Meeting 3","start_time":"2023-12-01T12:00:00Z","duration":60,"timezone":"UTC","description":"Test meeting 3 description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
-				// Mock for GetBase call in GetMeetingRegistrants service method
+				// Mock for GetBase call in ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-789").Return(&models.MeetingBase{UID: "meeting-789"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-789").Return([]*models.Registrant{}, nil)
 				// No further mocks needed - no registrants to delete
@@ -427,7 +427,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 			name:        "repository error when listing registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-error","meeting":{"uid":"meeting-error","project_uid":"project-error","title":"Error Meeting","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Error meeting description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
-				// Mock for GetBase call in GetMeetingRegistrants service method
+				// Mock for GetBase call in ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-error").Return(&models.MeetingBase{UID: "meeting-error"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-error").Return(
 					nil, domain.NewInternalError("internal error"),
@@ -453,7 +453,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 						Email:      "user2@example.com",
 					},
 				}
-				// Mock for GetBase call in GetMeetingRegistrants service method
+				// Mock for GetBase call in ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-partial").Return(&models.MeetingBase{UID: "meeting-partial"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-partial").Return(registrants, nil)
 				// Both deletions may be attempted concurrently, but at least one will fail
@@ -537,7 +537,7 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 						LastName:   "Smith",
 					},
 				}
-				// Mock for GetMeetingRegistrants service method
+				// Mock for ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-updated").Return(&models.MeetingBase{UID: "meeting-updated"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-updated").Return(registrants, nil)
 
@@ -572,7 +572,7 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 			name:        "successfully handle meeting with no registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-no-registrants","changes":{"Title":"Updated Title"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
-				// Mock for GetMeetingRegistrants service method
+				// Mock for ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-no-registrants").Return(&models.MeetingBase{UID: "meeting-no-registrants"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-no-registrants").Return([]*models.Registrant{}, nil)
 			},
@@ -606,7 +606,7 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 			name:        "handle repository error when listing registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-repo-error","changes":{"Title":"Updated"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
-				// Mock for GetMeetingRegistrants service method
+				// Mock for ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-repo-error").Return(&models.MeetingBase{UID: "meeting-repo-error"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-repo-error").Return([]*models.Registrant{}, domain.NewInternalError("internal error"))
 			},
@@ -632,7 +632,7 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 						LastName:   "User",
 					},
 				}
-				// Mock for GetMeetingRegistrants service method
+				// Mock for ListMeetingRegistrants service method
 				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-partial-email-fail").Return(&models.MeetingBase{UID: "meeting-partial-email-fail"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-partial-email-fail").Return(registrants, nil)
 

--- a/internal/handlers/meeting_handlers_test.go
+++ b/internal/handlers/meeting_handlers_test.go
@@ -556,6 +556,9 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 				}
 				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-updated").Return(meeting, uint64(0), nil)
 
+				// Mock GetProjectName for email notifications
+				mockBuilder.On("GetProjectName", mock.Anything, mock.AnythingOfType("string")).Return("Test Project", nil)
+
 				// Expect email notifications to be sent
 				mockEmailService.On("SendRegistrantUpdatedInvitation", mock.Anything, mock.MatchedBy(func(invitation domain.EmailUpdatedInvitation) bool {
 					return invitation.MeetingUID == "meeting-updated" &&
@@ -641,6 +644,9 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 					Timezone:  "UTC",
 				}
 				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-partial-email-fail").Return(meeting, uint64(0), nil)
+
+				// Mock GetProjectName for email notifications
+				mockBuilder.On("GetProjectName", mock.Anything, mock.AnythingOfType("string")).Return("Test Project", nil)
 
 				// First email succeeds, second fails
 				mockEmailService.On("SendRegistrantUpdatedInvitation", mock.Anything, mock.MatchedBy(func(invitation domain.EmailUpdatedInvitation) bool {

--- a/internal/handlers/meeting_handlers_test.go
+++ b/internal/handlers/meeting_handlers_test.go
@@ -43,6 +43,7 @@ func setupHandlerForTesting() (*MeetingHandler, *mocks.MockMeetingRepository, *m
 		RegistrantRepository: mockRegistrantRepo,
 		MessageBuilder:       mockMessageBuilder,
 		EmailService:         mockEmailService,
+		OccurrenceService:    occurrenceService,
 		Config:               config,
 	}
 
@@ -82,13 +83,14 @@ func TestMeetingHandler_HandleMessage(t *testing.T) {
 			messageData: []byte("01234567-89ab-cdef-0123-456789abcdef"),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
 				now := time.Now()
-				mockMeetingRepo.On("GetBase", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
 					&models.MeetingBase{
 						UID:       "01234567-89ab-cdef-0123-456789abcdef",
 						Title:     "Test Meeting",
 						CreatedAt: &now,
 						UpdatedAt: &now,
 					},
+					uint64(1),
 					nil,
 				)
 			},
@@ -110,6 +112,8 @@ func TestMeetingHandler_HandleMessage(t *testing.T) {
 						Host:       false,
 					},
 				}
+				// Mock for GetBase call in GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-to-delete").Return(&models.MeetingBase{UID: "meeting-to-delete"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-to-delete").Return(registrants, nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil)
 				mockBuilder.On("SendDeleteIndexMeetingRegistrant", mock.Anything, "registrant-1").Return(nil)
@@ -117,7 +121,7 @@ func TestMeetingHandler_HandleMessage(t *testing.T) {
 					return msg.UID == "registrant-1"
 				})).Return(nil)
 				// Mock GetBase for cancellation email (called in goroutine)
-				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-to-delete").Return(&models.MeetingBase{
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-to-delete").Return(&models.MeetingBase{
 					UID:         "meeting-to-delete",
 					ProjectUID:  "project-123",
 					Title:       "Test Meeting",
@@ -125,7 +129,7 @@ func TestMeetingHandler_HandleMessage(t *testing.T) {
 					Duration:    60,
 					Timezone:    "UTC",
 					Description: "Test meeting description",
-				}, nil).Maybe() // Maybe() because it's called in a goroutine
+				}, uint64(0), nil).Maybe() // Maybe() because it's called in a goroutine
 				// Mock GetProjectName for cancellation email (called in goroutine)
 				mockBuilder.On("GetProjectName", mock.Anything, "project-123").Return("Test Project", nil).Maybe()
 				// Mock email service for cancellation
@@ -190,13 +194,14 @@ func TestMeetingHandler_HandleGetTitleMessage(t *testing.T) {
 			messageData: []byte("01234567-89ab-cdef-0123-456789abcdef"),
 			setupMocks: func(mockRepo *mocks.MockMeetingRepository) {
 				now := time.Now()
-				mockRepo.On("GetBase", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
+				mockRepo.On("GetBaseWithRevision", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
 					&models.MeetingBase{
 						UID:       "01234567-89ab-cdef-0123-456789abcdef",
 						Title:     "Important Team Meeting",
 						CreatedAt: &now,
 						UpdatedAt: &now,
 					},
+					uint64(1),
 					nil,
 				)
 			},
@@ -208,13 +213,14 @@ func TestMeetingHandler_HandleGetTitleMessage(t *testing.T) {
 			messageData: []byte("11111111-2222-3333-4444-555555555555"),
 			setupMocks: func(mockRepo *mocks.MockMeetingRepository) {
 				now := time.Now()
-				mockRepo.On("GetBase", mock.Anything, "11111111-2222-3333-4444-555555555555").Return(
+				mockRepo.On("GetBaseWithRevision", mock.Anything, "11111111-2222-3333-4444-555555555555").Return(
 					&models.MeetingBase{
 						UID:       "11111111-2222-3333-4444-555555555555",
 						Title:     "Meeting: Q1 Review & Planning (Team A)",
 						CreatedAt: &now,
 						UpdatedAt: &now,
 					},
+					uint64(1),
 					nil,
 				)
 			},
@@ -226,8 +232,8 @@ func TestMeetingHandler_HandleGetTitleMessage(t *testing.T) {
 			name:        "repository error",
 			messageData: []byte("01234567-89ab-cdef-0123-456789abcdef"),
 			setupMocks: func(mockRepo *mocks.MockMeetingRepository) {
-				mockRepo.On("GetBase", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
-					nil, domain.NewInternalError("internal error"),
+				mockRepo.On("GetBaseWithRevision", mock.Anything, "01234567-89ab-cdef-0123-456789abcdef").Return(
+					nil, uint64(0), domain.NewInternalError("internal error"),
 				)
 			},
 			expectError:   true,
@@ -237,8 +243,8 @@ func TestMeetingHandler_HandleGetTitleMessage(t *testing.T) {
 			name:        "meeting not found",
 			messageData: []byte("00000000-0000-0000-0000-000000000000"),
 			setupMocks: func(mockRepo *mocks.MockMeetingRepository) {
-				mockRepo.On("GetBase", mock.Anything, "00000000-0000-0000-0000-000000000000").Return(
-					nil, domain.NewNotFoundError("meeting not found"),
+				mockRepo.On("GetBaseWithRevision", mock.Anything, "00000000-0000-0000-0000-000000000000").Return(
+					nil, uint64(0), domain.NewNotFoundError("meeting not found"),
 				)
 			},
 			expectError:   true,
@@ -315,6 +321,8 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 						Host:       false,
 					},
 				}
+				// Mock for GetBase call in GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-123").Return(&models.MeetingBase{UID: "meeting-123"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-123").Return(registrants, nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil)
 				mockBuilder.On("SendDeleteIndexMeetingRegistrant", mock.Anything, "registrant-1").Return(nil)
@@ -322,7 +330,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 					return msg.UID == "registrant-1"
 				})).Return(nil)
 				// Mock for cancellation email (called in goroutine)
-				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-123").Return(&models.MeetingBase{
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-123").Return(&models.MeetingBase{
 					UID:         "meeting-123",
 					ProjectUID:  "project-123",
 					Title:       "Test Meeting",
@@ -330,7 +338,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 					Duration:    60,
 					Timezone:    "UTC",
 					Description: "Test meeting description",
-				}, nil).Maybe()
+				}, uint64(0), nil).Maybe()
 				mockBuilder.On("GetProjectName", mock.Anything, "project-123").Return("Test Project", nil).Maybe()
 				mockEmailService.On("SendRegistrantCancellation", mock.Anything, mock.AnythingOfType("domain.EmailCancellation")).Return(nil).Maybe()
 			},
@@ -357,6 +365,8 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 						Host:       false,
 					},
 				}
+				// Mock for GetBase call in GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-456").Return(&models.MeetingBase{UID: "meeting-456"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-456").Return(registrants, nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil)
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-2", uint64(0)).Return(nil)
@@ -366,7 +376,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 					return msg.UID == "registrant-1" || msg.UID == "registrant-2"
 				})).Return(nil).Times(2)
 				// Mock for cancellation emails (called in goroutines)
-				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-456").Return(&models.MeetingBase{
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-456").Return(&models.MeetingBase{
 					UID:         "meeting-456",
 					ProjectUID:  "project-456",
 					Title:       "Team Sync",
@@ -374,7 +384,7 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 					Duration:    30,
 					Timezone:    "America/New_York",
 					Description: "Weekly team sync",
-				}, nil).Maybe()
+				}, uint64(0), nil).Maybe()
 				mockBuilder.On("GetProjectName", mock.Anything, "project-456").Return("Team Project", nil).Maybe()
 				mockEmailService.On("SendRegistrantCancellation", mock.Anything, mock.AnythingOfType("domain.EmailCancellation")).Return(nil).Maybe()
 			},
@@ -384,6 +394,8 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 			name:        "successfully handle meeting with no registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-789","meeting":{"uid":"meeting-789","project_uid":"project-789","title":"Test Meeting 3","start_time":"2023-12-01T12:00:00Z","duration":60,"timezone":"UTC","description":"Test meeting 3 description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
+				// Mock for GetBase call in GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-789").Return(&models.MeetingBase{UID: "meeting-789"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-789").Return([]*models.Registrant{}, nil)
 				// No further mocks needed - no registrants to delete
 			},
@@ -415,6 +427,8 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 			name:        "repository error when listing registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-error","meeting":{"uid":"meeting-error","project_uid":"project-error","title":"Error Meeting","start_time":"2023-12-01T10:00:00Z","duration":60,"timezone":"UTC","description":"Error meeting description"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
+				// Mock for GetBase call in GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-error").Return(&models.MeetingBase{UID: "meeting-error"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-error").Return(
 					nil, domain.NewInternalError("internal error"),
 				)
@@ -439,6 +453,8 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 						Email:      "user2@example.com",
 					},
 				}
+				// Mock for GetBase call in GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-partial").Return(&models.MeetingBase{UID: "meeting-partial"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-partial").Return(registrants, nil)
 				// Both deletions may be attempted concurrently, but at least one will fail
 				mockRegistrantRepo.On("Delete", mock.Anything, "registrant-1", uint64(0)).Return(nil).Maybe()
@@ -449,11 +465,11 @@ func TestMeetingHandler_HandleMeetingDeletedMessage(t *testing.T) {
 					return msg.UID == "registrant-1"
 				})).Return(nil).Maybe()
 				// Email sending might be attempted for successful deletion
-				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-partial").Return(&models.MeetingBase{
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-partial").Return(&models.MeetingBase{
 					UID:        "meeting-partial",
 					ProjectUID: "project-partial",
 					Title:      "Test",
-				}, nil).Maybe()
+				}, uint64(0), nil).Maybe()
 				mockBuilder.On("GetProjectName", mock.Anything, "project-partial").Return("Test Project", nil).Maybe()
 				mockEmailService.On("SendRegistrantCancellation", mock.Anything, mock.AnythingOfType("domain.EmailCancellation")).Return(nil).Maybe()
 			},
@@ -521,6 +537,8 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 						LastName:   "Smith",
 					},
 				}
+				// Mock for GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-updated").Return(&models.MeetingBase{UID: "meeting-updated"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-updated").Return(registrants, nil)
 
 				// Mock meeting retrieval for each registrant
@@ -536,7 +554,7 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 						Passcode:  "secret",
 					},
 				}
-				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-updated").Return(meeting, nil)
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-updated").Return(meeting, uint64(0), nil)
 
 				// Expect email notifications to be sent
 				mockEmailService.On("SendRegistrantUpdatedInvitation", mock.Anything, mock.MatchedBy(func(invitation domain.EmailUpdatedInvitation) bool {
@@ -551,6 +569,8 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 			name:        "successfully handle meeting with no registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-no-registrants","changes":{"Title":"Updated Title"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
+				// Mock for GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-no-registrants").Return(&models.MeetingBase{UID: "meeting-no-registrants"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-no-registrants").Return([]*models.Registrant{}, nil)
 			},
 			expectError: false,
@@ -583,6 +603,8 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 			name:        "handle repository error when listing registrants",
 			messageData: []byte(`{"meeting_uid":"meeting-repo-error","changes":{"Title":"Updated"}}`),
 			setupMocks: func(mockMeetingRepo *mocks.MockMeetingRepository, mockRegistrantRepo *mocks.MockRegistrantRepository, mockBuilder *mocks.MockMessageBuilder, mockEmailService *mocks.MockEmailService) {
+				// Mock for GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-repo-error").Return(&models.MeetingBase{UID: "meeting-repo-error"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-repo-error").Return([]*models.Registrant{}, domain.NewInternalError("internal error"))
 			},
 			expectError: true,
@@ -607,6 +629,8 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 						LastName:   "User",
 					},
 				}
+				// Mock for GetMeetingRegistrants service method
+				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-partial-email-fail").Return(&models.MeetingBase{UID: "meeting-partial-email-fail"}, nil)
 				mockRegistrantRepo.On("ListByMeeting", mock.Anything, "meeting-partial-email-fail").Return(registrants, nil)
 
 				meeting := &models.MeetingBase{
@@ -616,7 +640,7 @@ func TestMeetingHandler_HandleMeetingUpdatedMessage(t *testing.T) {
 					Duration:  120,
 					Timezone:  "UTC",
 				}
-				mockMeetingRepo.On("GetBase", mock.Anything, "meeting-partial-email-fail").Return(meeting, nil)
+				mockMeetingRepo.On("GetBaseWithRevision", mock.Anything, "meeting-partial-email-fail").Return(meeting, uint64(0), nil)
 
 				// First email succeeds, second fails
 				mockEmailService.On("SendRegistrantUpdatedInvitation", mock.Anything, mock.MatchedBy(func(invitation domain.EmailUpdatedInvitation) bool {

--- a/internal/handlers/zoom_webhook_handlers.go
+++ b/internal/handlers/zoom_webhook_handlers.go
@@ -1165,7 +1165,7 @@ func (s *ZoomWebhookHandler) createPastMeetingParticipants(ctx context.Context, 
 	)
 
 	// Get all registrants for this meeting
-	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, meeting.UID)
+	registrants, err := s.registrantService.ListMeetingRegistrants(ctx, meeting.UID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to get registrants for meeting", logging.ErrKey, err)
 		return fmt.Errorf("failed to get registrants: %w", err)
@@ -1883,7 +1883,7 @@ func (s *ZoomWebhookHandler) createParticipantFromLeftEvent(ctx context.Context,
 func (s *ZoomWebhookHandler) createParticipantRecord(ctx context.Context, pastMeeting *models.PastMeeting, participant ZoomPayloadForParticipant, session models.ParticipantSession) (*models.PastMeetingParticipant, error) {
 	// Check if this participant was invited (has a registrant record for this meeting)
 	var matchingRegistrant *models.Registrant
-	registrants, err := s.registrantService.GetRegistrantsByEmail(ctx, participant.Email)
+	registrants, err := s.registrantService.ListRegistrantsByEmail(ctx, participant.Email)
 	if err != nil {
 		slog.WarnContext(ctx, "could not check registrant records for participant",
 			logging.ErrKey, err,

--- a/internal/handlers/zoom_webhook_handlers.go
+++ b/internal/handlers/zoom_webhook_handlers.go
@@ -1165,7 +1165,7 @@ func (s *ZoomWebhookHandler) createPastMeetingParticipants(ctx context.Context, 
 	)
 
 	// Get all registrants for this meeting
-	registrants, err := s.registrantService.RegistrantRepository.ListByMeeting(ctx, meeting.UID)
+	registrants, err := s.registrantService.GetMeetingRegistrants(ctx, meeting.UID)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to get registrants for meeting", logging.ErrKey, err)
 		return fmt.Errorf("failed to get registrants: %w", err)
@@ -1883,7 +1883,7 @@ func (s *ZoomWebhookHandler) createParticipantFromLeftEvent(ctx context.Context,
 func (s *ZoomWebhookHandler) createParticipantRecord(ctx context.Context, pastMeeting *models.PastMeeting, participant ZoomPayloadForParticipant, session models.ParticipantSession) (*models.PastMeetingParticipant, error) {
 	// Check if this participant was invited (has a registrant record for this meeting)
 	var matchingRegistrant *models.Registrant
-	registrants, err := s.registrantService.RegistrantRepository.ListByEmail(ctx, participant.Email)
+	registrants, err := s.registrantService.GetRegistrantsByEmail(ctx, participant.Email)
 	if err != nil {
 		slog.WarnContext(ctx, "could not check registrant records for participant",
 			logging.ErrKey, err,

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -3,19 +3,34 @@
 
 package service
 
-import "github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/auth"
+import (
+	"context"
+	"log/slog"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/auth"
+)
 
 type AuthService struct {
-	Auth auth.IJWTAuth
+	auth auth.IJWTAuth
 }
 
 func NewAuthService(auth auth.IJWTAuth) *AuthService {
 	return &AuthService{
-		Auth: auth,
+		auth: auth,
 	}
 }
 
 // ServiceReady checks if the service is ready for use.
 func (s *AuthService) ServiceReady() bool {
-	return s.Auth != nil
+	return s.auth != nil
+}
+
+// ParsePrincipal parses the Heimdall-authorized principal from the bearer token.
+func (s *AuthService) ParsePrincipal(ctx context.Context, bearerToken string, logger *slog.Logger) (string, error) {
+	if !s.ServiceReady() {
+		return "", domain.NewUnavailableError("auth service not ready")
+	}
+
+	return s.auth.ParsePrincipal(ctx, bearerToken, logger)
 }

--- a/internal/service/meeting_service.go
+++ b/internal/service/meeting_service.go
@@ -114,8 +114,8 @@ func (s *MeetingService) ServiceReady() bool {
 		s.OccurrenceService != nil
 }
 
-// GetMeetings fetches all meetings
-func (s *MeetingService) GetMeetings(ctx context.Context) ([]*models.MeetingFull, error) {
+// ListMeetings fetches all meetings
+func (s *MeetingService) ListMeetings(ctx context.Context) ([]*models.MeetingFull, error) {
 	if !s.ServiceReady() {
 		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
 		return nil, domain.NewUnavailableError("meeting service is not ready")
@@ -156,8 +156,8 @@ func (s *MeetingService) GetMeetings(ctx context.Context) ([]*models.MeetingFull
 	return meetings, nil
 }
 
-// GetMeetingsByCommittee gets all meetings associated with a committee
-func (s *MeetingService) GetMeetingsByCommittee(ctx context.Context, committeeUID string) ([]*models.MeetingBase, []*models.MeetingSettings, error) {
+// ListMeetingsByCommittee gets all meetings associated with a committee
+func (s *MeetingService) ListMeetingsByCommittee(ctx context.Context, committeeUID string) ([]*models.MeetingBase, []*models.MeetingSettings, error) {
 	if !s.ServiceReady() {
 		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
 		return nil, nil, domain.NewUnavailableError("meeting service is not ready")

--- a/internal/service/meeting_service.go
+++ b/internal/service/meeting_service.go
@@ -415,6 +415,11 @@ func (s *MeetingService) GetMeetingByPlatformMeetingID(ctx context.Context, plat
 			slog.ErrorContext(ctx, "failed to find meeting by Zoom meeting ID", logging.ErrKey, err)
 			return nil, err
 		}
+
+		// Calculate next 50 occurrences from current time
+		currentTime := time.Now()
+		meeting.Occurrences = s.occurrenceService.CalculateOccurrencesFromDate(meeting, currentTime, 50)
+
 		slog.DebugContext(ctx, "returning meeting by Zoom meeting ID", "meeting_uid", meeting.UID)
 		return meeting, nil
 	default:

--- a/internal/service/meeting_service_test.go
+++ b/internal/service/meeting_service_test.go
@@ -27,13 +27,13 @@ func setupServiceForTesting() (*MeetingService, *mocks.MockMeetingRepository, *m
 		SkipEtagValidation: false,
 	}
 
-	service := &MeetingService{
-		MeetingRepository: mockRepo,
-		MessageBuilder:    mockBuilder,
-		PlatformRegistry:  mockPlatformRegistry,
-		OccurrenceService: occurrenceService,
-		Config:            config,
-	}
+	service := NewMeetingService(
+		mockRepo,
+		mockBuilder,
+		mockPlatformRegistry,
+		occurrenceService,
+		config,
+	)
 
 	return service, mockRepo, mockBuilder
 }
@@ -129,7 +129,7 @@ func TestMeetingsService_GetMeetings(t *testing.T) {
 			service, mockRepo, mockBuilder := setupServiceForTesting()
 
 			if tt.name == "service not ready" {
-				service.MeetingRepository = nil
+				service.meetingRepository = nil
 			}
 
 			tt.setupMocks(mockRepo, mockBuilder)
@@ -180,7 +180,7 @@ func TestMeetingsService_CreateMeeting(t *testing.T) {
 			},
 			setupMocks: func(service *MeetingService, mockRepo *mocks.MockMeetingRepository, mockBuilder *mocks.MockMessageBuilder) {
 				// Set up platform registry mock
-				mockPlatformRegistry := service.PlatformRegistry.(*mocks.MockPlatformRegistry)
+				mockPlatformRegistry := service.platformRegistry.(*mocks.MockPlatformRegistry)
 				mockProvider := &mocks.MockPlatformProvider{}
 				mockProvider.On("CreateMeeting", mock.Anything, mock.Anything).Return(&domain.CreateMeetingResult{
 					PlatformMeetingID: "zoom-meeting-123",
@@ -241,7 +241,7 @@ func TestMeetingsService_CreateMeeting(t *testing.T) {
 			},
 			setupMocks: func(service *MeetingService, mockRepo *mocks.MockMeetingRepository, mockBuilder *mocks.MockMessageBuilder) {
 				// Set up platform registry mock for cleanup on error
-				mockPlatformRegistry := service.PlatformRegistry.(*mocks.MockPlatformRegistry)
+				mockPlatformRegistry := service.platformRegistry.(*mocks.MockPlatformRegistry)
 				mockProvider := &mocks.MockPlatformProvider{}
 				mockProvider.On("CreateMeeting", mock.Anything, mock.Anything).Return(&domain.CreateMeetingResult{
 					PlatformMeetingID: "zoom-meeting-123",
@@ -267,7 +267,7 @@ func TestMeetingsService_CreateMeeting(t *testing.T) {
 			service, mockRepo, mockBuilder := setupServiceForTesting()
 
 			if tt.name == "service not ready" {
-				service.MeetingRepository = nil
+				service.meetingRepository = nil
 			}
 
 			tt.setupMocks(service, mockRepo, mockBuilder)
@@ -293,7 +293,7 @@ func TestMeetingsService_CreateMeeting(t *testing.T) {
 			mockRepo.AssertExpectations(t)
 			mockBuilder.AssertExpectations(t)
 			if tt.name != "service not ready" {
-				mockPlatformRegistry := service.PlatformRegistry.(*mocks.MockPlatformRegistry)
+				mockPlatformRegistry := service.platformRegistry.(*mocks.MockPlatformRegistry)
 				mockPlatformRegistry.AssertExpectations(t)
 			}
 		})
@@ -453,7 +453,7 @@ func TestMeetingsService_GetMeetingSettings(t *testing.T) {
 			service, mockRepo, mockBuilder := setupServiceForTesting()
 
 			if tt.name == "service not ready" {
-				service.MeetingRepository = nil
+				service.meetingRepository = nil
 			}
 
 			tt.setupMocks(mockRepo, mockBuilder)
@@ -596,11 +596,11 @@ func TestMeetingsService_UpdateMeetingSettings(t *testing.T) {
 			service, mockRepo, mockBuilder := setupServiceForTesting()
 
 			if tt.name == "service not ready" {
-				service.MeetingRepository = nil
+				service.meetingRepository = nil
 			}
 
 			if tt.name == "skip etag validation mode" {
-				service.Config.SkipEtagValidation = true
+				service.config.SkipEtagValidation = true
 			}
 
 			tt.setupMocks(mockRepo, mockBuilder)

--- a/internal/service/meeting_service_test.go
+++ b/internal/service/meeting_service_test.go
@@ -134,7 +134,7 @@ func TestMeetingsService_GetMeetings(t *testing.T) {
 
 			tt.setupMocks(mockRepo, mockBuilder)
 
-			result, err := service.GetMeetings(context.Background())
+			result, err := service.ListMeetings(context.Background())
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/service/past_meeting_participant_service.go
+++ b/internal/service/past_meeting_participant_service.go
@@ -50,8 +50,8 @@ func (s *PastMeetingParticipantService) ServiceReady() bool {
 		s.MessageBuilder != nil
 }
 
-// GetPastMeetingParticipants fetches all participants for a past meeting
-func (s *PastMeetingParticipantService) GetPastMeetingParticipants(ctx context.Context, pastMeetingUID string) ([]*models.PastMeetingParticipant, error) {
+// ListPastMeetingParticipants fetches all participants for a past meeting
+func (s *PastMeetingParticipantService) ListPastMeetingParticipants(ctx context.Context, pastMeetingUID string) ([]*models.PastMeetingParticipant, error) {
 	if !s.ServiceReady() {
 		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
 		return nil, domain.NewUnavailableError("service not initialized")

--- a/internal/service/past_meeting_participant_service_test.go
+++ b/internal/service/past_meeting_participant_service_test.go
@@ -196,7 +196,7 @@ func TestPastMeetingParticipantService_GetPastMeetingParticipants(t *testing.T) 
 				tt.setupMocks(mockPastMeetingRepo, mockParticipantRepo)
 			}
 
-			result, err := service.GetPastMeetingParticipants(ctx, tt.pastMeetingUID)
+			result, err := service.ListPastMeetingParticipants(ctx, tt.pastMeetingUID)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/service/past_meeting_participant_service_test.go
+++ b/internal/service/past_meeting_participant_service_test.go
@@ -52,27 +52,51 @@ func TestPastMeetingParticipantService_ServiceReady(t *testing.T) {
 		{
 			name: "service not ready - missing past meeting repository",
 			setupService: func() *PastMeetingParticipantService {
-				service, _, _, _, _ := setupPastMeetingParticipantServiceForTesting()
-				service.PastMeetingRepository = nil
-				return service
+				mockMeetingRepo := &mocks.MockMeetingRepository{}
+				mockParticipantRepo := &mocks.MockPastMeetingParticipantRepository{}
+				mockBuilder := &mocks.MockMessageBuilder{}
+				config := ServiceConfig{SkipEtagValidation: false}
+				return NewPastMeetingParticipantService(
+					mockMeetingRepo,
+					nil, // past meeting repository is nil
+					mockParticipantRepo,
+					mockBuilder,
+					config,
+				)
 			},
 			expectedReady: false,
 		},
 		{
 			name: "service not ready - missing participant repository",
 			setupService: func() *PastMeetingParticipantService {
-				service, _, _, _, _ := setupPastMeetingParticipantServiceForTesting()
-				service.PastMeetingParticipantRepository = nil
-				return service
+				mockMeetingRepo := &mocks.MockMeetingRepository{}
+				mockPastMeetingRepo := &mocks.MockPastMeetingRepository{}
+				mockBuilder := &mocks.MockMessageBuilder{}
+				config := ServiceConfig{SkipEtagValidation: false}
+				return NewPastMeetingParticipantService(
+					mockMeetingRepo,
+					mockPastMeetingRepo,
+					nil, // participant repository is nil
+					mockBuilder,
+					config,
+				)
 			},
 			expectedReady: false,
 		},
 		{
 			name: "service not ready - missing message builder",
 			setupService: func() *PastMeetingParticipantService {
-				service, _, _, _, _ := setupPastMeetingParticipantServiceForTesting()
-				service.MessageBuilder = nil
-				return service
+				mockMeetingRepo := &mocks.MockMeetingRepository{}
+				mockPastMeetingRepo := &mocks.MockPastMeetingRepository{}
+				mockParticipantRepo := &mocks.MockPastMeetingParticipantRepository{}
+				config := ServiceConfig{SkipEtagValidation: false}
+				return NewPastMeetingParticipantService(
+					mockMeetingRepo,
+					mockPastMeetingRepo,
+					mockParticipantRepo,
+					nil, // message builder is nil
+					config,
+				)
 			},
 			expectedReady: false,
 		},
@@ -189,7 +213,8 @@ func TestPastMeetingParticipantService_GetPastMeetingParticipants(t *testing.T) 
 
 			// Set service as not ready for specific test
 			if tt.name == "service not ready" {
-				service.PastMeetingRepository = nil
+				// Create a service with nil repository for this test
+				service = NewPastMeetingParticipantService(nil, nil, mockParticipantRepo, nil, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -367,7 +392,8 @@ func TestPastMeetingParticipantService_CreatePastMeetingParticipant(t *testing.T
 
 			// Set service as not ready for specific test
 			if tt.name == "service not ready" {
-				service.PastMeetingParticipantRepository = nil
+				// Create a service with nil participant repository for this test
+				service = NewPastMeetingParticipantService(nil, mockPastMeetingRepo, nil, mockBuilder, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -483,11 +509,12 @@ func TestPastMeetingParticipantService_GetPastMeetingParticipant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			service, _, mockPastMeetingRepo, mockParticipantRepo, _ := setupPastMeetingParticipantServiceForTesting()
+			service, _, mockPastMeetingRepo, mockParticipantRepo, mockBuilder := setupPastMeetingParticipantServiceForTesting()
 
 			// Set service as not ready for specific test
 			if tt.name == "service not ready" {
-				service.PastMeetingParticipantRepository = nil
+				// Create a service with nil participant repository for this test
+				service = NewPastMeetingParticipantService(nil, mockPastMeetingRepo, nil, mockBuilder, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -624,7 +651,8 @@ func TestPastMeetingParticipantService_UpdatePastMeetingParticipant(t *testing.T
 
 			// Set service as not ready for specific test
 			if tt.name == "service not ready" {
-				service.PastMeetingParticipantRepository = nil
+				// Create a service with nil participant repository for this test
+				service = NewPastMeetingParticipantService(nil, mockPastMeetingRepo, nil, mockBuilder, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -783,7 +811,8 @@ func TestPastMeetingParticipantService_DeletePastMeetingParticipant(t *testing.T
 
 			// Set service as not ready for specific test
 			if tt.name == "service not ready" {
-				service.PastMeetingParticipantRepository = nil
+				// Create a service with nil participant repository for this test
+				service = NewPastMeetingParticipantService(nil, mockPastMeetingRepo, nil, mockBuilder, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {

--- a/internal/service/past_meeting_service.go
+++ b/internal/service/past_meeting_service.go
@@ -230,6 +230,11 @@ func (s *PastMeetingService) UpdatePastMeeting(ctx context.Context, pastMeeting 
 		return domain.NewUnavailableError("service not initialized")
 	}
 
+	if pastMeeting == nil || pastMeeting.UID == "" {
+		slog.WarnContext(ctx, "past meeting UID is required")
+		return domain.NewValidationError("past meeting UID is required for update")
+	}
+
 	var err error
 	if s.config.SkipEtagValidation {
 		// If skipping the Etag validation, we need to get the key revision from the store with a Get request.

--- a/internal/service/past_meeting_service.go
+++ b/internal/service/past_meeting_service.go
@@ -18,10 +18,10 @@ import (
 
 // PastMeetingService implements the meetingsvc.Service interface and domain.MessageHandler
 type PastMeetingService struct {
-	MeetingRepository     domain.MeetingRepository
-	PastMeetingRepository domain.PastMeetingRepository
-	MessageBuilder        domain.MessageBuilder
-	Config                ServiceConfig
+	meetingRepository     domain.MeetingRepository
+	pastMeetingRepository domain.PastMeetingRepository
+	messageBuilder        domain.MessageBuilder
+	config                ServiceConfig
 }
 
 // NewPastMeetingService creates a new PastMeetingService.
@@ -32,18 +32,18 @@ func NewPastMeetingService(
 	config ServiceConfig,
 ) *PastMeetingService {
 	return &PastMeetingService{
-		Config:                config,
-		MeetingRepository:     meetingRepository,
-		PastMeetingRepository: pastMeetingRepository,
-		MessageBuilder:        messageBuilder,
+		config:                config,
+		meetingRepository:     meetingRepository,
+		pastMeetingRepository: pastMeetingRepository,
+		messageBuilder:        messageBuilder,
 	}
 }
 
 // ServiceReady checks if the service is ready for use.
 func (s *PastMeetingService) ServiceReady() bool {
-	return s.MeetingRepository != nil &&
-		s.PastMeetingRepository != nil &&
-		s.MessageBuilder != nil
+	return s.meetingRepository != nil &&
+		s.pastMeetingRepository != nil &&
+		s.messageBuilder != nil
 }
 
 func (s *PastMeetingService) ListPastMeetings(ctx context.Context) ([]*models.PastMeeting, error) {
@@ -52,7 +52,7 @@ func (s *PastMeetingService) ListPastMeetings(ctx context.Context) ([]*models.Pa
 		return nil, domain.NewUnavailableError("service not initialized")
 	}
 
-	pastMeetings, err := s.PastMeetingRepository.ListAll(ctx)
+	pastMeetings, err := s.pastMeetingRepository.ListAll(ctx)
 	if err != nil {
 		slog.ErrorContext(ctx, "error listing past meetings", logging.ErrKey, err)
 		return nil, err
@@ -116,7 +116,7 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, pastMeetingR
 	}
 
 	// Check if the original meeting exists (optional validation)
-	exists, err := s.MeetingRepository.Exists(ctx, pastMeetingReq.MeetingUID)
+	exists, err := s.meetingRepository.Exists(ctx, pastMeetingReq.MeetingUID)
 	if err != nil {
 		slog.ErrorContext(ctx, "error checking if meeting exists", logging.ErrKey, err)
 		return nil, err
@@ -130,7 +130,7 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, pastMeetingR
 	pastMeetingReq.UID = uuid.New().String()
 
 	// Save to repository
-	if err := s.PastMeetingRepository.Create(ctx, pastMeetingReq); err != nil {
+	if err := s.pastMeetingRepository.Create(ctx, pastMeetingReq); err != nil {
 		slog.ErrorContext(ctx, "error creating past meeting", logging.ErrKey, err)
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, pastMeetingR
 	pool := concurrent.NewWorkerPool(2) // 2 messages to send
 	messages := []func() error{
 		func() error {
-			return s.MessageBuilder.SendIndexPastMeeting(ctx, models.ActionCreated, *pastMeetingReq)
+			return s.messageBuilder.SendIndexPastMeeting(ctx, models.ActionCreated, *pastMeetingReq)
 		},
 		func() error {
 			// For the message we only need the committee UIDs.
@@ -148,7 +148,7 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, pastMeetingR
 				committees[i] = committee.UID
 			}
 
-			return s.MessageBuilder.SendUpdateAccessPastMeeting(ctx, models.PastMeetingAccessMessage{
+			return s.messageBuilder.SendUpdateAccessPastMeeting(ctx, models.PastMeetingAccessMessage{
 				UID:        pastMeetingReq.UID,
 				MeetingUID: pastMeetingReq.MeetingUID,
 				Public:     pastMeetingReq.IsPublic(),
@@ -172,13 +172,109 @@ func (s *PastMeetingService) GetPastMeeting(ctx context.Context, uid string) (*m
 		return nil, "", domain.NewUnavailableError("service not initialized")
 	}
 
-	pastMeeting, revision, err := s.PastMeetingRepository.GetWithRevision(ctx, uid)
+	pastMeeting, revision, err := s.pastMeetingRepository.GetWithRevision(ctx, uid)
 	if err != nil {
 		slog.ErrorContext(ctx, "error getting past meeting", logging.ErrKey, err)
 		return nil, "", err
 	}
 
 	return pastMeeting, strconv.FormatUint(revision, 10), nil
+}
+
+func (s *PastMeetingService) GetByPlatformMeetingID(ctx context.Context, platform, platformMeetingID string) (*models.PastMeeting, error) {
+	if !s.ServiceReady() {
+		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
+		return nil, domain.NewUnavailableError("service not initialized")
+	}
+
+	pastMeeting, err := s.pastMeetingRepository.GetByPlatformMeetingID(ctx, platform, platformMeetingID)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.DebugContext(ctx, "returning past meeting by platform meeting ID",
+		"past_meeting_uid", pastMeeting.UID,
+		"platform", platform,
+		"platform_meeting_id", platformMeetingID)
+
+	return pastMeeting, nil
+}
+
+// GetByPlatformMeetingIDAndOccurrence gets a past meeting by platform meeting ID and occurrence
+func (s *PastMeetingService) GetByPlatformMeetingIDAndOccurrence(ctx context.Context, platform, platformMeetingID, occurrenceID string) (*models.PastMeeting, error) {
+	if !s.ServiceReady() {
+		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
+		return nil, domain.NewUnavailableError("service not initialized")
+	}
+
+	ctx = logging.AppendCtx(ctx,
+		slog.String("platform", platform))
+	ctx = logging.AppendCtx(ctx,
+		slog.String("platform_meeting_id", platformMeetingID))
+	ctx = logging.AppendCtx(ctx,
+		slog.String("occurrence_id", occurrenceID))
+
+	pastMeeting, err := s.pastMeetingRepository.GetByPlatformMeetingIDAndOccurrence(ctx, platform, platformMeetingID, occurrenceID)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.DebugContext(ctx, "returning past meeting by platform meeting ID and occurrence", "past_meeting_uid", pastMeeting.UID)
+
+	return pastMeeting, nil
+}
+
+func (s *PastMeetingService) UpdatePastMeeting(ctx context.Context, pastMeeting *models.PastMeeting, revision uint64) error {
+	if !s.ServiceReady() {
+		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
+		return domain.NewUnavailableError("service not initialized")
+	}
+
+	var err error
+	if s.config.SkipEtagValidation {
+		// If skipping the Etag validation, we need to get the key revision from the store with a Get request.
+		_, revision, err = s.pastMeetingRepository.GetWithRevision(ctx, pastMeeting.UID)
+		if err != nil {
+			slog.ErrorContext(ctx, "error getting past meeting from store", logging.ErrKey, err)
+			return err
+		}
+	}
+
+	// Update the past meeting
+	if err := s.pastMeetingRepository.Update(ctx, pastMeeting, revision); err != nil {
+		slog.ErrorContext(ctx, "error updating past meeting", logging.ErrKey, err)
+		return err
+	}
+
+	// Use WorkerPool for concurrent NATS message sending
+	pool := concurrent.NewWorkerPool(2) // 2 messages to send
+	messages := []func() error{
+		func() error {
+			return s.messageBuilder.SendIndexPastMeeting(ctx, models.ActionUpdated, *pastMeeting)
+		},
+		func() error {
+			// For the message we only need the committee UIDs.
+			committees := make([]string, len(pastMeeting.Committees))
+			for i, committee := range pastMeeting.Committees {
+				committees[i] = committee.UID
+			}
+
+			return s.messageBuilder.SendUpdateAccessPastMeeting(ctx, models.PastMeetingAccessMessage{
+				UID:        pastMeeting.UID,
+				MeetingUID: pastMeeting.MeetingUID,
+				Public:     pastMeeting.IsPublic(),
+				ProjectUID: pastMeeting.ProjectUID,
+				Committees: committees,
+			})
+		},
+	}
+
+	if err := pool.Run(ctx, messages...); err != nil {
+		slog.ErrorContext(ctx, "failed to send NATS messages", logging.ErrKey, err)
+		// Don't fail the operation if messaging fails
+	}
+
+	return nil
 }
 
 func (s *PastMeetingService) DeletePastMeeting(ctx context.Context, uid string, revision uint64) error {
@@ -188,9 +284,9 @@ func (s *PastMeetingService) DeletePastMeeting(ctx context.Context, uid string, 
 	}
 
 	var err error
-	if s.Config.SkipEtagValidation {
+	if s.config.SkipEtagValidation {
 		// If skipping the Etag validation, we need to get the key revision from the store with a Get request.
-		_, revision, err = s.PastMeetingRepository.GetWithRevision(ctx, uid)
+		_, revision, err = s.pastMeetingRepository.GetWithRevision(ctx, uid)
 		if err != nil {
 			slog.ErrorContext(ctx, "error getting meeting from store", logging.ErrKey, err)
 			return err
@@ -198,7 +294,7 @@ func (s *PastMeetingService) DeletePastMeeting(ctx context.Context, uid string, 
 	}
 
 	// Check if the past meeting exists
-	exists, err := s.PastMeetingRepository.Exists(ctx, uid)
+	exists, err := s.pastMeetingRepository.Exists(ctx, uid)
 	if err != nil {
 		slog.ErrorContext(ctx, "error checking if past meeting exists", logging.ErrKey, err)
 		return err
@@ -209,7 +305,7 @@ func (s *PastMeetingService) DeletePastMeeting(ctx context.Context, uid string, 
 	}
 
 	// Delete the past meeting
-	if err := s.PastMeetingRepository.Delete(ctx, uid, revision); err != nil {
+	if err := s.pastMeetingRepository.Delete(ctx, uid, revision); err != nil {
 		slog.ErrorContext(ctx, "error deleting past meeting", logging.ErrKey, err)
 		return err
 	}
@@ -218,10 +314,10 @@ func (s *PastMeetingService) DeletePastMeeting(ctx context.Context, uid string, 
 	pool := concurrent.NewWorkerPool(2) // 2 messages to send
 	messages := []func() error{
 		func() error {
-			return s.MessageBuilder.SendDeleteIndexPastMeeting(ctx, uid)
+			return s.messageBuilder.SendDeleteIndexPastMeeting(ctx, uid)
 		},
 		func() error {
-			return s.MessageBuilder.SendDeleteAllAccessPastMeeting(ctx, uid)
+			return s.messageBuilder.SendDeleteAllAccessPastMeeting(ctx, uid)
 		},
 	}
 

--- a/internal/service/past_meeting_service.go
+++ b/internal/service/past_meeting_service.go
@@ -46,6 +46,21 @@ func (s *PastMeetingService) ServiceReady() bool {
 		s.MessageBuilder != nil
 }
 
+func (s *PastMeetingService) ListPastMeetings(ctx context.Context) ([]*models.PastMeeting, error) {
+	if !s.ServiceReady() {
+		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
+		return nil, domain.NewUnavailableError("service not initialized")
+	}
+
+	pastMeetings, err := s.PastMeetingRepository.ListAll(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "error listing past meetings", logging.ErrKey, err)
+		return nil, err
+	}
+
+	return pastMeetings, nil
+}
+
 func (s *PastMeetingService) validateCreatePastMeetingPayload(ctx context.Context, pastMeeting *models.PastMeeting) error {
 	// Validate that required fields are present
 	if pastMeeting == nil {
@@ -149,21 +164,6 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, pastMeetingR
 	}
 
 	return pastMeetingReq, nil
-}
-
-func (s *PastMeetingService) GetPastMeetings(ctx context.Context) ([]*models.PastMeeting, error) {
-	if !s.ServiceReady() {
-		slog.ErrorContext(ctx, "service not initialized", logging.PriorityCritical())
-		return nil, domain.NewUnavailableError("service not initialized")
-	}
-
-	pastMeetings, err := s.PastMeetingRepository.ListAll(ctx)
-	if err != nil {
-		slog.ErrorContext(ctx, "error listing past meetings", logging.ErrKey, err)
-		return nil, err
-	}
-
-	return pastMeetings, nil
 }
 
 func (s *PastMeetingService) GetPastMeeting(ctx context.Context, uid string) (*models.PastMeeting, string, error) {

--- a/internal/service/past_meeting_service_test.go
+++ b/internal/service/past_meeting_service_test.go
@@ -36,12 +36,12 @@ func setupPastMeetingServiceForTesting() (*PastMeetingService, *mocks.MockMeetin
 		SkipEtagValidation: false,
 	}
 
-	service := &PastMeetingService{
-		MeetingRepository:     mockMeetingRepo,
-		PastMeetingRepository: mockPastMeetingRepo,
-		MessageBuilder:        mockBuilder,
-		Config:                config,
-	}
+	service := NewPastMeetingService(
+		mockMeetingRepo,
+		mockPastMeetingRepo,
+		mockBuilder,
+		config,
+	)
 
 	return service, mockMeetingRepo, mockPastMeetingRepo, mockBuilder
 }
@@ -63,27 +63,42 @@ func TestPastMeetingService_ServiceReady(t *testing.T) {
 		{
 			name: "service not ready - missing past meeting repository",
 			setup: func() *PastMeetingService {
-				service, _, _, _ := setupPastMeetingServiceForTesting()
-				service.PastMeetingRepository = nil
-				return service
+				_, mockMeetingRepo, _, mockBuilder := setupPastMeetingServiceForTesting()
+				config := ServiceConfig{SkipEtagValidation: false}
+				return NewPastMeetingService(
+					mockMeetingRepo,
+					nil, // past meeting repository is nil
+					mockBuilder,
+					config,
+				)
 			},
 			expected: false,
 		},
 		{
 			name: "service not ready - missing meeting repository",
 			setup: func() *PastMeetingService {
-				service, _, _, _ := setupPastMeetingServiceForTesting()
-				service.MeetingRepository = nil
-				return service
+				_, _, mockPastMeetingRepo, mockBuilder := setupPastMeetingServiceForTesting()
+				config := ServiceConfig{SkipEtagValidation: false}
+				return NewPastMeetingService(
+					nil, // meeting repository is nil
+					mockPastMeetingRepo,
+					mockBuilder,
+					config,
+				)
 			},
 			expected: false,
 		},
 		{
 			name: "service not ready - missing message builder",
 			setup: func() *PastMeetingService {
-				service, _, _, _ := setupPastMeetingServiceForTesting()
-				service.MessageBuilder = nil
-				return service
+				_, mockMeetingRepo, mockPastMeetingRepo, _ := setupPastMeetingServiceForTesting()
+				config := ServiceConfig{SkipEtagValidation: false}
+				return NewPastMeetingService(
+					mockMeetingRepo,
+					mockPastMeetingRepo,
+					nil, // message builder is nil
+					config,
+				)
 			},
 			expected: false,
 		},
@@ -413,7 +428,8 @@ func TestPastMeetingService_CreatePastMeeting(t *testing.T) {
 
 			// Remove repositories to test service not ready case
 			if tt.name == "service not ready" {
-				service.PastMeetingRepository = nil
+				// Create a service with nil repository for this test
+				service = NewPastMeetingService(nil, nil, mockBuilder, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -506,7 +522,8 @@ func TestPastMeetingService_GetPastMeetings(t *testing.T) {
 
 			// Test service not ready case
 			if tt.name == "service not ready" {
-				service.PastMeetingRepository = nil
+				// Create a service with nil repository for this test
+				service = NewPastMeetingService(nil, nil, nil, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -602,7 +619,8 @@ func TestPastMeetingService_GetPastMeeting(t *testing.T) {
 
 			// Test service not ready case
 			if tt.name == "service not ready" {
-				service.PastMeetingRepository = nil
+				// Create a service with nil repository for this test
+				service = NewPastMeetingService(nil, nil, nil, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {
@@ -745,12 +763,21 @@ func TestPastMeetingService_DeletePastMeeting(t *testing.T) {
 			service, _, mockPastMeetingRepo, mockBuilder := setupPastMeetingServiceForTesting()
 
 			if tt.skipEtag {
-				service.Config.SkipEtagValidation = true
+				// Create a service with SkipEtagValidation enabled
+				config := ServiceConfig{SkipEtagValidation: true}
+				_, mockMeetingRepo, _, _ := setupPastMeetingServiceForTesting()
+				service = NewPastMeetingService(
+					mockMeetingRepo,
+					mockPastMeetingRepo,
+					mockBuilder,
+					config,
+				)
 			}
 
 			// Test service not ready case
 			if tt.name == "service not ready" {
-				service.PastMeetingRepository = nil
+				// Create a service with nil repository for this test
+				service = NewPastMeetingService(nil, nil, nil, ServiceConfig{})
 			}
 
 			if tt.setupMocks != nil {

--- a/internal/service/past_meeting_service_test.go
+++ b/internal/service/past_meeting_service_test.go
@@ -513,7 +513,7 @@ func TestPastMeetingService_GetPastMeetings(t *testing.T) {
 				tt.setupMocks(mockPastMeetingRepo)
 			}
 
-			result, err := service.GetPastMeetings(ctx)
+			result, err := service.ListPastMeetings(ctx)
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary
- Make all service struct fields unexported (private) to prevent external access and improve encapsulation
- Add service layer methods to eliminate direct infrastructure access from handlers (clean architecture)
- Update service method naming from "Get" to "List" pattern for collection operations  
- Refactor zoom webhook handlers to use proper service methods instead of direct repository access
- Update all test files to use service constructors instead of direct field access

## Changes Made

### Service Field Encapsulation
- ✅ **AuthService**: Made `auth` field private + added `ParsePrincipal` service method
- ✅ **MeetingService**: Made all fields private (`meetingRepository`, `messageBuilder`, etc.)
- ✅ **MeetingRegistrantService**: Made all fields private (`meetingRepository`, `registrantRepository`, etc.)  
- ✅ **PastMeetingService**: Made all fields private (`meetingRepository`, `pastMeetingRepository`, etc.)
- ✅ **PastMeetingParticipantService**: Made all fields private (`pastMeetingParticipantRepository`, etc.)
- ✅ **PastMeetingRecordingService**: Made all fields private (`pastMeetingRecordingRepository`, etc.)
- ✅ **PastMeetingSummaryService**: Made all fields private (`pastMeetingSummaryRepository`, etc.)
- ✅ **ZoomWebhookService**: Made all fields private (`messageBuilder`, `webhookValidator`)

### Clean Architecture Improvements
- ✅ **Added AuthService.ParsePrincipal()** method to eliminate direct infrastructure access from API layer
- ✅ **Updated api.go** to use service method: `s.authService.ParsePrincipal()` instead of `s.authService.Auth.ParsePrincipal()`
- ✅ **Refactored zoom webhook handlers** to use service methods instead of direct repository calls
- ✅ **Added service methods** like `GetMeetingByPlatformMeetingID`, `GetByPlatformMeetingIDAndOccurrence`, `UpdatePastMeeting`

### Method Naming Consistency
- ✅ **Renamed collection methods** from "Get" to "List" pattern:
  - `GetMeetingRegistrants` → `ListMeetingRegistrants`
  - `GetRegistrantsByEmail` → `ListRegistrantsByEmail`
  - `GetMeetings` → `ListMeetings` 
  - `GetMeetingsByCommittee` → `ListMeetingsByCommittee`
  - `GetPastMeetings` → `ListPastMeetings`

### Test Updates
- ✅ **Updated all test files** to use service constructors instead of direct struct field access
- ✅ **Fixed test fixtures** to work with private fields
- ✅ **Maintained test coverage** while improving encapsulation

## Benefits
- **Better Encapsulation**: Infrastructure dependencies now properly hidden from external consumers
- **Clean Architecture**: Service layer properly abstracts infrastructure concerns following layered architecture principles
- **Maintainability**: Changes to internal implementations won't affect external consumers
- **Go Best Practices**: Follows idiomatic Go patterns for struct field visibility
- **Consistency**: All services now follow the same encapsulation and naming patterns

## Testing
- ✅ All existing tests pass with updated constructor usage
- ✅ No breaking changes to public APIs
- ✅ Clean architecture principles maintained
- ✅ Zero linting issues

## Related Issues
- Relates to LFXV2-530: Meeting Service: Refactor the service layer to not expose Repository and MessageBuilder structs
- Relates to LFXV2-581: Meeting Service: Refactor handlers to use service methods for CRUD operations instead of writing/reading from the database layer directly

🤖 Generated with [Claude Code](https://claude.ai/code)