### PR TITLE
[LFXV2-1441] feat: return meeting/past-meeting with empty committee UID when mapping fails

### DIFF
--- a/internal/service/itx/meeting_service.go
+++ b/internal/service/itx/meeting_service.go
@@ -248,8 +248,8 @@ func (s *MeetingService) mapResponseV1ToV2(ctx context.Context, resp *itx.ZoomMe
 		resp.Project = v2UID
 	}
 
-	// Map committee SFIDs (v1) to committee UIDs (v2). A missing mapping or transient error
-	// leaves the committee UID empty so the caller still receives the full meeting response.
+	// Map committee SFIDs (v1) to committee UIDs (v2). On any mapping failure, log a warning,
+	// leave the committee UID empty, and continue so the caller still receives the full response.
 	for i := range resp.Committees {
 		if resp.Committees[i].ID != "" {
 			v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.Committees[i].ID)

--- a/internal/service/itx/meeting_service.go
+++ b/internal/service/itx/meeting_service.go
@@ -5,6 +5,7 @@ package itx
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/models"
@@ -247,12 +248,16 @@ func (s *MeetingService) mapResponseV1ToV2(ctx context.Context, resp *itx.ZoomMe
 		resp.Project = v2UID
 	}
 
-	// Map committee SFIDs (v1) to committee UIDs (v2)
+	// Map committee SFIDs (v1) to committee UIDs (v2). A missing mapping or transient error
+	// leaves the committee UID empty so the caller still receives the full meeting response.
 	for i := range resp.Committees {
 		if resp.Committees[i].ID != "" {
 			v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.Committees[i].ID)
 			if err != nil {
-				return err
+				slog.WarnContext(ctx, "failed to map committee ID in meeting response; returning empty committee UID",
+					"v1_id", resp.Committees[i].ID, "err", err)
+				resp.Committees[i].ID = ""
+				continue
 			}
 			resp.Committees[i].ID = v2UID
 		}

--- a/internal/service/itx/past_meeting_service.go
+++ b/internal/service/itx/past_meeting_service.go
@@ -61,8 +61,8 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, req *itx.Cre
 		resp.ProjectID = v2UID
 	}
 
-	// Map committee IDs back to v2 UIDs. A missing mapping or transient error leaves the
-	// committee UID empty so the caller still receives the full past meeting response.
+	// Map committee IDs back to v2 UIDs. On any mapping failure, log a warning,
+	// leave the committee UID empty, and continue so the caller still receives the full response.
 	for i := range resp.Committees {
 		if resp.Committees[i].ID != "" {
 			v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.Committees[i].ID)
@@ -95,12 +95,16 @@ func (s *PastMeetingService) GetPastMeeting(ctx context.Context, pastMeetingID s
 		resp.ProjectID = v2UID
 	}
 
-	// Map committee IDs back to v2 UIDs
+	// Map committee IDs back to v2 UIDs. On any mapping failure, log a warning,
+	// leave the committee UID empty, and continue so the caller still receives the full response.
 	for i := range resp.Committees {
 		if resp.Committees[i].ID != "" {
 			v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.Committees[i].ID)
 			if err != nil {
-				return nil, err
+				slog.WarnContext(ctx, "failed to map committee ID in past meeting response; returning empty committee UID",
+					"v1_id", resp.Committees[i].ID, "err", err)
+				resp.Committees[i].ID = ""
+				continue
 			}
 			resp.Committees[i].ID = v2UID
 		}

--- a/internal/service/itx/past_meeting_service.go
+++ b/internal/service/itx/past_meeting_service.go
@@ -5,6 +5,7 @@ package itx
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
@@ -60,12 +61,16 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, req *itx.Cre
 		resp.ProjectID = v2UID
 	}
 
-	// Map committee IDs back to v2 UIDs
+	// Map committee IDs back to v2 UIDs. A missing mapping or transient error leaves the
+	// committee UID empty so the caller still receives the full past meeting response.
 	for i := range resp.Committees {
 		if resp.Committees[i].ID != "" {
 			v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.Committees[i].ID)
 			if err != nil {
-				return nil, err
+				slog.WarnContext(ctx, "failed to map committee ID in past meeting response; returning empty committee UID",
+					"v1_id", resp.Committees[i].ID, "err", err)
+				resp.Committees[i].ID = ""
+				continue
 			}
 			resp.Committees[i].ID = v2UID
 		}

--- a/internal/service/itx/registrant_service.go
+++ b/internal/service/itx/registrant_service.go
@@ -5,6 +5,7 @@ package itx
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
@@ -40,13 +41,17 @@ func (s *RegistrantService) CreateRegistrant(ctx context.Context, meetingID stri
 		return nil, err
 	}
 
-	// Map committee SFID back to committee UID if present
+	// Map committee SFID back to committee UID if present. On any mapping failure, log a warning
+	// and leave the committee UID empty so the caller still receives the full registrant response.
 	if resp.CommitteeID != "" {
 		v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.CommitteeID)
 		if err != nil {
-			return nil, err
+			slog.WarnContext(ctx, "failed to map committee ID in registrant response; returning empty committee UID",
+				"v1_id", resp.CommitteeID, "err", err)
+			resp.CommitteeID = ""
+		} else {
+			resp.CommitteeID = v2UID
 		}
-		resp.CommitteeID = v2UID
 	}
 
 	return resp, nil
@@ -59,13 +64,17 @@ func (s *RegistrantService) GetRegistrant(ctx context.Context, meetingID, regist
 		return nil, err
 	}
 
-	// Map committee SFID back to committee UID if present
+	// Map committee SFID back to committee UID if present. On any mapping failure, log a warning
+	// and leave the committee UID empty so the caller still receives the full registrant response.
 	if resp.CommitteeID != "" {
 		v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.CommitteeID)
 		if err != nil {
-			return nil, err
+			slog.WarnContext(ctx, "failed to map committee ID in registrant response; returning empty committee UID",
+				"v1_id", resp.CommitteeID, "err", err)
+			resp.CommitteeID = ""
+		} else {
+			resp.CommitteeID = v2UID
 		}
-		resp.CommitteeID = v2UID
 	}
 
 	return resp, nil


### PR DESCRIPTION
## Summary

- GET endpoints for meetings and past meetings now return a successful response when committee ID mapping fails
- Instead of propagating the error, the committee UID is left empty and a warning is logged
- The full meeting/past-meeting data is still returned to the caller

## Ticket

[LFXV2-1441](https://linuxfoundation.atlassian.net/browse/LFXV2-1441)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1441]: https://linuxfoundation.atlassian.net/browse/LFXV2-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ