### PR TITLE
Hide repeats section for non-recurring meetings in email templates

### DIFF
--- a/internal/infrastructure/email/templates/meeting_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_invitation.html
@@ -218,10 +218,12 @@
             <div class="details-title">Next Meeting</div>
             {{formatTime .StartTime .Timezone}}
         </div>
+        {{if .Recurrence}}
         <div class="details">
             <div class="details-title">Repeats</div>
             {{formatRecurrence .Recurrence .StartTime .Timezone}}
         </div>
+        {{end}}
         <div class="details">
             <div class="details-title">Duration</div>
             {{formatDuration .Duration}}

--- a/internal/infrastructure/email/templates/meeting_updated_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_updated_invitation.html
@@ -270,6 +270,7 @@
         </div>
         {{end}}
 
+        {{if or .Recurrence .OldRecurrence}}
         {{if ne (formatRecurrence .Recurrence .StartTime .Timezone) (formatRecurrence .OldRecurrence .OldStartTime
         .OldTimezone)}}
         <div class="details changed-component">
@@ -288,6 +289,7 @@
             <div class="details-title">Repeats</div>
             {{formatRecurrence .Recurrence .StartTime .Timezone}}
         </div>
+        {{end}}
         {{end}}
 
         {{if ne .Duration .OldDuration}}


### PR DESCRIPTION
## Summary
- Only show repeats section when meetings have recurrence patterns
- Hide unnecessary recurrence information for non-recurring meetings
- Improve email content relevance and readability

## Changes
- Update invitation template to conditionally show repeats info based on `.Recurrence`
- Update meeting update template to show repeats only when current or old meeting had recurrence
- Check both `.Recurrence` and `.OldRecurrence` for updated meetings to handle recurrence changes

## Test plan
- [ ] Test invitation emails for non-recurring meetings (should not show repeats section)
- [ ] Test invitation emails for recurring meetings (should show repeats section)
- [ ] Test updated meeting emails when recurrence is added/removed/changed
- [ ] Verify email templates render correctly without repeats section

🤖 Generated with [Claude Code](https://claude.com/claude-code)