### PR TITLE
[LFXV2-601, LFXV2-602] Fix email template formatting and ICS sequence for calendar updates

### DIFF
--- a/internal/domain/email.go
+++ b/internal/domain/email.go
@@ -79,6 +79,7 @@ type EmailUpdatedInvitation struct {
 	Passcode           string             // Zoom passcode
 	Recurrence         *models.Recurrence // Recurrence pattern for ICS
 	Changes            map[string]any     // Map of what changed (field names to new values)
+	IcsSequence        int                // ICS sequence number for calendar updates
 	ICSAttachment      *EmailAttachment   // Updated ICS calendar attachment
 
 	// Previous meeting data for showing what changed

--- a/internal/domain/models/meeting.go
+++ b/internal/domain/models/meeting.go
@@ -55,6 +55,7 @@ type MeetingBase struct {
 	RegistrantResponseDeclinedCount int          `json:"registrant_response_declined_count,omitempty"`
 	RegistrantResponseAcceptedCount int          `json:"registrant_response_accepted_count,omitempty"`
 	Occurrences                     []Occurrence `json:"occurrences,omitempty"`
+	IcsSequence                     int          `json:"ics_sequence,omitempty"`
 	CreatedAt                       *time.Time   `json:"created_at,omitempty"`
 	UpdatedAt                       *time.Time   `json:"updated_at,omitempty"`
 }

--- a/internal/infrastructure/email/ics.go
+++ b/internal/infrastructure/email/ics.go
@@ -420,8 +420,8 @@ func buildDescription(description, meetingID, passcode, joinLink, projectName st
 	var desc strings.Builder
 
 	if projectName != "" {
-		desc.WriteString("Project: ")
 		desc.WriteString(projectName)
+		desc.WriteString(" Meeting")
 		desc.WriteString("\n\n")
 	}
 

--- a/internal/infrastructure/email/ics_test.go
+++ b/internal/infrastructure/email/ics_test.go
@@ -336,7 +336,7 @@ func TestBuildDescription(t *testing.T) {
 			"Test Project",
 		)
 
-		assert.Contains(t, desc, "Project: Test Project")
+		assert.Contains(t, desc, "Test Project Meeting")
 		assert.Contains(t, desc, "Original description")
 		assert.Contains(t, desc, "Meeting ID: 123456789")
 		assert.Contains(t, desc, "Passcode: abc123")

--- a/internal/infrastructure/email/smtp_service.go
+++ b/internal/infrastructure/email/smtp_service.go
@@ -251,7 +251,7 @@ func (s *SMTPService) SendRegistrantUpdatedInvitation(ctx context.Context, updat
 			RecipientEmail: updatedInvitation.RecipientEmail,
 			ProjectName:    updatedInvitation.ProjectName,
 			Recurrence:     updatedInvitation.Recurrence,
-			Sequence:       1, // Incremented sequence for updates
+			Sequence:       updatedInvitation.IcsSequence, // Use actual ICS sequence from meeting
 		})
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to generate ICS update", logging.ErrKey, err)

--- a/internal/infrastructure/email/templates.go
+++ b/internal/infrastructure/email/templates.go
@@ -45,10 +45,11 @@ type templateConfig struct {
 // loadTemplate loads a single template with the shared function map
 func loadTemplate(config templateConfig) (*template.Template, error) {
 	tmpl, err := template.New(config.name).Funcs(template.FuncMap{
-		"formatTime":       formatTime,
-		"formatDuration":   formatDuration,
-		"formatRecurrence": formatRecurrence,
-		"capitalize":       capitalize,
+		"formatTime":         formatTime,
+		"formatDuration":     formatDuration,
+		"formatRecurrence":   formatRecurrence,
+		"capitalize":         capitalize,
+		"newLineToBreakLine": newLineToBreakLine,
 	}).ParseFS(templateFS, config.path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %s template: %w", config.name, err)
@@ -265,4 +266,13 @@ func capitalize(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + strings.ToLower(s[1:])
+}
+
+// newLineToBreakLine converts newlines to HTML break tags for proper email formatting
+func newLineToBreakLine(s string) template.HTML {
+	// Replace newlines with <br> tags
+	escaped := template.HTMLEscapeString(s)
+	replaced := strings.ReplaceAll(escaped, "\n", "<br>")
+	// Return as template.HTML to prevent double escaping
+	return template.HTML(replaced)
 }

--- a/internal/infrastructure/email/templates/meeting_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_invitation.html
@@ -230,7 +230,7 @@
         </div>
         <div class="details">
             <div class="details-title">Meeting Details</div>
-            {{.Description}}
+            {{newLineToBreakLine .Description}}
             {{if .MeetingDetailsLink}}
             <a href="{{.MeetingDetailsLink}}" class="text-button display-block-margin-top-16">See full details in LFX
                 One</a>

--- a/internal/infrastructure/email/templates/meeting_updated_invitation.html
+++ b/internal/infrastructure/email/templates/meeting_updated_invitation.html
@@ -317,8 +317,8 @@
                 <span class="badge badge-changed">Changed</span>
             </div>
             <div>
-                <div class="changed-details-old">{{.OldDescription}}</div>
-                <div class="changed-details-new"><strong>New: </strong>{{.Description}}</div>
+                <div class="changed-details-old">{{newLineToBreakLine .OldDescription}}</div>
+                <div class="changed-details-new"><strong>New: </strong>{{newLineToBreakLine .Description}}</div>
             </div>
             {{if .MeetingDetailsLink}}
             <a href="{{.MeetingDetailsLink}}" class="text-button display-block-margin-top-16">See full details in LFX
@@ -328,7 +328,7 @@
         {{else}}
         <div class="details">
             <div class="details-title">Meeting Details</div>
-            {{.Description}}
+            {{newLineToBreakLine .Description}}
             {{if .MeetingDetailsLink}}
             <a href="{{.MeetingDetailsLink}}" class="text-button display-block-margin-top-16">See full details in LFX
                 One</a>

--- a/internal/service/meeting_registrant_service.go
+++ b/internal/service/meeting_registrant_service.go
@@ -640,6 +640,7 @@ func (s *MeetingRegistrantService) SendRegistrantUpdatedInvitation(ctx context.C
 		Changes:            changes,
 		ProjectName:        projectName,
 		ProjectLogo:        projectLogo,
+		IcsSequence:        meeting.IcsSequence,
 		// Previous meeting data
 		OldStartTime:   oldMeeting.StartTime,
 		OldDuration:    oldMeeting.Duration,

--- a/internal/service/meeting_service.go
+++ b/internal/service/meeting_service.go
@@ -561,6 +561,9 @@ func (s *MeetingService) UpdateMeetingBase(ctx context.Context, reqMeeting *mode
 		}
 	}
 
+	// Increment ICS sequence for calendar updates
+	reqMeeting.IcsSequence = existingMeetingDB.IcsSequence + 1
+
 	// Detect changes before updating
 	changes := detectMeetingBaseChanges(existingMeetingDB, reqMeeting)
 


### PR DESCRIPTION
## Summary
- Fix newline formatting in email template descriptions 
- Add proper ICS sequence tracking for Google Calendar updates
- Update ICS description format for improved readability

## Changes Made

### Email Template Formatting (LFXV2-601)
- Add `newLineToBreakLine` function to convert `\n` to HTML `<br>` tags
- Apply function to description fields in invitation and update templates
- Ensure multi-line descriptions display correctly in HTML emails
- Preserve proper formatting for meeting agendas and lists

### ICS Sequence Fix (LFXV2-602)
- Add `IcsSequence` field to `MeetingBase` struct to track calendar updates
- Initialize `IcsSequence` to 0 for new meetings (Go default)
- Increment `IcsSequence` on meeting updates in `UpdateMeetingBase`
- Pass actual `IcsSequence` to email service and ICS generator
- Replace hardcoded `sequence=1` with meeting's `IcsSequence` value
- Update ICS description format from "Project: {name}" to "{name} Meeting"

## Test Plan
- [ ] Test invitation emails with multi-line descriptions display proper line breaks
- [ ] Test ICS files are generated with correct incrementing sequence numbers
- [ ] Test Google Calendar properly recognizes meeting updates
- [ ] Test recurring meetings maintain proper sequence tracking
- [ ] Verify all existing tests pass

## Ticket Links
- **LFXV2-601**: https://linuxfoundation.atlassian.net/browse/LFXV2-601
- **LFXV2-602**: https://linuxfoundation.atlassian.net/browse/LFXV2-602

🤖 Generated with [Claude Code](https://claude.com/claude-code)