### PR TITLE
[LFXV2-626] Fix occurrence calculation to include ongoing meetings and 40-minute buffer

### DIFF
--- a/charts/lfx-v2-meeting-service/Chart.yaml
+++ b/charts/lfx-v2-meeting-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-meeting-service
 description: LFX Platform V2 Meeting Service chart
 type: application
-version: 0.4.14
+version: 0.4.15
 appVersion: "latest"


### PR DESCRIPTION
## Summary
- Fix occurrence calculation to properly include meetings that are currently in progress
- Add 40-minute buffer period after meeting end time to keep recently ended meetings visible
- Ensure late joiners can still see and access meetings that have started but not yet ended

## Problem
Previously, the `CalculateOccurrencesFromDate` function only returned occurrences with start times on or after the query date. This meant:
- Ongoing meetings (started before query time but still in progress) were excluded
- Recently ended meetings were immediately removed from the list
- Late joiners couldn't see meetings they could still join

## Solution
- Added `isOccurrenceRelevant` helper function to check if an occurrence should be included
- Include occurrences that are:
  - Starting on or after the query date (future meetings)
  - Currently ongoing (started before query date but end time is after it)
  - Within a 40-minute buffer after their end time (for post-meeting activities)

## Test plan
- [x] Added test case for ongoing meetings
- [x] Added test case for meetings within 40-minute buffer
- [x] Added test case for meetings outside buffer (should be excluded)
- [x] Added test case for recurring meetings with ongoing occurrences
- [x] All existing tests pass

## Ticket
[LFXV2-626](https://linuxfoundation.atlassian.net/browse/LFXV2-626)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-626]: https://linuxfoundation.atlassian.net/browse/LFXV2-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ