### PR TITLE
[LFXV2-595] fix ruleset.yaml with openfga disabled

### DIFF
--- a/charts/lfx-v2-meeting-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-meeting-service/templates/ruleset.yaml
@@ -67,8 +67,10 @@ spec:
               relation: writer
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -95,8 +97,10 @@ spec:
               relation: viewer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -123,8 +127,10 @@ spec:
               relation: viewer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -153,8 +159,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -181,8 +189,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -209,8 +219,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -237,8 +249,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -265,8 +279,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -296,8 +312,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -324,8 +342,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -352,8 +372,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -380,8 +402,10 @@ spec:
               relation: organizer
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -410,8 +434,10 @@ spec:
               relation: writer
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -434,8 +460,10 @@ spec:
         {{- if .Values.app.use_oidc_contextualizer }}
         - contextualizer: oidc_contextualizer
         {{- end }}
-        # This rule is on an endpoint that is just used for local development,
-        # it will get removed once we remove the list meetings endpoint.
+        {{/*
+          This rule is on an endpoint that is just used for local development,
+          it will get removed once we remove the list meetings endpoint.
+        */}}
         - authorizer: allow_all
         - finalizer: create_jwt
           config:
@@ -461,8 +489,10 @@ spec:
               relation: viewer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -489,8 +519,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -517,8 +549,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -548,8 +582,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -576,8 +612,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -604,8 +642,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -632,8 +672,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -663,8 +705,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -691,8 +735,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt
@@ -719,8 +765,10 @@ spec:
               relation: organizer
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
-        # When OpenFGA is disabled, allow all requests
-        # (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        {{/*
+          When OpenFGA is disabled, allow all requests
+          (Only meant for *local development* because OpenFGA should be enabled when deployed)
+        */}}
         - authorizer: allow_all
         {{- end }}
         - finalizer: create_jwt


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-595

This pull request updates the `charts/lfx-v2-meeting-service/templates/ruleset.yaml` file to improve the clarity and maintainability of comments related to authorization rules for local development. Specifically, comments indicating that all requests are allowed when OpenFGA is disabled have been converted from inline comments to Helm-compatible block comments, making it clear these sections are meant for local development only.

Comment formatting improvements:

* Converted inline comments explaining that all requests are allowed when OpenFGA is disabled to Helm block comments (`{{/* ... */}}`) throughout the ruleset, ensuring these comments are not rendered in the final YAML output and are clearly marked as developer notes. [[1]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L70-R73) [[2]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L98-R103) [[3]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L126-R133) [[4]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L156-R165) [[5]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L184-R195) [[6]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L212-R225) [[7]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L240-R255) [[8]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L268-R285) [[9]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L299-R318) [[10]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L327-R348) [[11]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L355-R378) [[12]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L383-R408) [[13]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L413-R440) [[14]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L464-R495) [[15]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L492-R525) [[16]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L520-R555) [[17]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L551-R588) [[18]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L579-R618) [[19]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L607-R648) [[20]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L635-R678) [[21]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L666-R711) [[22]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L694-R741) [[23]](diffhunk://#diff-b0287cf454d948042c9c3e691a5b3975ebd36d56fbd4f2e8dc7a83b7bac618e6L722-R771)

Local development endpoint clarification:

* Updated the comment for the rule related to the list meetings endpoint to a Helm block comment, clarifying its purpose for local development and indicating it will be removed once the endpoint is deprecated.

These changes help ensure that developer-only comments are kept out of production manifests and make the ruleset easier to maintain and understand.