### PR TITLE
fix(ruleset): use meetings_creator relation for meeting create rules

### DIFF
--- a/charts/lfx-v2-meeting-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-meeting-service/templates/ruleset.yaml
@@ -51,7 +51,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: writer
+              relation: meetings_creator
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
         {{- else }}
         {{/*
@@ -579,7 +579,7 @@ spec:
         - authorizer: openfga_check
           config:
             values:
-              relation: writer
+              relation: meetings_creator
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
         {{- else }}
         {{/*


### PR DESCRIPTION
## Summary

- Updates `POST /itx/meetings` and `POST /itx/past_meetings` RuleSet rules to check `relation: meetings_creator` instead of `relation: writer` on `project:{project_uid}`.
- The FGA model (being updated in [lfx-v2-helm#127](https://github.com/linuxfoundation/lfx-v2-helm/pull/127)) adds a new `meetings_creator = writer or meeting_coordinator` union relation on `project`. These RuleSet rules must match so that `meeting_coordinator` role holders can create meetings without needing the broader `writer` role.

## Jira

[LFXV2-1431](https://linuxfoundation.atlassian.net/browse/LFXV2-1431) — FGA model audit fixes (Bug 2: add `meetings_creator` relation)

## Notes

- **Draft** — depends on lfx-v2-helm#127 landing first. Mark ready once the model PR is merged.
- No Go code changes; only the Helm RuleSet template is affected.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot) (via OpenCode)

[LFXV2-1431]: https://linuxfoundation.atlassian.net/browse/LFXV2-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ