### PR TITLE
[LFXV2-1398] docs: add indexer contract documentation for meeting service

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The service includes a comprehensive event processing system for v1→v2 data sy
 
 For complete details, see **[Event Processing Documentation](docs/event-processing.md)**.
 
+For the data schemas, tags, access control values, and parent references for all indexed resource types — see **[Indexer Contract](docs/indexer-contract.md)**.
+
 ## 🛠️ Development
 
 ### Prerequisites

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -82,7 +82,7 @@ These fields are indexed and queryable via `filters` or `cel_filter` in the quer
 | `last_mailing_list_members_sync_job_failed_count` | int | Failed count from last mailing list sync job |
 | `mailing_list_group_ids` | []string | Mailing list group IDs associated with this meeting |
 | `last_mailing_list_members_sync_job_warning_count` | int | Warning count from last mailing list sync job |
-| `use_unique_ics_uid` | bool | Whether to generate/use a unique ICS UID for calendar events |
+| `use_unique_ics_uid` | string | UUID used as the unique ICS UID for calendar events (empty string when not set) |
 | `show_meeting_attendees` | bool | Whether attendee data is visible to other attendees |
 | `organizers` | []string | Auth0 sub-format usernames of meeting organizers |
 
@@ -93,7 +93,7 @@ Each entry in `committees` has:
 | Field | Type | Description |
 |---|---|---|
 | `uid` | string | Committee v2 UUID |
-| `allowed_voting_statuses` | []string (optional) | Voting status filters for the committee |
+| `allowed_voting_statuses` | []string (optional) | Voting status filter strings for the committee; omitted when empty |
 
 #### User Reference Schema
 
@@ -301,8 +301,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `response_type` | string | RSVP response (`"accepted"`, `"declined"`, `"maybe"`) |
 | `scope` | string | Response scope (`"all"`, `"single"`, `"this_and_following"`) |
 | `is_recurring` | bool | Whether the parent meeting is recurring |
-| `created_at` | timestamp | Creation time |
-| `modified_at` | timestamp | Last modification time |
+| `created_at` | string (RFC3339) | Creation time |
+| `modified_at` | string (RFC3339) | Last modification time |
 
 ### Tags
 
@@ -366,12 +366,12 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `committee_filters` | []string (optional) | Committee filter values |
 | `title` | string | Meeting title |
 | `description` | string | Meeting description |
-| `start_time` | timestamp | Occurrence start time |
-| `end_time` | timestamp | Occurrence end time |
+| `start_time` | string (RFC3339) | Occurrence start time |
+| `end_time` | string (RFC3339) | Occurrence end time |
 | `duration` | int | Actual duration in minutes |
 | `timezone` | string | Meeting timezone (IANA) |
 | `meeting_type` | string (optional) | Zoom meeting type |
-| `committees` | []object | Associated committees (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees (see [Committee schema](#committee-schema)); omitted when empty |
 | `visibility` | string (optional) | Meeting visibility |
 | `artifact_visibility` | string (optional) | Visibility of meeting artifacts |
 | `restricted` | bool | Whether the meeting was restricted |
@@ -390,8 +390,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `zoom_config` | object (optional) | Zoom-specific configuration (see [Zoom Config schema](#zoom-config-schema)) |
 | `is_manually_created` | bool (optional) | Whether this past meeting was created manually |
 | `sessions` | []object (optional) | Zoom meeting instances within this past meeting (each has `uuid`, `start_time`, `end_time`) |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last update time |
+| `created_at` | string (RFC3339) | Creation time |
+| `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
 | `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
 | `updated_by_list` | []object (optional) | All users who have updated the record |
@@ -463,8 +463,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `is_invited` | bool | Whether the participant was invited |
 | `is_attended` | bool | Whether the participant attended |
 | `sessions` | []object (optional) | Join/leave sessions (each has `uid`, `join_time`, `leave_time`, `leave_reason`) |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last update time |
+| `created_at` | string (RFC3339) | Creation time |
+| `updated_at` | string (RFC3339) | Last update time |
 
 ### Tags
 
@@ -534,10 +534,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `recording_count` | int | Number of recording files |
 | `recording_files` | []object | Recording files (see [Recording File schema](#recording-file-schema)) |
 | `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
-| `start_time` | timestamp | Recording start time |
+| `start_time` | string (RFC3339) | Recording start time |
 | `total_size` | int64 | Total size of all recording files in bytes |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last update time |
+| `created_at` | string (RFC3339) | Creation time |
+| `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
 | `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
 
@@ -552,8 +552,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_size` | int64 | File size in bytes |
 | `recording_type` | string | Zoom recording type (e.g., `"shared_screen_with_speaker_view"`) |
 | `status` | string | File status |
-| `recording_start` | timestamp | Recording start time |
-| `recording_end` | timestamp | Recording end time |
+| `recording_start` | string (RFC3339) | Recording start time |
+| `recording_end` | string (RFC3339) | Recording end time |
 | `download_url` | string (optional) | Download URL |
 | `play_url` | string (optional) | Playback URL |
 
@@ -562,7 +562,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Field | Type | Description |
 |---|---|---|
 | `uuid` | string | Zoom meeting instance UUID |
-| `start_time` | timestamp | Session start time |
+| `start_time` | string (RFC3339) | Session start time |
 | `total_size` | int64 | Session total size in bytes |
 | `share_url` | string (optional) | Share URL for the session |
 
@@ -629,10 +629,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `visibility` | string | Transcript visibility |
 | `recording_files` | []object | Associated recording files (see [Recording File schema](#recording-file-schema)) |
 | `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
-| `start_time` | timestamp | Transcript start time |
+| `start_time` | string (RFC3339) | Transcript start time |
 | `total_size` | int64 | Total size in bytes |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last update time |
+| `created_at` | string (RFC3339) | Creation time |
+| `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
 | `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
 
@@ -708,8 +708,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform` | string | Meeting platform (always `"Zoom"`) |
 | `zoom_config` | object | Zoom identifiers (has `meeting_id` string and `meeting_uuid` string) |
 | `email_sent` | bool | Whether a summary notification email has been sent |
-| `created_at` | timestamp | Creation time |
-| `updated_at` | timestamp | Last update time |
+| `created_at` | string (RFC3339) | Creation time |
+| `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
 | `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
 
@@ -777,9 +777,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_upload_status` | string (optional) | Upload status |
 | `file_content_type` | string (optional) | MIME content type |
 | `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
-| `file_uploaded_at` | timestamp (optional) | Time the file was uploaded |
-| `created_at` | timestamp | Creation time |
-| `modified_at` | timestamp | Last modification time |
+| `file_uploaded_at` | string (RFC3339) (optional) | Time the file was uploaded |
+| `created_at` | string (RFC3339) | Creation time |
+| `modified_at` | string (RFC3339) | Last modification time |
 | `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
 | `updated_by` | object | User who last updated the attachment (see [User Reference schema](#user-reference-schema)) |
 
@@ -845,9 +845,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_upload_status` | string (optional) | Upload status |
 | `file_content_type` | string (optional) | MIME content type |
 | `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
-| `file_uploaded_at` | timestamp (optional) | Time the file was uploaded |
-| `created_at` | timestamp | Creation time |
-| `modified_at` | timestamp | Last modification time |
+| `file_uploaded_at` | string (RFC3339) (optional) | Time the file was uploaded |
+| `created_at` | string (RFC3339) | Creation time |
+| `modified_at` | string (RFC3339) | Last modification time |
 | `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
 | `updated_by` | object | User who last updated the attachment (see [User Reference schema](#user-reference-schema)) |
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -39,7 +39,7 @@ These fields are indexed and queryable via `filters` or `cel_filter` in the quer
 | `committee` | string | v1 Salesforce ID of the primary committee |
 | `committee_uid` | string (optional) | v2 UUID of the primary committee; omitted when empty |
 | `committee_filters` | []string | List of committee filter values |
-| `committees` | []object | Associated committees (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees (see [Committee schema](#committee-schema)); omitted when empty |
 | `user_id` | string | Zoom user ID of the meeting host |
 | `title` | string | Meeting title (from Zoom `topic`) |
 | `description` | string | Meeting description (from Zoom `agenda`) |
@@ -82,7 +82,7 @@ These fields are indexed and queryable via `filters` or `cel_filter` in the quer
 | `last_mailing_list_members_sync_job_failed_count` | int | Failed count from last mailing list sync job |
 | `mailing_list_group_ids` | []string | Mailing list group IDs associated with this meeting |
 | `last_mailing_list_members_sync_job_warning_count` | int | Warning count from last mailing list sync job |
-| `use_unique_ics_uid` | string | Override UUID for calendar event ID (when calendar issues require a new UID) |
+| `use_unique_ics_uid` | bool | Whether to generate/use a unique ICS UID for calendar events |
 | `show_meeting_attendees` | bool | Whether attendee data is visible to other attendees |
 | `organizers` | []string | Auth0 sub-format usernames of meeting organizers |
 
@@ -93,7 +93,7 @@ Each entry in `committees` has:
 | Field | Type | Description |
 |---|---|---|
 | `uid` | string | Committee v2 UUID |
-| `allowed_voting_statuses` | []object (optional) | Voting status filters for the committee |
+| `allowed_voting_statuses` | []string (optional) | Voting status filters for the committee |
 
 #### User Reference Schema
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -23,6 +23,10 @@ This document is the authoritative reference for all data the meeting service se
 
 ## V1 Meeting
 
+**Object type:** `v1_meeting`
+
+**NATS subject:** `lfx.index.v1_meeting`
+
 **Source struct:** `internal/domain/models/event_models.go` — `MeetingEventData`
 
 **Indexed on:** create, update, delete of a meeting (sourced from the v1 meeting data).
@@ -199,6 +203,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 ## V1 Meeting Registrant
 
+**Object type:** `v1_meeting_registrant`
+
+**NATS subject:** `lfx.index.v1_meeting_registrant`
+
 **Source struct:** `internal/domain/models/event_models.go` — `RegistrantEventData`
 
 **Indexed on:** create, update, delete of a meeting registrant.
@@ -278,6 +286,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 ## V1 Meeting RSVP
 
+**Object type:** `v1_meeting_rsvp`
+
+**NATS subject:** `lfx.index.v1_meeting_rsvp`
+
 **Source struct:** `internal/domain/models/event_models.go` — `InviteResponseEventData`
 
 **Indexed on:** create, update, delete of a meeting RSVP (invite response).
@@ -345,6 +357,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 ---
 
 ## V1 Past Meeting
+
+**Object type:** `v1_past_meeting`
+
+**NATS subject:** `lfx.index.v1_past_meeting`
 
 **Source struct:** `internal/domain/models/event_models.go` — `PastMeetingEventData`
 
@@ -438,6 +454,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 ## V1 Past Meeting Participant
 
+**Object type:** `v1_past_meeting_participant`
+
+**NATS subject:** `lfx.index.v1_past_meeting_participant`
+
 **Source struct:** `internal/domain/models/event_models.go` — `PastMeetingParticipantEventData`
 
 **Indexed on:** create, update, delete of a past meeting participant (invitee or attendee).
@@ -507,6 +527,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 ---
 
 ## V1 Past Meeting Recording
+
+**Object type:** `v1_past_meeting_recording`
+
+**NATS subject:** `lfx.index.v1_past_meeting_recording`
 
 **Source struct:** `internal/domain/models/event_models.go` — `RecordingEventData`
 
@@ -607,6 +631,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 ## V1 Past Meeting Transcript
 
+**Object type:** `v1_past_meeting_transcript`
+
+**NATS subject:** `lfx.index.v1_past_meeting_transcript`
+
 **Source struct:** `internal/domain/models/event_models.go` — `TranscriptEventData`
 
 **Indexed on:** create, update, delete of a past meeting transcript.
@@ -675,6 +703,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 ---
 
 ## V1 Past Meeting Summary
+
+**Object type:** `v1_past_meeting_summary`
+
+**NATS subject:** `lfx.index.v1_past_meeting_summary`
 
 **Source struct:** `internal/domain/models/event_models.go` — `SummaryEventData`
 
@@ -754,6 +786,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 ## V1 Meeting Attachment
 
+**Object type:** `v1_meeting_attachment`
+
+**NATS subject:** `lfx.index.v1_meeting_attachment`
+
 **Source struct:** `internal/domain/models/event_models.go` — `MeetingAttachmentEventData`
 
 **Indexed on:** create, update, delete of an attachment on an active meeting.
@@ -820,6 +856,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 ---
 
 ## V1 Past Meeting Attachment
+
+**Object type:** `v1_past_meeting_attachment`
+
+**NATS subject:** `lfx.index.v1_past_meeting_attachment`
 
 **Source struct:** `internal/domain/models/event_models.go` — `PastMeetingAttachmentEventData`
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -182,7 +182,11 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 ### Search Behavior
 
-_(not configured — `fulltext`, `name_and_aliases`, and `sort_name` are not set in IndexingConfig)_
+| Field | Value |
+|---|---|
+| `sort_name` | `title` (trimmed) |
+| `name_and_aliases` | `[title]` (omitted when empty) |
+| `fulltext` | `title` + `description` (space-joined, deduplicated, omits empty values) |
 
 ### Parent References
 
@@ -257,7 +261,11 @@ _(not configured — `fulltext`, `name_and_aliases`, and `sort_name` are not set
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `email` (trimmed) |
+| `name_and_aliases` | `[username, email]` (deduplicated, omits empty values) |
+| `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
 
@@ -322,7 +330,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `email` (trimmed) |
+| `name_and_aliases` | `[username, email]` (deduplicated, omits empty values) |
+| `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
 
@@ -409,7 +421,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `title` (trimmed) |
+| `name_and_aliases` | `[title]` (omitted when empty) |
+| `fulltext` | `title` + `description` (space-joined, deduplicated, omits empty values) |
 
 ### Parent References
 
@@ -476,7 +492,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `email` (trimmed) |
+| `name_and_aliases` | `[first_name, last_name, username]` (deduplicated, omits empty values) |
+| `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
 
@@ -571,7 +591,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `title` (trimmed) |
+| `name_and_aliases` | `[title]` (omitted when empty) |
+| `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
 
@@ -636,7 +660,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `title` (trimmed) |
+| `name_and_aliases` | `[title]` (omitted when empty) |
+| `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
 
@@ -710,7 +738,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `zoom_meeting_topic` (trimmed) |
+| `name_and_aliases` | `[zoom_meeting_topic]` (omitted when empty) |
+| `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
 
@@ -773,7 +805,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `name` (trimmed) |
+| `name_and_aliases` | `[file_name, link, name]` (deduplicated, omits empty values) |
+| `fulltext` | `sort_name` + `name_and_aliases` + `description` (space-joined, deduplicated, omits empty values) |
 
 ### Parent References
 
@@ -838,7 +874,11 @@ _(not configured)_
 
 ### Search Behavior
 
-_(not configured)_
+| Field | Value |
+|---|---|
+| `sort_name` | `name` (trimmed) |
+| `name_and_aliases` | `[file_name, link, name]` (deduplicated, omits empty values) |
+| `fulltext` | `sort_name` + `name_and_aliases` + `description` (space-joined, deduplicated, omits empty values) |
 
 ### Parent References
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -1,0 +1,847 @@
+# Indexer Contract — Meeting Service
+
+This document is the authoritative reference for all data the meeting service sends to the indexer service, which makes resources searchable via the [query service](https://github.com/linuxfoundation/lfx-v2-query-service).
+
+**Update this document in the same PR as any change to indexer message construction.**
+
+---
+
+## Resource Types
+
+- [V1 Meeting](#v1-meeting)
+- [V1 Meeting Registrant](#v1-meeting-registrant)
+- [V1 Meeting RSVP](#v1-meeting-rsvp)
+- [V1 Past Meeting](#v1-past-meeting)
+- [V1 Past Meeting Participant](#v1-past-meeting-participant)
+- [V1 Past Meeting Recording](#v1-past-meeting-recording)
+- [V1 Past Meeting Transcript](#v1-past-meeting-transcript)
+- [V1 Past Meeting Summary](#v1-past-meeting-summary)
+- [V1 Meeting Attachment](#v1-meeting-attachment)
+- [V1 Past Meeting Attachment](#v1-past-meeting-attachment)
+
+---
+
+## V1 Meeting
+
+**Source struct:** `internal/domain/models/event_models.go` — `MeetingEventData`
+
+**Indexed on:** create, update, delete of a meeting (sourced from the v1 meeting data).
+
+### Data Schema
+
+These fields are indexed and queryable via `filters` or `cel_filter` in the query service.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Meeting ID (used as the object ID) |
+| `project_sfid` | string | Salesforce ID of the associated LF project |
+| `project_uid` | string | v2 UUID of the associated LF project |
+| `committee` | string | v1 Salesforce ID of the primary committee |
+| `committee_uid` | string (optional) | v2 UUID of the primary committee; omitted when empty |
+| `committee_filters` | []string | List of committee filter values |
+| `committees` | []object | Associated committees (see [Committee schema](#committee-schema)) |
+| `user_id` | string | Zoom user ID of the meeting host |
+| `title` | string | Meeting title (from Zoom `topic`) |
+| `description` | string | Meeting description (from Zoom `agenda`) |
+| `visibility` | string | Meeting visibility on LFX (e.g., `"public"`, `"private"`) |
+| `meeting_type` | string | Zoom meeting type |
+| `start_time` | string | Start time of the first occurrence (RFC3339) |
+| `timezone` | string | Meeting timezone (IANA, e.g., `"America/Los_Angeles"`) |
+| `duration` | int | Meeting duration in minutes |
+| `early_join_time_minutes` | int | Minutes before start time that attendees can join |
+| `last_end_time` | int64 | End time of the last occurrence (Unix timestamp) |
+| `host_key` | string | Six-digit Zoom host PIN (rotated weekly) |
+| `join_url` | string | LFX meeting join page URL |
+| `password` | string | UUID password for the join page |
+| `restricted` | bool | Whether only invited users can join |
+| `artifact_visibility` | string | Visibility of meeting artifacts (recordings, transcripts, summaries) |
+| `recording_enabled` | bool | Whether Zoom recording is enabled |
+| `transcript_enabled` | bool | Whether Zoom transcript is enabled |
+| `recording_access` | string | Recording access level (`"public"`, `"meeting_hosts"`, `"meeting_participants"`) |
+| `transcript_access` | string | Transcript access level |
+| `created_at` | string | Creation time (RFC3339) |
+| `updated_at` | string | Last update time (RFC3339) |
+| `created_by` | object | User who created the meeting (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the meeting (see [User Reference schema](#user-reference-schema)) |
+| `updated_by_list` | []object (optional) | All users who have updated the meeting |
+| `use_new_invite_email_address` | bool | Whether to use the new invite email address |
+| `recurrence` | object (optional) | Zoom recurrence pattern (see [Recurrence schema](#recurrence-schema)) |
+| `occurrences` | []object (optional) | Upcoming meeting occurrences (see [Occurrence schema](#occurrence-schema)) |
+| `cancelled_occurrences` | []string (optional) | Occurrence IDs that have been cancelled |
+| `updated_occurrences` | []object (optional) | Occurrences with custom overrides (see [Updated Occurrence schema](#updated-occurrence-schema)) |
+| `ics_uid_timezone` | string (optional) | Timezone anchored for calendar UID generation |
+| `ics_additional_uids` | []string (optional) | Additional calendar event UIDs for updated occurrence sequences |
+| `zoom_config` | object | Zoom-specific configuration (see [Zoom Config schema](#zoom-config-schema)) |
+| `ai_summary_access` | string (optional) | AI summary access level |
+| `youtube_upload_enabled` | bool (optional) | Whether recording is uploaded to YouTube |
+| `concurrent_zoom_user_enabled` | bool (optional) | Whether meeting uses concurrent Zoom license pool |
+| `last_bulk_registrant_job_status` | string | Status of the last bulk registrant import job |
+| `last_bulk_registrants_job_failed_count` | int | Failed record count from the last bulk registrant job |
+| `last_bulk_registrants_job_warning_count` | int | Warning record count from the last bulk registrant job |
+| `last_mailing_list_members_sync_job_status` | string | Status of the last mailing list sync job |
+| `last_mailing_list_members_sync_job_failed_count` | int | Failed count from last mailing list sync job |
+| `mailing_list_group_ids` | []string | Mailing list group IDs associated with this meeting |
+| `last_mailing_list_members_sync_job_warning_count` | int | Warning count from last mailing list sync job |
+| `use_unique_ics_uid` | string | Override UUID for calendar event ID (when calendar issues require a new UID) |
+| `show_meeting_attendees` | bool | Whether attendee data is visible to other attendees |
+| `organizers` | []string | Auth0 sub-format usernames of meeting organizers |
+
+#### Committee Schema
+
+Each entry in `committees` has:
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Committee v2 UUID |
+| `allowed_voting_statuses` | []object (optional) | Voting status filters for the committee |
+
+#### User Reference Schema
+
+Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
+
+| Field | Type | Description |
+|---|---|---|
+| `user_id` | string (optional) | Auth0 user identifier |
+| `username` | string (optional) | LFX username |
+| `email` | string (optional) | User email address |
+| `name` | string (optional) | Display name |
+| `profile_picture` | string (optional) | Profile picture URL |
+
+#### Recurrence Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | int | Recurrence type (1=daily, 2=weekly, 3=monthly) |
+| `repeat_interval` | int | Interval between occurrences |
+| `weekly_days` | string (optional) | Days of week for weekly recurrence |
+| `monthly_day` | int (optional) | Day of month for monthly recurrence |
+| `monthly_week` | int (optional) | Week of month for monthly recurrence |
+| `monthly_week_day` | int (optional) | Day of week paired with `monthly_week` |
+| `end_times` | int (optional) | Number of times to repeat |
+| `end_date_time` | string (optional) | End date/time for the recurrence pattern (RFC3339) |
+
+#### Occurrence Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `occurrence_id` | string | Unix timestamp of occurrence start (used as ID) |
+| `start_time` | string | Occurrence start time (RFC3339) |
+| `duration` | int | Duration in minutes |
+| `is_cancelled` | bool | Whether this occurrence is cancelled |
+| `title` | string | Occurrence title |
+| `description` | string | Occurrence description |
+| `recurrence` | object (optional) | Override recurrence pattern for this occurrence |
+| `response_count_yes` | int | Accepted RSVP count |
+| `response_count_no` | int | Declined RSVP count |
+| `registrant_count` | int | Registrant count |
+
+#### Updated Occurrence Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `old_occurrence_id` | string | Original occurrence ID (Unix timestamp) |
+| `new_occurrence_id` | string | New occurrence ID after start time change |
+| `timezone` | string | Updated timezone |
+| `duration` | int | Updated duration in minutes |
+| `title` | string | Updated title |
+| `description` | string | Updated description |
+| `recurrence` | object (optional) | Updated recurrence pattern |
+| `all_following` | bool | Whether changes apply to all following occurrences |
+
+#### Zoom Config Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `meeting_id` | string (optional) | Zoom numeric meeting ID |
+| `passcode` | string (optional) | Zoom meeting passcode |
+| `ai_companion_enabled` | bool | Whether Zoom AI Companion is enabled |
+| `ai_summary_require_approval` | bool | Whether AI summaries require approval before publishing |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{id}` | `93699735000` | Direct lookup by meeting ID |
+| `meeting_id:{id}` | `meeting_id:93699735000` | Namespaced lookup by meeting ID |
+| `project_uid:{value}` | `project_uid:cbef1ed5-17dc-4a50-84e2-6cddd70f6878` | Find meetings for a project |
+| `title:{value}` | `title:TSC Monthly Meeting` | Find meetings by title |
+| `visibility:{value}` | `visibility:public` | Find meetings by visibility |
+| `meeting_type:{value}` | `meeting_type:recurring` | Find meetings by type |
+
+> `visibility` and `meeting_type` tags are only emitted when the value is non-empty.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_meeting:{id}` |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_meeting:{id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `true` when `visibility == "public"`, `false` otherwise |
+
+### Search Behavior
+
+_(not configured — `fulltext`, `name_and_aliases`, and `sort_name` are not set in IndexingConfig)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `project:{project_uid}` | Always set |
+| `committee:{uid}` | For each entry in `committees` with a non-empty `uid` |
+
+---
+
+## V1 Meeting Registrant
+
+**Source struct:** `internal/domain/models/event_models.go` — `RegistrantEventData`
+
+**Indexed on:** create, update, delete of a meeting registrant.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Registrant unique identifier (UUID) |
+| `meeting_id` | string | ID of the associated meeting |
+| `type` | string | Registrant type |
+| `committee_uid` | string | v2 UUID of the associated committee (empty when not a committee registrant) |
+| `user_id` | string | Auth0 user ID of the registrant |
+| `email` | string | Email address for meeting invites |
+| `case_insensitive_email` | string | Lowercase version of `email` |
+| `first_name` | string | Registrant first name |
+| `last_name` | string | Registrant last name |
+| `org_name` | string (optional) | Organization name |
+| `org_is_member` | bool (optional) | Whether the organization is an LF member |
+| `org_is_project_member` | bool (optional) | Whether the organization is a project member |
+| `job_title` | string (optional) | Job title |
+| `host` | bool | Whether the registrant is a host |
+| `occurrence` | string (optional) | Occurrence ID if invited to a specific occurrence only |
+| `avatar_url` | string | Profile picture URL |
+| `username` | string (optional) | LFX username |
+| `last_invite_received_time` | string | Timestamp of last invite sent (RFC3339) |
+| `last_invite_received_message_id` | string (optional) | SES message ID of last invite |
+| `last_invite_delivery_successful` | bool (optional) | Whether last invite was delivered |
+| `last_invite_delivered_time` | string (optional) | Delivery timestamp (RFC3339) |
+| `last_invite_bounced` | bool (optional) | Whether last invite bounced |
+| `last_invite_bounced_time` | string (optional) | Bounce timestamp (RFC3339) |
+| `last_invite_bounced_type` | string (optional) | SES bounce type |
+| `last_invite_bounced_sub_type` | string (optional) | SES bounce subtype |
+| `last_invite_bounced_diagnostic_code` | string (optional) | SES bounce diagnostic code |
+| `created_at` | string | Creation time (RFC3339) |
+| `updated_at` | string | Last update time (RFC3339) |
+| `created_by` | object | User who created the registrant (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the registrant (see [User Reference schema](#user-reference-schema)) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `registrant_uid:{uid}` | `registrant_uid:a1b2c3d4-...` | Lookup by registrant UID |
+| `username:{value}` | `username:jdoe` | Find registrants by username |
+| `email:{value}` | `email:jdoe@example.com` | Find registrants by email |
+| `host:true` | `host:true` | Find registrants who are hosts |
+
+> `username` and `email` tags are only emitted when non-empty. `host:true` is only emitted when `host` is `true`.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_meeting:{meeting_id}` (access checked on the parent meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_meeting:{meeting_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `false` (always) |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `meeting:{meeting_id}` | Always set |
+| `committee:{committee_uid}` | Only when `committee_uid` is non-empty |
+
+---
+
+## V1 Meeting RSVP
+
+**Source struct:** `internal/domain/models/event_models.go` — `InviteResponseEventData`
+
+**Indexed on:** create, update, delete of a meeting RSVP (invite response).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | RSVP unique identifier |
+| `meeting_and_occurrence_id` | string | Combined meeting+occurrence ID (e.g., `{meeting_id}:{occurrence_id}`) |
+| `meeting_id` | string | Parent meeting ID |
+| `occurrence_id` | string (optional) | Occurrence ID for occurrence-specific RSVPs |
+| `registrant_id` | string | UID of the associated registrant |
+| `project_uid` | string | v2 UUID of the associated project |
+| `user_id` | string | Auth0 user ID |
+| `username` | string (optional) | LFX username |
+| `name` | string (optional) | Respondent display name |
+| `email` | string | Respondent email address |
+| `org` | string (optional) | Organization name |
+| `job_title` | string (optional) | Job title |
+| `response_type` | string | RSVP response (`"accepted"`, `"declined"`, `"maybe"`) |
+| `scope` | string | Response scope (`"all"`, `"single"`, `"this_and_following"`) |
+| `is_recurring` | bool | Whether the parent meeting is recurring |
+| `created_at` | timestamp | Creation time |
+| `modified_at` | timestamp | Last modification time |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{id}` | `abc123-...` | Direct lookup by RSVP ID |
+| `invite_response_uid:{id}` | `invite_response_uid:abc123-...` | Namespaced lookup by RSVP ID |
+| `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find RSVPs for a specific occurrence |
+| `meeting_id:{value}` | `meeting_id:93699735000` | Find RSVPs for a meeting |
+| `registrant_uid:{value}` | `registrant_uid:a1b2c3d4-...` | Find RSVPs for a registrant |
+| `email:{value}` | `email:jdoe@example.com` | Find RSVPs by email |
+| `username:{value}` | `username:jdoe` | Find RSVPs by username |
+
+> `username` is only emitted when non-empty.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_meeting:{meeting_id}` (access checked on the parent meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_meeting:{meeting_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `false` (always) |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `meeting:{meeting_id}` | Always set |
+
+---
+
+## V1 Past Meeting
+
+**Source struct:** `internal/domain/models/event_models.go` — `PastMeetingEventData`
+
+**Indexed on:** create, update, delete of a past meeting (a completed occurrence of a meeting).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Past meeting unique identifier (UUID) |
+| `meeting_id` | string | ID of the originating active meeting |
+| `meeting_and_occurrence_id` | string | Combined ID used across related resources (e.g., `{meeting_id}:{occurrence_id}`) |
+| `occurrence_id` | string (optional) | Occurrence ID within the recurring meeting |
+| `proj_id` | string (optional) | Salesforce project ID |
+| `project_uid` | string | v2 UUID of the associated project |
+| `project_slug` | string (optional) | URL slug of the associated project |
+| `committee` | string (optional) | v1 Salesforce ID of the primary committee |
+| `committee_uid` | string (optional) | v2 UUID of the primary committee |
+| `committee_filters` | []string (optional) | Committee filter values |
+| `title` | string | Meeting title |
+| `description` | string | Meeting description |
+| `start_time` | timestamp | Occurrence start time |
+| `end_time` | timestamp | Occurrence end time |
+| `duration` | int | Actual duration in minutes |
+| `timezone` | string | Meeting timezone (IANA) |
+| `meeting_type` | string (optional) | Zoom meeting type |
+| `committees` | []object | Associated committees (see [Committee schema](#committee-schema)) |
+| `visibility` | string (optional) | Meeting visibility |
+| `artifact_visibility` | string (optional) | Visibility of meeting artifacts |
+| `restricted` | bool | Whether the meeting was restricted |
+| `recording_enabled` | bool | Whether recording was enabled |
+| `recording_access` | string (optional) | Recording access level |
+| `transcript_enabled` | bool | Whether transcript was enabled |
+| `transcript_access` | string (optional) | Transcript access level |
+| `zoom_ai_enabled` | bool (optional) | Whether Zoom AI Companion was enabled |
+| `ai_summary_access` | string (optional) | AI summary access level (`"public"`, `"meeting_hosts"`, `"meeting_participants"`) |
+| `require_ai_summary_approval` | bool (optional) | Whether AI summary requires approval |
+| `early_join_time_minutes` | int (optional) | Early join buffer in minutes |
+| `youtube_link` | string (optional) | YouTube recording link |
+| `platform` | string (optional) | Meeting platform (e.g., `"Zoom"`) |
+| `platform_meeting_id` | string (optional) | Platform-specific meeting ID |
+| `recording_password` | string (optional) | Password for the recording |
+| `zoom_config` | object (optional) | Zoom-specific configuration (see [Zoom Config schema](#zoom-config-schema)) |
+| `is_manually_created` | bool (optional) | Whether this past meeting was created manually |
+| `sessions` | []object (optional) | Zoom meeting instances within this past meeting (each has `uuid`, `start_time`, `end_time`) |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update time |
+| `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
+| `updated_by_list` | []object (optional) | All users who have updated the record |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `past_meeting_id:{id}` | `past_meeting_id:a1b2c3d4-...` | Lookup by past meeting UUID |
+| `meeting_id:{value}` | `meeting_id:93699735000` | Find past meetings for an active meeting |
+| `project_uid:{value}` | `project_uid:cbef1ed5-...` | Find past meetings for a project |
+| `title:{value}` | `title:TSC Monthly Meeting` | Find past meetings by title |
+| `timezone:{value}` | `timezone:America/Los_Angeles` | Find past meetings by timezone |
+| `committee_uid:{value}` | `committee_uid:061a110a-...` | Find past meetings for a committee |
+
+> `timezone` is only emitted when non-empty. One `committee_uid` tag is emitted per committee in `committees` with a non-empty `uid`.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_past_meeting:{id}` |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_past_meeting:{id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `false` (always) |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `project:{project_uid}` | Always set |
+| `committee:{uid}` | For each entry in `committees` with a non-empty `uid` |
+
+---
+
+## V1 Past Meeting Participant
+
+**Source struct:** `internal/domain/models/event_models.go` — `PastMeetingParticipantEventData`
+
+**Indexed on:** create, update, delete of a past meeting participant (invitee or attendee).
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Participant unique identifier (UUID) |
+| `meeting_and_occurrence_id` | string | Combined meeting+occurrence ID of the parent past meeting |
+| `meeting_id` | string | ID of the originating active meeting |
+| `project_uid` | string | v2 UUID of the associated project |
+| `email` | string | Participant email address |
+| `first_name` | string | Participant first name |
+| `last_name` | string | Participant last name |
+| `host` | bool | Whether the participant was the host |
+| `job_title` | string (optional) | Job title |
+| `org_name` | string (optional) | Organization name |
+| `org_is_member` | bool | Whether the organization is an LF member |
+| `org_is_project_member` | bool | Whether the organization is a project member |
+| `avatar_url` | string (optional) | Profile picture URL |
+| `username` | string (optional) | LFX username |
+| `is_invited` | bool | Whether the participant was invited |
+| `is_attended` | bool | Whether the participant attended |
+| `sessions` | []object (optional) | Join/leave sessions (each has `uid`, `join_time`, `leave_time`, `leave_reason`) |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update time |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `past_meeting_participant_uid:{uid}` | `past_meeting_participant_uid:a1b2c3d4-...` | Lookup by participant UID |
+| `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find participants for a past meeting |
+| `project_uid:{value}` | `project_uid:cbef1ed5-...` | Find participants for a project |
+| `username:{value}` | `username:jdoe` | Find participants by username |
+| `email:{value}` | `email:jdoe@example.com` | Find participants by email |
+| `is_invited:true` | `is_invited:true` | Find invited participants |
+| `is_attended:true` | `is_attended:true` | Find attendees |
+
+> `username` and `email` tags are only emitted when non-empty. `is_invited:true` and `is_attended:true` are only emitted when the corresponding flag is `true`.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` (access checked on the parent past meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `false` (always) |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `past_meeting:{meeting_and_occurrence_id}` | Always set |
+
+---
+
+## V1 Past Meeting Recording
+
+**Source struct:** `internal/domain/models/event_models.go` — `RecordingEventData`
+
+**Indexed on:** create, update, delete of a past meeting recording.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Recording unique identifier |
+| `meeting_and_occurrence_id` | string | Combined meeting+occurrence ID of the parent past meeting |
+| `project_uid` | string | v2 UUID of the associated project |
+| `project_slug` | string | URL slug of the associated project |
+| `host_email` | string | Email of the meeting host |
+| `host_id` | string | Zoom user ID of the host |
+| `meeting_id` | string | ID of the originating active meeting |
+| `occurrence_id` | string | Occurrence ID |
+| `platform` | string | Meeting platform (always `"Zoom"`) |
+| `platform_meeting_id` | string | Zoom numeric meeting ID |
+| `recording_access` | string | Access level (`"public"`, `"meeting_hosts"`, `"meeting_participants"`) |
+| `title` | string | Recording title |
+| `transcript_access` | string (optional) | Transcript access level |
+| `transcript_enabled` | bool | Whether transcript is enabled |
+| `visibility` | string | Recording visibility |
+| `recording_count` | int | Number of recording files |
+| `recording_files` | []object | Recording files (see [Recording File schema](#recording-file-schema)) |
+| `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
+| `start_time` | timestamp | Recording start time |
+| `total_size` | int64 | Total size of all recording files in bytes |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update time |
+| `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
+
+#### Recording File Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | File unique identifier |
+| `meeting_id` | string | Associated meeting ID |
+| `file_type` | string | File type (e.g., `"MP4"`, `"M4A"`) |
+| `file_extension` | string | File extension |
+| `file_size` | int64 | File size in bytes |
+| `recording_type` | string | Zoom recording type (e.g., `"shared_screen_with_speaker_view"`) |
+| `status` | string | File status |
+| `recording_start` | timestamp | Recording start time |
+| `recording_end` | timestamp | Recording end time |
+| `download_url` | string (optional) | Download URL |
+| `play_url` | string (optional) | Playback URL |
+
+#### Recording Session Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uuid` | string | Zoom meeting instance UUID |
+| `start_time` | timestamp | Session start time |
+| `total_size` | int64 | Session total size in bytes |
+| `share_url` | string (optional) | Share URL for the session |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{id}` | `abc123-...` | Direct lookup by recording ID |
+| `past_meeting_recording_id:{id}` | `past_meeting_recording_id:abc123-...` | Namespaced lookup by recording ID |
+| `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find recordings for a past meeting |
+| `platform:Zoom` | `platform:Zoom` | All recordings (platform is always Zoom) |
+| `platform_meeting_id:{value}` | `platform_meeting_id:93699735000` | Find recordings by Zoom meeting ID |
+| `platform_meeting_instance_id:{uuid}` | `platform_meeting_instance_id:abc...` | Find recordings by Zoom session UUID |
+
+> One `platform_meeting_instance_id` tag is emitted per session in `sessions`.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` (access checked on the parent past meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `true` when `recording_access == "public"`, `false` otherwise |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `past_meeting:{meeting_and_occurrence_id}` | Always set |
+
+---
+
+## V1 Past Meeting Transcript
+
+**Source struct:** `internal/domain/models/event_models.go` — `TranscriptEventData`
+
+**Indexed on:** create, update, delete of a past meeting transcript.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Transcript unique identifier |
+| `meeting_and_occurrence_id` | string | Combined meeting+occurrence ID of the parent past meeting |
+| `project_uid` | string | v2 UUID of the associated project |
+| `project_slug` | string | URL slug of the associated project |
+| `host_email` | string | Email of the meeting host |
+| `host_id` | string | Zoom user ID of the host |
+| `meeting_id` | string | ID of the originating active meeting |
+| `occurrence_id` | string | Occurrence ID |
+| `platform` | string | Meeting platform (always `"Zoom"`) |
+| `transcript_access` | string | Access level (`"public"`, `"meeting_hosts"`, `"meeting_participants"`) |
+| `title` | string | Transcript title |
+| `visibility` | string | Transcript visibility |
+| `recording_files` | []object | Associated recording files (see [Recording File schema](#recording-file-schema)) |
+| `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
+| `start_time` | timestamp | Transcript start time |
+| `total_size` | int64 | Total size in bytes |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update time |
+| `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{id}` | `abc123-...` | Direct lookup by transcript ID |
+| `past_meeting_transcript_id:{id}` | `past_meeting_transcript_id:abc123-...` | Namespaced lookup by transcript ID |
+| `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find transcripts for a past meeting |
+| `platform:Zoom` | `platform:Zoom` | All transcripts (platform is always Zoom) |
+| `platform_meeting_instance_id:{uuid}` | `platform_meeting_instance_id:abc...` | Find transcripts by Zoom session UUID |
+
+> One `platform_meeting_instance_id` tag is emitted per session in `sessions`.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` (access checked on the parent past meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `true` when `transcript_access == "public"`, `false` otherwise |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `past_meeting:{meeting_and_occurrence_id}` | Always set |
+
+---
+
+## V1 Past Meeting Summary
+
+**Source struct:** `internal/domain/models/event_models.go` — `SummaryEventData`
+
+**Indexed on:** create, update, delete of an AI-generated past meeting summary.
+
+> The `public` flag is derived from the **parent past meeting's** `ai_summary_access` field, not from a field on the summary itself.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Summary unique identifier |
+| `meeting_and_occurrence_id` | string | Combined meeting+occurrence ID of the parent past meeting |
+| `project_uid` | string | v2 UUID of the associated project |
+| `meeting_id` | string | ID of the originating active meeting |
+| `occurrence_id` | string | Occurrence ID |
+| `zoom_meeting_uuid` | string | Zoom meeting UUID from the webhook event |
+| `zoom_meeting_host_id` | string | Zoom user ID of the host |
+| `zoom_meeting_host_email` | string | Email of the host |
+| `zoom_meeting_topic` | string | Zoom meeting topic |
+| `zoom_webhook_event` | string (optional) | Zoom webhook event type that triggered this summary |
+| `summary_title` | string (optional) | AI-generated summary title |
+| `summary_start_time` | string (optional) | Summary start time (RFC3339) |
+| `summary_end_time` | string (optional) | Summary end time (RFC3339) |
+| `summary_created_time` | string (optional) | Time the summary was generated (RFC3339) |
+| `summary_last_modified_time` | string (optional) | Last modification time (RFC3339) |
+| `content` | string | Consolidated markdown content |
+| `edited_content` | string | Edited markdown content (may differ from `content`) |
+| `requires_approval` | bool | Whether this summary requires human approval before publishing |
+| `approved` | bool | Whether this summary has been approved |
+| `platform` | string | Meeting platform (always `"Zoom"`) |
+| `zoom_config` | object | Zoom identifiers (has `meeting_id` string and `meeting_uuid` string) |
+| `email_sent` | bool | Whether a summary notification email has been sent |
+| `created_at` | timestamp | Creation time |
+| `updated_at` | timestamp | Last update time |
+| `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the record (see [User Reference schema](#user-reference-schema)) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `{id}` | `abc123-...` | Direct lookup by summary ID |
+| `past_meeting_summary_id:{id}` | `past_meeting_summary_id:abc123-...` | Namespaced lookup by summary ID |
+| `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find summaries for a past meeting |
+| `meeting_id:{value}` | `meeting_id:93699735000` | Find summaries for a meeting |
+| `platform:Zoom` | `platform:Zoom` | All summaries (platform is always Zoom) |
+| `title:{value}` | `title:TSC Monthly Meeting` | Find summaries by Zoom meeting topic |
+
+> `title` tag uses `zoom_meeting_topic` and is only emitted when non-empty.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` (access checked on the parent past meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `true` when the parent past meeting's `ai_summary_access == "public"`, `false` otherwise |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `past_meeting:{meeting_and_occurrence_id}` | Always set |
+
+---
+
+## V1 Meeting Attachment
+
+**Source struct:** `internal/domain/models/event_models.go` — `MeetingAttachmentEventData`
+
+**Indexed on:** create, update, delete of an attachment on an active meeting.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Attachment unique identifier |
+| `meeting_id` | string | ID of the parent meeting |
+| `type` | string | Attachment type (e.g., `"link"`, `"file"`) |
+| `category` | string (optional) | Attachment category |
+| `link` | string (optional) | Link URL (for link-type attachments) |
+| `name` | string | Attachment display name |
+| `description` | string (optional) | Attachment description |
+| `source` | string (optional) | Attachment source |
+| `file_name` | string (optional) | Uploaded file name |
+| `file_size` | int (optional) | File size in bytes |
+| `file_url` | string (optional) | URL to the uploaded file |
+| `file_uploaded` | bool (optional) | Whether the file has been uploaded |
+| `file_upload_status` | string (optional) | Upload status |
+| `file_content_type` | string (optional) | MIME content type |
+| `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
+| `file_uploaded_at` | timestamp (optional) | Time the file was uploaded |
+| `created_at` | timestamp | Creation time |
+| `modified_at` | timestamp | Last modification time |
+| `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the attachment (see [User Reference schema](#user-reference-schema)) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `meeting_attachment_uid:{uid}` | `meeting_attachment_uid:a1b2c3d4-...` | Lookup by attachment UID |
+| `meeting_id:{value}` | `meeting_id:93699735000` | Find attachments for a meeting |
+| `type:{value}` | `type:file` | Find attachments by type |
+
+> `type` tag is only emitted when non-empty.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_meeting:{meeting_id}` (access checked on the parent meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_meeting:{meeting_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `false` (always) |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `meeting:{meeting_id}` | Always set |
+
+---
+
+## V1 Past Meeting Attachment
+
+**Source struct:** `internal/domain/models/event_models.go` — `PastMeetingAttachmentEventData`
+
+**Indexed on:** create, update, delete of an attachment on a past meeting.
+
+### Data Schema
+
+| Field | Type | Description |
+|---|---|---|
+| `uid` | string | Attachment unique identifier |
+| `meeting_and_occurrence_id` | string | Combined meeting+occurrence ID of the parent past meeting |
+| `meeting_id` | string | ID of the originating active meeting |
+| `type` | string | Attachment type (e.g., `"link"`, `"file"`) |
+| `category` | string (optional) | Attachment category |
+| `link` | string (optional) | Link URL (for link-type attachments) |
+| `name` | string | Attachment display name |
+| `description` | string (optional) | Attachment description |
+| `source` | string (optional) | Attachment source |
+| `file_name` | string (optional) | Uploaded file name |
+| `file_size` | int (optional) | File size in bytes |
+| `file_url` | string (optional) | URL to the uploaded file |
+| `file_uploaded` | bool (optional) | Whether the file has been uploaded |
+| `file_upload_status` | string (optional) | Upload status |
+| `file_content_type` | string (optional) | MIME content type |
+| `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
+| `file_uploaded_at` | timestamp (optional) | Time the file was uploaded |
+| `created_at` | timestamp | Creation time |
+| `modified_at` | timestamp | Last modification time |
+| `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
+| `updated_by` | object | User who last updated the attachment (see [User Reference schema](#user-reference-schema)) |
+
+### Tags
+
+| Tag Format | Example | Purpose |
+|---|---|---|
+| `past_meeting_attachment_uid:{uid}` | `past_meeting_attachment_uid:a1b2c3d4-...` | Lookup by attachment UID |
+| `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find attachments for a past meeting |
+| `meeting_id:{value}` | `meeting_id:93699735000` | Find attachments by originating meeting |
+| `type:{value}` | `type:link` | Find attachments by type |
+
+> `type` tag is only emitted when non-empty.
+
+### Access Control (IndexingConfig)
+
+| Field | Value |
+|---|---|
+| `access_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` (access checked on the parent past meeting) |
+| `access_check_relation` | `viewer` |
+| `history_check_object` | `v1_past_meeting:{meeting_and_occurrence_id}` |
+| `history_check_relation` | `auditor` |
+| `public` | `false` (always) |
+
+### Search Behavior
+
+_(not configured)_
+
+### Parent References
+
+| Ref | Condition |
+|---|---|
+| `past_meeting:{meeting_and_occurrence_id}` | Always set |

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -4,6 +4,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 )
 
@@ -331,6 +332,35 @@ type MeetingEventData struct {
 	Organizers []string `json:"organizers"`
 }
 
+// SortName returns the primary sort name for this meeting.
+func (m *MeetingEventData) SortName() string {
+	return strings.TrimSpace(m.Title)
+}
+
+// NameAndAliases returns the searchable name aliases for this meeting.
+func (m *MeetingEventData) NameAndAliases() []string {
+	if t := strings.TrimSpace(m.Title); t != "" {
+		return []string{t}
+	}
+	return nil
+}
+
+// FullText returns the fulltext search content for this meeting.
+func (m *MeetingEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{m.SortName()}, m.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	if desc := strings.TrimSpace(m.Description); desc != "" && !seen[desc] {
+		parts = append(parts, desc)
+	}
+	return strings.Join(parts, " ")
+}
+
 // Tags returns the indexer tags for this meeting.
 func (m *MeetingEventData) Tags() []string {
 	tags := []string{
@@ -478,6 +508,38 @@ type RegistrantEventData struct {
 	UpdatedBy UpdatedBy `json:"updated_by"`
 }
 
+// SortName returns the primary sort name for this registrant.
+func (r *RegistrantEventData) SortName() string {
+	return strings.TrimSpace(r.Email)
+}
+
+// NameAndAliases returns the searchable name aliases for this registrant.
+func (r *RegistrantEventData) NameAndAliases() []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range []string{r.Username, r.Email} {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+// FullText returns the fulltext search content for this registrant.
+func (r *RegistrantEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{r.SortName()}, r.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
 // Tags returns the indexer tags for this registrant.
 func (r *RegistrantEventData) Tags() []string {
 	tags := []string{"registrant_uid:" + r.UID}
@@ -521,6 +583,38 @@ type InviteResponseEventData struct {
 	IsRecurring            bool      `json:"is_recurring"`
 	CreatedAt              time.Time `json:"created_at"`
 	ModifiedAt             time.Time `json:"modified_at"`
+}
+
+// SortName returns the primary sort name for this invite response.
+func (r *InviteResponseEventData) SortName() string {
+	return strings.TrimSpace(r.Email)
+}
+
+// NameAndAliases returns the searchable name aliases for this invite response.
+func (r *InviteResponseEventData) NameAndAliases() []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range []string{r.Username, r.Email} {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+// FullText returns the fulltext search content for this invite response.
+func (r *InviteResponseEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{r.SortName()}, r.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // Tags returns the indexer tags for this invite response.
@@ -596,6 +690,35 @@ type PastMeetingSession struct {
 	EndTime   time.Time `json:"end_time"`
 }
 
+// SortName returns the primary sort name for this past meeting.
+func (m *PastMeetingEventData) SortName() string {
+	return strings.TrimSpace(m.Title)
+}
+
+// NameAndAliases returns the searchable name aliases for this past meeting.
+func (m *PastMeetingEventData) NameAndAliases() []string {
+	if t := strings.TrimSpace(m.Title); t != "" {
+		return []string{t}
+	}
+	return nil
+}
+
+// FullText returns the fulltext search content for this past meeting.
+func (m *PastMeetingEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{m.SortName()}, m.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	if desc := strings.TrimSpace(m.Description); desc != "" && !seen[desc] {
+		parts = append(parts, desc)
+	}
+	return strings.Join(parts, " ")
+}
+
 // Tags returns the indexer tags for this past meeting.
 func (m *PastMeetingEventData) Tags() []string {
 	tags := []string{
@@ -647,6 +770,38 @@ type PastMeetingParticipantEventData struct {
 	Sessions               []ParticipantSession `json:"sessions,omitempty"`
 	CreatedAt              time.Time            `json:"created_at"`
 	UpdatedAt              time.Time            `json:"updated_at"`
+}
+
+// SortName returns the primary sort name for this past meeting participant.
+func (p *PastMeetingParticipantEventData) SortName() string {
+	return strings.TrimSpace(p.Email)
+}
+
+// NameAndAliases returns the searchable name aliases for this past meeting participant.
+func (p *PastMeetingParticipantEventData) NameAndAliases() []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range []string{p.FirstName, p.LastName, p.Username} {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+// FullText returns the fulltext search content for this past meeting participant.
+func (p *PastMeetingParticipantEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{p.SortName()}, p.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // Tags returns the indexer tags for this past meeting participant.
@@ -710,6 +865,32 @@ type RecordingEventData struct {
 	UpdatedAt              time.Time          `json:"updated_at"`
 	CreatedBy              CreatedBy          `json:"created_by"`
 	UpdatedBy              UpdatedBy          `json:"updated_by"`
+}
+
+// SortName returns the primary sort name for this recording.
+func (r *RecordingEventData) SortName() string {
+	return strings.TrimSpace(r.Title)
+}
+
+// NameAndAliases returns the searchable name aliases for this recording.
+func (r *RecordingEventData) NameAndAliases() []string {
+	if t := strings.TrimSpace(r.Title); t != "" {
+		return []string{t}
+	}
+	return nil
+}
+
+// FullText returns the fulltext search content for this recording.
+func (r *RecordingEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{r.SortName()}, r.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // Tags returns the indexer tags for this recording.
@@ -779,6 +960,32 @@ type TranscriptEventData struct {
 	UpdatedBy              UpdatedBy          `json:"updated_by"`
 }
 
+// SortName returns the primary sort name for this transcript.
+func (t *TranscriptEventData) SortName() string {
+	return strings.TrimSpace(t.Title)
+}
+
+// NameAndAliases returns the searchable name aliases for this transcript.
+func (t *TranscriptEventData) NameAndAliases() []string {
+	if v := strings.TrimSpace(t.Title); v != "" {
+		return []string{v}
+	}
+	return nil
+}
+
+// FullText returns the fulltext search content for this transcript.
+func (t *TranscriptEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{t.SortName()}, t.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
 // Tags returns the indexer tags for this transcript.
 func (t *TranscriptEventData) Tags() []string {
 	tags := []string{
@@ -826,6 +1033,32 @@ type SummaryEventData struct {
 	UpdatedAt               time.Time         `json:"updated_at"`
 	CreatedBy               CreatedBy         `json:"created_by"`
 	UpdatedBy               UpdatedBy         `json:"updated_by"`
+}
+
+// SortName returns the primary sort name for this summary.
+func (s *SummaryEventData) SortName() string {
+	return strings.TrimSpace(s.ZoomMeetingTopic)
+}
+
+// NameAndAliases returns the searchable name aliases for this summary.
+func (s *SummaryEventData) NameAndAliases() []string {
+	if v := strings.TrimSpace(s.ZoomMeetingTopic); v != "" {
+		return []string{v}
+	}
+	return nil
+}
+
+// FullText returns the fulltext search content for this summary.
+func (s *SummaryEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{s.SortName()}, s.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // Tags returns the indexer tags for this summary.
@@ -878,6 +1111,41 @@ type MeetingAttachmentEventData struct {
 	UpdatedBy        UpdatedBy  `json:"updated_by"`
 }
 
+// SortName returns the primary sort name for this meeting attachment.
+func (a *MeetingAttachmentEventData) SortName() string {
+	return strings.TrimSpace(a.Name)
+}
+
+// NameAndAliases returns the searchable name aliases for this meeting attachment.
+func (a *MeetingAttachmentEventData) NameAndAliases() []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range []string{a.FileName, a.Link, a.Name} {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+// FullText returns the fulltext search content for this meeting attachment.
+func (a *MeetingAttachmentEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{a.SortName()}, a.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	if desc := strings.TrimSpace(a.Description); desc != "" && !seen[desc] {
+		parts = append(parts, desc)
+	}
+	return strings.Join(parts, " ")
+}
+
 // Tags returns the indexer tags for this meeting attachment.
 func (a *MeetingAttachmentEventData) Tags() []string {
 	tags := []string{
@@ -918,6 +1186,41 @@ type PastMeetingAttachmentEventData struct {
 	ModifiedAt             time.Time  `json:"modified_at"`
 	CreatedBy              CreatedBy  `json:"created_by"`
 	UpdatedBy              UpdatedBy  `json:"updated_by"`
+}
+
+// SortName returns the primary sort name for this past meeting attachment.
+func (a *PastMeetingAttachmentEventData) SortName() string {
+	return strings.TrimSpace(a.Name)
+}
+
+// NameAndAliases returns the searchable name aliases for this past meeting attachment.
+func (a *PastMeetingAttachmentEventData) NameAndAliases() []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range []string{a.FileName, a.Link, a.Name} {
+		v = strings.TrimSpace(v)
+		if v != "" && !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+// FullText returns the fulltext search content for this past meeting attachment.
+func (a *PastMeetingAttachmentEventData) FullText() string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, v := range append([]string{a.SortName()}, a.NameAndAliases()...) {
+		if v != "" && !seen[v] {
+			parts = append(parts, v)
+			seen[v] = true
+		}
+	}
+	if desc := strings.TrimSpace(a.Description); desc != "" && !seen[desc] {
+		parts = append(parts, desc)
+	}
+	return strings.Join(parts, " ")
 }
 
 // Tags returns the indexer tags for this past meeting attachment.


### PR DESCRIPTION
## Summary

- Create `docs/indexer-contract.md` as the authoritative reference for all data the meeting service sends to the indexer service
- Covers all 10 resource types: V1 Meeting, V1 Meeting Registrant, V1 Meeting RSVP, V1 Past Meeting, V1 Past Meeting Participant, V1 Past Meeting Recording, V1 Past Meeting Transcript, V1 Past Meeting Summary, V1 Meeting Attachment, V1 Past Meeting Attachment
- Each resource type documents the full data schema, tags, IndexingConfig access control values, search behavior (not configured), and parent references
- Add pointer from `README.md` following the established pattern

## Ticket

[LFXV2-1398](https://linuxfoundation.atlassian.net/browse/LFXV2-1398) — Document Query Service Data & Types — lfx-v2-meeting-service

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1398]: https://linuxfoundation.atlassian.net/browse/LFXV2-1398