### PR TITLE
update ruleset to use auditor for reads

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.4.13
+version: 0.4.14
 appVersion: "latest"

--- a/charts/lfx-v2-meeting-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-meeting-service/templates/ruleset.yaml
@@ -154,9 +154,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              # TODO: should this be auditor relation on the project object? If so,
-              # how do we get the project_uid from the request body?
-              relation: organizer
+              relation: auditor
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*

--- a/charts/lfx-v2-meeting-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-meeting-service/templates/ruleset.yaml
@@ -309,7 +309,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: organizer
+              relation: auditor
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*
@@ -369,7 +369,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: organizer
+              relation: auditor
               object: "meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*
@@ -579,7 +579,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: organizer
+              relation: auditor
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*
@@ -639,7 +639,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: organizer
+              relation: auditor
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*
@@ -702,7 +702,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: organizer
+              relation: auditor
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*
@@ -762,7 +762,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: organizer
+              relation: auditor
               object: "past_meeting:{{ "{{- .Request.URL.Captures.id -}}" }}"
         {{- else -}}
         {{/*


### PR DESCRIPTION
We had several rules which required organizer for read, but they really should have been auditor (which is a more elevated read permission over viewer for sensitive info like registrants).

I also updated the past meeting summary endpoints, but those will be rewritten elsewhere as those artifacts and others (recordings & transcripts) will need to be rewritten.