### PR TITLE
[LFXV2-1455] fix: populate fulltext search fields in indexer messages

### DIFF
--- a/internal/infrastructure/eventing/nats_publisher.go
+++ b/internal/infrastructure/eventing/nats_publisher.go
@@ -113,6 +113,9 @@ func (p *NATSPublisher) PublishMeetingEvent(ctx context.Context, action string, 
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           meeting.ParentRefs(),
 			Tags:                 tags,
+			SortName:             meeting.SortName(),
+			NameAndAliases:       meeting.NameAndAliases(),
+			Fulltext:             meeting.FullText(),
 		},
 	}
 
@@ -183,6 +186,9 @@ func (p *NATSPublisher) PublishRegistrantEvent(ctx context.Context, action strin
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           registrant.ParentRefs(),
 			Tags:                 tags,
+			SortName:             registrant.SortName(),
+			NameAndAliases:       registrant.NameAndAliases(),
+			Fulltext:             registrant.FullText(),
 		},
 	}
 
@@ -246,6 +252,9 @@ func (p *NATSPublisher) PublishInviteResponseEvent(ctx context.Context, action s
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           response.ParentRefs(),
 			Tags:                 tags,
+			SortName:             response.SortName(),
+			NameAndAliases:       response.NameAndAliases(),
+			Fulltext:             response.FullText(),
 		},
 	}
 
@@ -276,6 +285,9 @@ func (p *NATSPublisher) PublishPastMeetingEvent(ctx context.Context, action stri
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           meeting.ParentRefs(),
 			Tags:                 tags,
+			SortName:             meeting.SortName(),
+			NameAndAliases:       meeting.NameAndAliases(),
+			Fulltext:             meeting.FullText(),
 		},
 	}
 
@@ -342,6 +354,9 @@ func (p *NATSPublisher) PublishPastMeetingParticipantEvent(ctx context.Context, 
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           participant.ParentRefs(),
 			Tags:                 tags,
+			SortName:             participant.SortName(),
+			NameAndAliases:       participant.NameAndAliases(),
+			Fulltext:             participant.FullText(),
 		},
 	}
 
@@ -409,6 +424,9 @@ func (p *NATSPublisher) PublishPastMeetingRecordingEvent(ctx context.Context, ac
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           recording.ParentRefs(),
 			Tags:                 tags,
+			SortName:             recording.SortName(),
+			NameAndAliases:       recording.NameAndAliases(),
+			Fulltext:             recording.FullText(),
 		},
 	}
 
@@ -472,6 +490,9 @@ func (p *NATSPublisher) PublishPastMeetingTranscriptEvent(ctx context.Context, a
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           transcript.ParentRefs(),
 			Tags:                 tags,
+			SortName:             transcript.SortName(),
+			NameAndAliases:       transcript.NameAndAliases(),
+			Fulltext:             transcript.FullText(),
 		},
 	}
 
@@ -534,6 +555,9 @@ func (p *NATSPublisher) PublishPastMeetingSummaryEvent(ctx context.Context, acti
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           summary.ParentRefs(),
 			Tags:                 tags,
+			SortName:             summary.SortName(),
+			NameAndAliases:       summary.NameAndAliases(),
+			Fulltext:             summary.FullText(),
 		},
 	}
 
@@ -595,6 +619,9 @@ func (p *NATSPublisher) PublishMeetingAttachmentEvent(ctx context.Context, actio
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           attachment.ParentRefs(),
 			Tags:                 tags,
+			SortName:             attachment.SortName(),
+			NameAndAliases:       attachment.NameAndAliases(),
+			Fulltext:             attachment.FullText(),
 		},
 	}
 
@@ -625,6 +652,9 @@ func (p *NATSPublisher) PublishPastMeetingAttachmentEvent(ctx context.Context, a
 			HistoryCheckRelation: "auditor",
 			ParentRefs:           attachment.ParentRefs(),
 			Tags:                 tags,
+			SortName:             attachment.SortName(),
+			NameAndAliases:       attachment.NameAndAliases(),
+			Fulltext:             attachment.FullText(),
 		},
 	}
 


### PR DESCRIPTION
## Summary
- IndexingConfig in nats_publisher.go was missing `SortName`, `NameAndAliases`, and `Fulltext` fields for all 10 resource types
- This caused name-based searches (e.g. `name=Member`) to return no results for meetings and all other meeting-service resource types
- Confirmed via direct OpenSearch query — indexed documents had tags but no fulltext/sort_name/name_and_aliases fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)