### PR TITLE
[LFXV2-1391] fix(helm): use colon-prefix path params in past_meetings ruleset routes

### DIFF
--- a/charts/lfx-v2-meeting-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-meeting-service/templates/ruleset.yaml
@@ -597,7 +597,7 @@ spec:
         methods:
           - GET
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}
+          - path: /itx/past_meetings/:past_meeting_id
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -628,7 +628,7 @@ spec:
         methods:
           - DELETE
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}
+          - path: /itx/past_meetings/:past_meeting_id
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -659,7 +659,7 @@ spec:
         methods:
           - PUT
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}
+          - path: /itx/past_meetings/:past_meeting_id
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -686,7 +686,7 @@ spec:
         methods:
           - GET
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}/summaries/{summary_uid}
+          - path: /itx/past_meetings/:past_meeting_id/summaries/:summary_uid
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -717,7 +717,7 @@ spec:
         methods:
           - PUT
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}/summaries/{summary_uid}
+          - path: /itx/past_meetings/:past_meeting_id/summaries/:summary_uid
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -748,7 +748,7 @@ spec:
         methods:
           - POST
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}/participants
+          - path: /itx/past_meetings/:past_meeting_id/participants
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -779,7 +779,7 @@ spec:
         methods:
           - PUT
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}/participants/{participant_id}
+          - path: /itx/past_meetings/:past_meeting_id/participants/:participant_id
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc
@@ -810,7 +810,7 @@ spec:
         methods:
           - DELETE
         routes:
-          - path: /itx/past_meetings/{past_meeting_id}/participants/{participant_id}
+          - path: /itx/past_meetings/:past_meeting_id/participants/:participant_id
       allow_encoded_slashes: "off"
       execute:
         - authenticator: oidc


### PR DESCRIPTION
## Summary

All `past_meetings` routes in the Heimdall RuleSet were using `{param}` (curly-brace) syntax for path parameters. Heimdall uses `:param` (colon-prefix) syntax for path captures — `{param}` is not recognized, so every request to these endpoints fell through to the default rule instead of applying the correct OpenFGA authorization check.

Fixed routes:
- `GET /itx/past_meetings/:past_meeting_id`
- `DELETE /itx/past_meetings/:past_meeting_id`
- `PUT /itx/past_meetings/:past_meeting_id`
- `GET /itx/past_meetings/:past_meeting_id/summaries/:summary_uid`
- `PUT /itx/past_meetings/:past_meeting_id/summaries/:summary_uid`
- `POST /itx/past_meetings/:past_meeting_id/participants`
- `PUT /itx/past_meetings/:past_meeting_id/participants/:participant_id`
- `DELETE /itx/past_meetings/:past_meeting_id/participants/:participant_id`

## Ticket

[LFXV2-1391](https://linuxfoundation.atlassian.net/browse/LFXV2-1391)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1391]: https://linuxfoundation.atlassian.net/browse/LFXV2-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ