### PR TITLE
Add deployment annotation for Backstage ingestion

### DIFF
--- a/charts/lfx-v2-meeting-service/templates/deployment.yaml
+++ b/charts/lfx-v2-meeting-service/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -25,6 +26,7 @@ spec:
       {{- end }}
       labels:
         app: {{ .Chart.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/lfx-v2-meeting-service/templates/deployment.yaml
+++ b/charts/lfx-v2-meeting-service/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.deployment.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/lfx-v2-meeting-service/templates/deployment.yaml
+++ b/charts/lfx-v2-meeting-service/templates/deployment.yaml
@@ -10,10 +10,8 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.deployment.labels }}
   labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/lfx-v2-meeting-service/templates/deployment.yaml
+++ b/charts/lfx-v2-meeting-service/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
-      app.kubernetes.io/name: {{ .Chart.Name }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/lfx-v2-meeting-service/values.yaml
+++ b/charts/lfx-v2-meeting-service/values.yaml
@@ -12,6 +12,12 @@ image:
 
 replicaCount: 1
 
+# deployment configures the Deployment object itself.
+deployment:
+  # labels are additional labels applied to the Deployment metadata.
+  labels:
+    app.kubernetes.io/name: "lfx-v2-meeting-service"
+
 # podAnnotations are additional annotations applied to the pod template.
 # Example:
 #   prometheus.io/scrape: "true"

--- a/charts/lfx-v2-meeting-service/values.yaml
+++ b/charts/lfx-v2-meeting-service/values.yaml
@@ -12,12 +12,6 @@ image:
 
 replicaCount: 1
 
-# deployment configures the Deployment object itself.
-deployment:
-  # labels are additional labels applied to the Deployment metadata.
-  labels:
-    app.kubernetes.io/name: "lfx-v2-meeting-service"
-
 # podAnnotations are additional annotations applied to the pod template.
 # Example:
 #   prometheus.io/scrape: "true"


### PR DESCRIPTION
Spotify Backstage can pull kubernetes data from components using deployment annotations. This service is missing the name annotation needed to discover it.