### PR TITLE
[LFXV2-1540] feat: index committee UIDs on meeting child resources

### DIFF
--- a/cmd/meeting-api/eventing/attachment_event_handler.go
+++ b/cmd/meeting-api/eventing/attachment_event_handler.go
@@ -111,11 +111,11 @@ func (h *EventHandlers) handleMeetingAttachmentUpdate(
 	}
 	funcLogger = funcLogger.With("attachment_uid", attachmentData.UID, "meeting_id", attachmentData.MeetingID)
 
-	// Look up project UID from parent meeting.
-	// lookupProjectFromMeeting returns ("", nil) both when the meeting record is missing
+	// Look up project UID and primary committee SFID from parent meeting.
+	// lookupProjectFromMeeting returns ("","",nil) both when the meeting record is missing
 	// and when the meeting has no proj_id, so we distinguish the two cases to decide
 	// whether to retry or permanently skip.
-	projSFID, err := lookupProjectFromMeeting(ctx, attachmentData.MeetingID, h.v1ObjectsKV, funcLogger)
+	projSFID, primaryCommitteeSFID, err := lookupProjectFromMeeting(ctx, attachmentData.MeetingID, h.v1ObjectsKV, funcLogger)
 	if err != nil {
 		funcLogger.With(logging.ErrKey, err).WarnContext(ctx, "transient error looking up parent meeting, will retry")
 		return true
@@ -141,6 +141,7 @@ func (h *EventHandlers) handleMeetingAttachmentUpdate(
 		return false
 	}
 	attachmentData.ProjectUID = projectUID
+	attachmentData.Committees = resolveParentMeetingCommittees(ctx, attachmentData.MeetingID, primaryCommitteeSFID, h.idMapper, h.v1MappingsKV, funcLogger)
 
 	// Look up project slug from the projects API via NATS.
 	// An empty slug (no error) means no slug could be resolved (project not found or has no slug) — proceed without it.

--- a/cmd/meeting-api/eventing/attachment_event_handler.go
+++ b/cmd/meeting-api/eventing/attachment_event_handler.go
@@ -112,9 +112,9 @@ func (h *EventHandlers) handleMeetingAttachmentUpdate(
 	funcLogger = funcLogger.With("attachment_uid", attachmentData.UID, "meeting_id", attachmentData.MeetingID)
 
 	// Look up project UID and primary committee SFID from parent meeting.
-	// lookupProjectFromMeeting returns ("","",nil) both when the meeting record is missing
-	// and when the meeting has no proj_id, so we distinguish the two cases to decide
-	// whether to retry or permanently skip.
+	// lookupProjectFromMeeting returns ("","",nil) when the meeting record is missing.
+	// When the meeting exists but has no proj_id, projSFID is empty but primaryCommitteeSFID
+	// may still be populated — we distinguish the two proj_id cases to decide whether to retry.
 	projSFID, primaryCommitteeSFID, err := lookupProjectFromMeeting(ctx, attachmentData.MeetingID, h.v1ObjectsKV, funcLogger)
 	if err != nil {
 		funcLogger.With(logging.ErrKey, err).WarnContext(ctx, "transient error looking up parent meeting, will retry")
@@ -141,7 +141,12 @@ func (h *EventHandlers) handleMeetingAttachmentUpdate(
 		return false
 	}
 	attachmentData.ProjectUID = projectUID
-	attachmentData.Committees = resolveParentMeetingCommittees(ctx, attachmentData.MeetingID, primaryCommitteeSFID, h.idMapper, h.v1MappingsKV, funcLogger)
+	committees, commErr := resolveParentMeetingCommittees(ctx, attachmentData.MeetingID, primaryCommitteeSFID, h.idMapper, h.v1MappingsKV, funcLogger)
+	if commErr != nil {
+		funcLogger.With(logging.ErrKey, commErr).WarnContext(ctx, "transient error resolving parent committees for attachment, will retry")
+		return true
+	}
+	attachmentData.Committees = committees
 
 	// Look up project slug from the projects API via NATS.
 	// An empty slug (no error) means no slug could be resolved (project not found or has no slug) — proceed without it.

--- a/cmd/meeting-api/eventing/attachment_event_handler.go
+++ b/cmd/meeting-api/eventing/attachment_event_handler.go
@@ -336,10 +336,10 @@ func (h *EventHandlers) handlePastMeetingAttachmentUpdate(
 	}
 	funcLogger = funcLogger.With("attachment_uid", attachmentData.UID, "meeting_and_occurrence_id", attachmentData.MeetingAndOccurrenceID)
 
-	// Look up project info from the parent past meeting record.
-	// lookupProjectFromPastMeeting returns ("","",nil) for ErrKeyNotFound (permanent miss)
+	// Look up project info and primary committee SFID from the parent past meeting record.
+	// lookupProjectFromPastMeeting returns ("","","",nil) for ErrKeyNotFound (permanent miss)
 	// and a non-nil error for transient KV/decode failures.
-	projSFID, projectSlug, err := lookupProjectFromPastMeeting(ctx, attachmentData.MeetingAndOccurrenceID, h.v1ObjectsKV, funcLogger)
+	projSFID, projectSlug, primaryCommitteeSFID, err := lookupProjectFromPastMeeting(ctx, attachmentData.MeetingAndOccurrenceID, h.v1ObjectsKV, funcLogger)
 	if err != nil {
 		funcLogger.With(logging.ErrKey, err).WarnContext(ctx, "transient error looking up parent past meeting, will retry")
 		return true
@@ -359,6 +359,13 @@ func (h *EventHandlers) handlePastMeetingAttachmentUpdate(
 		return false
 	}
 	attachmentData.ProjectUID = projectUID
+
+	committees, commErr := resolveParentPastMeetingCommittees(ctx, attachmentData.MeetingAndOccurrenceID, primaryCommitteeSFID, h.idMapper, h.v1MappingsKV, funcLogger)
+	if commErr != nil {
+		funcLogger.With(logging.ErrKey, commErr).WarnContext(ctx, "transient error resolving parent committees for attachment, will retry")
+		return true
+	}
+	attachmentData.Committees = committees
 
 	// Determine action (created vs updated)
 	mappingKey := fmt.Sprintf("v1_past_meeting_attachments.%s", attachmentData.UID)

--- a/cmd/meeting-api/eventing/kv_helpers.go
+++ b/cmd/meeting-api/eventing/kv_helpers.go
@@ -13,34 +13,34 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-// lookupProjectFromMeeting fetches the proj_id of the parent active meeting from the v1-objects KV
-// bucket. Returns an empty string (no error) in two cases: (1) the meeting record is not found in
-// KV yet, or (2) the meeting exists but has no proj_id. Callers that need to distinguish between
-// these two cases should perform a follow-up KV lookup on ErrKeyNotFound. Returns a non-nil error
-// for transient KV/decode failures (caller should retry).
+// lookupProjectFromMeeting fetches the proj_id and primary committee SFID of the parent active
+// meeting from the v1-objects KV bucket. Returns empty strings (no error) in two cases: (1) the
+// meeting record is not found in KV yet, or (2) the meeting exists but has no proj_id. Callers
+// that need to distinguish between these two cases should perform a follow-up KV lookup on
+// ErrKeyNotFound. Returns a non-nil error for transient KV/decode failures (caller should retry).
 func lookupProjectFromMeeting(
 	ctx context.Context,
 	meetingID string,
 	v1ObjectsKV jetstream.KeyValue,
 	logger *slog.Logger,
-) (projSFID string, err error) {
+) (projSFID, primaryCommitteeSFID string, err error) {
 	if meetingID == "" {
-		return "", nil
+		return "", "", nil
 	}
 	meetingKey := fmt.Sprintf("itx-zoom-meetings-v2.%s", meetingID)
 	entry, kvErr := v1ObjectsKV.Get(ctx, meetingKey)
 	if kvErr != nil {
 		if errors.Is(kvErr, jetstream.ErrKeyNotFound) {
 			logger.WarnContext(ctx, "parent meeting not found in KV for project lookup", "key", meetingKey)
-			return "", nil
+			return "", "", nil
 		}
-		return "", fmt.Errorf("transient error fetching parent meeting: %w", kvErr)
+		return "", "", fmt.Errorf("transient error fetching parent meeting: %w", kvErr)
 	}
 	meetingData, decErr := decodeData(entry.Value())
 	if decErr != nil {
-		return "", fmt.Errorf("transient error decoding parent meeting: %w", decErr)
+		return "", "", fmt.Errorf("transient error decoding parent meeting: %w", decErr)
 	}
-	return utils.GetString(meetingData["proj_id"]), nil
+	return utils.GetString(meetingData["proj_id"]), utils.GetString(meetingData["committee"]), nil
 }
 
 // lookupProjectFromPastMeeting fetches the proj_id, project_slug, and primary committee SFID of

--- a/cmd/meeting-api/eventing/kv_helpers.go
+++ b/cmd/meeting-api/eventing/kv_helpers.go
@@ -43,31 +43,34 @@ func lookupProjectFromMeeting(
 	return utils.GetString(meetingData["proj_id"]), nil
 }
 
-// lookupProjectFromPastMeeting fetches the proj_id and project_slug of the parent past meeting
-// from the v1-objects KV bucket. Returns empty strings (no error) when the record is not found —
-// that is a permanent miss and the caller should not retry. Returns a non-nil error for transient
-// KV fetch failures or decode failures (caller should retry).
+// lookupProjectFromPastMeeting fetches the proj_id, project_slug, and primary committee SFID of
+// the parent past meeting from the v1-objects KV bucket. Returns empty strings (no error) when the
+// record is not found — that is a permanent miss and the caller should not retry. Returns a non-nil
+// error for transient KV fetch or decode failures (caller should retry).
 func lookupProjectFromPastMeeting(
 	ctx context.Context,
 	meetingAndOccurrenceID string,
 	v1ObjectsKV jetstream.KeyValue,
 	logger *slog.Logger,
-) (projSFID, projectSlug string, err error) {
+) (projSFID, projectSlug, primaryCommitteeSFID string, err error) {
 	if meetingAndOccurrenceID == "" {
-		return "", "", nil
+		return "", "", "", nil
 	}
 	pastMeetingKey := fmt.Sprintf("itx-zoom-past-meetings.%s", meetingAndOccurrenceID)
 	entry, kvErr := v1ObjectsKV.Get(ctx, pastMeetingKey)
 	if kvErr != nil {
 		if errors.Is(kvErr, jetstream.ErrKeyNotFound) {
 			logger.WarnContext(ctx, "parent past_meeting not found for project lookup", "key", pastMeetingKey)
-			return "", "", nil
+			return "", "", "", nil
 		}
-		return "", "", fmt.Errorf("transient error fetching parent past_meeting: %w", kvErr)
+		return "", "", "", fmt.Errorf("transient error fetching parent past_meeting: %w", kvErr)
 	}
 	pastMeetingData, decErr := decodeData(entry.Value())
 	if decErr != nil {
-		return "", "", fmt.Errorf("transient error decoding parent past_meeting: %w", decErr)
+		return "", "", "", fmt.Errorf("transient error decoding parent past_meeting: %w", decErr)
 	}
-	return utils.GetString(pastMeetingData["proj_id"]), utils.GetString(pastMeetingData["project_slug"]), nil
+	return utils.GetString(pastMeetingData["proj_id"]),
+		utils.GetString(pastMeetingData["project_slug"]),
+		utils.GetString(pastMeetingData["committee"]),
+		nil
 }

--- a/cmd/meeting-api/eventing/kv_helpers.go
+++ b/cmd/meeting-api/eventing/kv_helpers.go
@@ -9,15 +9,17 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/utils"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
 // lookupProjectFromMeeting fetches the proj_id and primary committee SFID of the parent active
-// meeting from the v1-objects KV bucket. Returns empty strings (no error) in two cases: (1) the
-// meeting record is not found in KV yet, or (2) the meeting exists but has no proj_id. Callers
-// that need to distinguish between these two cases should perform a follow-up KV lookup on
-// ErrKeyNotFound. Returns a non-nil error for transient KV/decode failures (caller should retry).
+// meeting from the v1-objects KV bucket. Returns ("","",nil) when the meeting record is not found
+// in KV yet. When the meeting exists but has no proj_id, projSFID is empty but primaryCommitteeSFID
+// may still be non-empty if the committee field is set. Callers that need to distinguish a missing
+// meeting from a meeting with no project should perform a follow-up KV lookup. Returns a non-nil
+// error for transient KV/decode failures (caller should retry).
 func lookupProjectFromMeeting(
 	ctx context.Context,
 	meetingID string,
@@ -34,11 +36,11 @@ func lookupProjectFromMeeting(
 			logger.WarnContext(ctx, "parent meeting not found in KV for project lookup", "key", meetingKey)
 			return "", "", nil
 		}
-		return "", "", fmt.Errorf("transient error fetching parent meeting: %w", kvErr)
+		return "", "", domain.NewUnavailableError("transient error fetching parent meeting", kvErr)
 	}
 	meetingData, decErr := decodeData(entry.Value())
 	if decErr != nil {
-		return "", "", fmt.Errorf("transient error decoding parent meeting: %w", decErr)
+		return "", "", domain.NewUnavailableError("transient error decoding parent meeting", decErr)
 	}
 	return utils.GetString(meetingData["proj_id"]), utils.GetString(meetingData["committee"]), nil
 }
@@ -63,11 +65,11 @@ func lookupProjectFromPastMeeting(
 			logger.WarnContext(ctx, "parent past_meeting not found for project lookup", "key", pastMeetingKey)
 			return "", "", "", nil
 		}
-		return "", "", "", fmt.Errorf("transient error fetching parent past_meeting: %w", kvErr)
+		return "", "", "", domain.NewUnavailableError("transient error fetching parent past_meeting", kvErr)
 	}
 	pastMeetingData, decErr := decodeData(entry.Value())
 	if decErr != nil {
-		return "", "", "", fmt.Errorf("transient error decoding parent past_meeting: %w", decErr)
+		return "", "", "", domain.NewUnavailableError("transient error decoding parent past_meeting", decErr)
 	}
 	return utils.GetString(pastMeetingData["proj_id"]),
 		utils.GetString(pastMeetingData["project_slug"]),

--- a/cmd/meeting-api/eventing/meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler.go
@@ -1026,6 +1026,29 @@ func getCommitteesForMeeting(
 	return committees
 }
 
+// resolveParentMeetingCommittees returns the fully-resolved committee list for an active meeting,
+// matching the shape MeetingEventData.Committees is populated with. Combines the v1-mappings KV
+// lookup with the primary-committee fallback from the meeting row itself.
+func resolveParentMeetingCommittees(
+	ctx context.Context,
+	meetingID string,
+	primaryCommitteeSFID string,
+	idMapper domain.IDMapper,
+	mappingsKV jetstream.KeyValue,
+	logger *slog.Logger,
+) []models.Committee {
+	committees := getCommitteesForMeeting(ctx, meetingID, idMapper, mappingsKV, logger)
+	if len(committees) == 0 && primaryCommitteeSFID != "" {
+		uid, err := idMapper.MapCommitteeV1ToV2(ctx, primaryCommitteeSFID)
+		if err != nil {
+			logger.With(logging.ErrKey, err).WarnContext(ctx, "failed to map primary committee ID for parent meeting", "v1_id", primaryCommitteeSFID)
+		} else if uid != "" {
+			committees = []models.Committee{{UID: uid}}
+		}
+	}
+	return committees
+}
+
 func updateCommitteeMappings(
 	ctx context.Context,
 	meetingID string,

--- a/cmd/meeting-api/eventing/meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler.go
@@ -754,7 +754,10 @@ func convertMapToMeetingData(
 	}
 	meeting.ProjectUID = projectUID
 
-	committees := getCommitteesForMeeting(ctx, rawMeeting.MeetingID, idMapper, mappingsKV, logger)
+	committees, err := getCommitteesForMeeting(ctx, rawMeeting.MeetingID, idMapper, mappingsKV, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch committee mappings (transient): %w", err)
+	}
 	meeting.Committees = committees
 
 	// Map the primary committee v1 ID to v2 UID
@@ -986,23 +989,24 @@ func getCommitteesForMeeting(
 	idMapper domain.IDMapper,
 	mappingsKV jetstream.KeyValue,
 	logger *slog.Logger,
-) []models.Committee {
+) ([]models.Committee, error) {
 	key := fmt.Sprintf("v1-mappings.meeting-mappings.%s", meetingID)
 	entry, err := mappingsKV.Get(ctx, key)
 	if err != nil {
 		if !errors.Is(err, jetstream.ErrKeyNotFound) {
 			logger.With(logging.ErrKey, err).WarnContext(ctx, "failed to load meeting committee mappings", "key", key)
+			return nil, fmt.Errorf("failed to load meeting committee mappings: %w", err)
 		}
-		return nil
+		return nil, nil
 	}
 	if string(entry.Value()) == tombstoneMarker {
-		return nil
+		return nil, nil
 	}
 
 	var mappings map[string]map[string]interface{}
 	if err := json.Unmarshal(entry.Value(), &mappings); err != nil {
 		logger.With(logging.ErrKey, err).WarnContext(ctx, "failed to unmarshal committee mappings")
-		return nil
+		return nil, nil
 	}
 
 	committees := make([]models.Committee, 0, len(mappings))
@@ -1023,7 +1027,7 @@ func getCommitteesForMeeting(
 		}
 	}
 
-	return committees
+	return committees, nil
 }
 
 // resolveParentMeetingCommittees returns the fully-resolved committee list for an active meeting,
@@ -1036,17 +1040,23 @@ func resolveParentMeetingCommittees(
 	idMapper domain.IDMapper,
 	mappingsKV jetstream.KeyValue,
 	logger *slog.Logger,
-) []models.Committee {
-	committees := getCommitteesForMeeting(ctx, meetingID, idMapper, mappingsKV, logger)
+) ([]models.Committee, error) {
+	committees, err := getCommitteesForMeeting(ctx, meetingID, idMapper, mappingsKV, logger)
+	if err != nil {
+		return nil, err
+	}
 	if len(committees) == 0 && primaryCommitteeSFID != "" {
-		uid, err := idMapper.MapCommitteeV1ToV2(ctx, primaryCommitteeSFID)
-		if err != nil {
-			logger.With(logging.ErrKey, err).WarnContext(ctx, "failed to map primary committee ID for parent meeting", "v1_id", primaryCommitteeSFID)
+		uid, mapErr := idMapper.MapCommitteeV1ToV2(ctx, primaryCommitteeSFID)
+		if mapErr != nil {
+			if domain.GetErrorType(mapErr) != domain.ErrorTypeValidation {
+				return nil, fmt.Errorf("failed to map primary committee ID for parent meeting (transient): %w", mapErr)
+			}
+			logger.With(logging.ErrKey, mapErr).WarnContext(ctx, "primary committee mapping not found for parent meeting", "v1_id", primaryCommitteeSFID)
 		} else if uid != "" {
 			committees = []models.Committee{{UID: uid}}
 		}
 	}
-	return committees
+	return committees, nil
 }
 
 func updateCommitteeMappings(

--- a/cmd/meeting-api/eventing/participant_event_handler.go
+++ b/cmd/meeting-api/eventing/participant_event_handler.go
@@ -903,7 +903,7 @@ func resolveProjectFields(
 		return projectSFID, projectSlug, nil
 	}
 
-	sfid, slug, err := lookupProjectFromPastMeeting(ctx, meetingAndOccurrenceID, v1ObjectsKV, logger)
+	sfid, slug, _, err := lookupProjectFromPastMeeting(ctx, meetingAndOccurrenceID, v1ObjectsKV, logger)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to lookup project from parent past_meeting (transient): %w", err)
 	}

--- a/cmd/meeting-api/eventing/past_meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/past_meeting_event_handler.go
@@ -613,6 +613,34 @@ func getCommitteesForPastMeeting(
 	return committees, nil
 }
 
+// resolveParentPastMeetingCommittees returns the fully-resolved committee list for a past meeting,
+// matching the shape PastMeetingEventData.Committees is populated with. Combines the v1-mappings KV
+// lookup with the primary-committee fallback from the past-meeting row itself.
+func resolveParentPastMeetingCommittees(
+	ctx context.Context,
+	meetingAndOccurrenceID string,
+	primaryCommitteeSFID string,
+	idMapper domain.IDMapper,
+	mappingsKV jetstream.KeyValue,
+	logger *slog.Logger,
+) ([]models.Committee, error) {
+	committees, err := getCommitteesForPastMeeting(ctx, meetingAndOccurrenceID, idMapper, mappingsKV, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(committees) == 0 && primaryCommitteeSFID != "" {
+		uid, mapErr := idMapper.MapCommitteeV1ToV2(ctx, primaryCommitteeSFID)
+		if mapErr != nil {
+			logger.With(logging.ErrKey, mapErr).WarnContext(ctx, "failed to map primary committee ID for parent past meeting", "v1_id", primaryCommitteeSFID)
+		} else if uid != "" {
+			committees = []models.Committee{{UID: uid}}
+		}
+	}
+
+	return committees, nil
+}
+
 func updatePastMeetingCommitteeMappings(
 	ctx context.Context,
 	pastMeetingUUID string,

--- a/cmd/meeting-api/eventing/past_meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/past_meeting_event_handler.go
@@ -632,7 +632,10 @@ func resolveParentPastMeetingCommittees(
 	if len(committees) == 0 && primaryCommitteeSFID != "" {
 		uid, mapErr := idMapper.MapCommitteeV1ToV2(ctx, primaryCommitteeSFID)
 		if mapErr != nil {
-			logger.With(logging.ErrKey, mapErr).WarnContext(ctx, "failed to map primary committee ID for parent past meeting", "v1_id", primaryCommitteeSFID)
+			if domain.GetErrorType(mapErr) != domain.ErrorTypeValidation {
+				return nil, fmt.Errorf("failed to map primary committee ID for parent past meeting (transient): %w", mapErr)
+			}
+			logger.With(logging.ErrKey, mapErr).WarnContext(ctx, "primary committee mapping not found for parent past meeting", "v1_id", primaryCommitteeSFID)
 		} else if uid != "" {
 			committees = []models.Committee{{UID: uid}}
 		}

--- a/cmd/meeting-api/eventing/recording_event_handler.go
+++ b/cmd/meeting-api/eventing/recording_event_handler.go
@@ -262,6 +262,22 @@ func (h *EventHandlers) handlePastMeetingRecordingUpdate(
 	}
 	funcLogger = funcLogger.With("recording_id", recordingData.ID)
 
+	// Resolve committees from the parent past meeting record.
+	_, _, primaryCommitteeSFID, lookupErr := lookupProjectFromPastMeeting(ctx, recordingData.MeetingAndOccurrenceID, h.v1ObjectsKV, funcLogger)
+	if lookupErr != nil {
+		funcLogger.With(logging.ErrKey, lookupErr).WarnContext(ctx, "transient error fetching parent past meeting for committees, will retry")
+		return true
+	}
+	committees, commErr := resolveParentPastMeetingCommittees(ctx, recordingData.MeetingAndOccurrenceID, primaryCommitteeSFID, h.idMapper, h.v1MappingsKV, funcLogger)
+	if commErr != nil {
+		funcLogger.With(logging.ErrKey, commErr).WarnContext(ctx, "transient error resolving parent committees for recording, will retry")
+		return true
+	}
+	recordingData.Committees = committees
+	if transcriptData != nil {
+		transcriptData.Committees = committees
+	}
+
 	// Determine action (created vs updated)
 	mappingKey := fmt.Sprintf("v1_past_meeting_recordings.%s", recordingData.ID)
 	indexerAction := indexerConstants.ActionCreated

--- a/cmd/meeting-api/eventing/summary_event_handler.go
+++ b/cmd/meeting-api/eventing/summary_event_handler.go
@@ -201,6 +201,7 @@ func (h *EventHandlers) handlePastMeetingSummaryUpdate(
 		aiSummaryAccess = access
 	}
 	projSFID := utils.GetString(pastMeetingData["proj_id"])
+	primaryCommitteeSFID := utils.GetString(pastMeetingData["committee"])
 	summaryData.ProjectSlug = utils.GetString(pastMeetingData["project_slug"])
 	if projSFID != "" {
 		projectUID, mapErr := h.idMapper.MapProjectV1ToV2(ctx, projSFID)
@@ -216,6 +217,13 @@ func (h *EventHandlers) handlePastMeetingSummaryUpdate(
 		funcLogger.WarnContext(ctx, "skipping summary: project not yet in v2")
 		return false
 	}
+
+	committees, commErr := resolveParentPastMeetingCommittees(ctx, summaryData.MeetingAndOccurrenceID, primaryCommitteeSFID, h.idMapper, h.v1MappingsKV, funcLogger)
+	if commErr != nil {
+		funcLogger.With(logging.ErrKey, commErr).WarnContext(ctx, "transient error resolving parent committees for summary, will retry")
+		return true
+	}
+	summaryData.Committees = committees
 
 	// Publish to indexer and FGA-sync
 	if err := h.publisher.PublishPastMeetingSummaryEvent(ctx, string(indexerAction), summaryData, aiSummaryAccess); err != nil {

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -567,6 +567,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
 | `start_time` | string (RFC3339) | Recording start time |
 | `total_size` | int64 | Total size of all recording files in bytes |
+| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
@@ -607,8 +608,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform:Zoom` | `platform:Zoom` | All recordings (platform is always Zoom) |
 | `platform_meeting_id:{value}` | `platform_meeting_id:93699735000` | Find recordings by Zoom meeting ID |
 | `platform_meeting_instance_id:{uuid}` | `platform_meeting_instance_id:abc...` | Find recordings by Zoom session UUID |
+| `committee_uid:{value}` | `committee_uid:abc123...` | Find recordings by committee |
 
-> One `platform_meeting_instance_id` tag is emitted per session in `sessions`.
+> One `platform_meeting_instance_id` tag is emitted per session in `sessions`. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -633,6 +635,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Ref | Condition |
 |---|---|
 | `past_meeting:{meeting_and_occurrence_id}` | Always set |
+| `project:{project_uid}` | Set when `project_uid` is non-empty |
+| `committee:{uid}` | Set once per entry in `committees` with a non-empty `uid` |
 
 ---
 
@@ -666,6 +670,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
 | `start_time` | string (RFC3339) | Transcript start time |
 | `total_size` | int64 | Total size in bytes |
+| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
@@ -680,8 +685,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find transcripts for a past meeting |
 | `platform:Zoom` | `platform:Zoom` | All transcripts (platform is always Zoom) |
 | `platform_meeting_instance_id:{uuid}` | `platform_meeting_instance_id:abc...` | Find transcripts by Zoom session UUID |
+| `committee_uid:{value}` | `committee_uid:abc123...` | Find transcripts by committee |
 
-> One `platform_meeting_instance_id` tag is emitted per session in `sessions`.
+> One `platform_meeting_instance_id` tag is emitted per session in `sessions`. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -706,6 +712,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Ref | Condition |
 |---|---|
 | `past_meeting:{meeting_and_occurrence_id}` | Always set |
+| `project:{project_uid}` | Set when `project_uid` is non-empty |
+| `committee:{uid}` | Set once per entry in `committees` with a non-empty `uid` |
 
 ---
 
@@ -747,6 +755,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform` | string | Meeting platform (always `"Zoom"`) |
 | `zoom_config` | object | Zoom identifiers (has `meeting_id` string and `meeting_uuid` string) |
 | `email_sent` | bool | Whether a summary notification email has been sent |
+| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
@@ -762,8 +771,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `meeting_id:{value}` | `meeting_id:93699735000` | Find summaries for a meeting |
 | `platform:Zoom` | `platform:Zoom` | All summaries (platform is always Zoom) |
 | `title:{value}` | `title:TSC Monthly Meeting` | Find summaries by Zoom meeting topic |
+| `committee_uid:{value}` | `committee_uid:abc123...` | Find summaries by committee |
 
-> `title` tag uses `zoom_meeting_topic` and is only emitted when non-empty.
+> `title` tag uses `zoom_meeting_topic` and is only emitted when non-empty. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -788,6 +798,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Ref | Condition |
 |---|---|
 | `past_meeting:{meeting_and_occurrence_id}` | Always set |
+| `project:{project_uid}` | Set when `project_uid` is non-empty |
+| `committee:{uid}` | Set once per entry in `committees` with a non-empty `uid` |
 
 ---
 
@@ -900,6 +912,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_content_type` | string (optional) | MIME content type |
 | `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
 | `file_uploaded_at` | string (RFC3339) (optional) | Time the file was uploaded |
+| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `modified_at` | string (RFC3339) | Last modification time |
 | `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
@@ -915,8 +928,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `project_uid:{value}` | `project_uid:abc123...` | Find attachments by project |
 | `project_slug:{value}` | `project_slug:my-project` | Find attachments by project slug |
 | `type:{value}` | `type:link` | Find attachments by type |
+| `committee_uid:{value}` | `committee_uid:abc123...` | Find attachments by committee |
 
-> `project_uid`, `project_slug`, and `type` tags are only emitted when non-empty.
+> `project_uid`, `project_slug`, `type`, and `committee_uid` tags are only emitted when non-empty. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -942,3 +956,4 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 |---|---|
 | `past_meeting:{meeting_and_occurrence_id}` | Always set |
 | `project:{project_uid}` | Set when `project_uid` is non-empty |
+| `committee:{uid}` | Set once per entry in `committees` with a non-empty `uid` |

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -835,6 +835,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_content_type` | string (optional) | MIME content type |
 | `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
 | `file_uploaded_at` | string (RFC3339) (optional) | Time the file was uploaded |
+| `committees` | []object | Associated committees sourced from the parent meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `modified_at` | string (RFC3339) | Last modification time |
 | `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
@@ -849,8 +850,9 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `project_uid:{value}` | `project_uid:abc123...` | Find attachments by project |
 | `project_slug:{value}` | `project_slug:cncf` | Find attachments by project slug |
 | `type:{value}` | `type:file` | Find attachments by type |
+| `committee_uid:{value}` | `committee_uid:abc123...` | Find attachments by committee |
 
-> `project_uid`, `project_slug`, and `type` tags are only emitted when non-empty. `project_slug` is resolved at event-processing time via the `lfx.projects-api.get_slug` NATS subject.
+> `project_uid`, `project_slug`, `type`, and `committee_uid` tags are only emitted when non-empty. `project_slug` is resolved at event-processing time via the `lfx.projects-api.get_slug` NATS subject. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -876,6 +878,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 |---|---|
 | `meeting:{meeting_id}` | Always set |
 | `project:{project_uid}` | Set when `project_uid` is non-empty |
+| `committee:{uid}` | Set once per entry in `committees` with a non-empty `uid` |
 
 ---
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -567,7 +567,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
 | `start_time` | string (RFC3339) | Recording start time |
 | `total_size` | int64 | Total size of all recording files in bytes |
-| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
@@ -670,7 +670,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `sessions` | []object | Recording sessions (see [Recording Session schema](#recording-session-schema)) |
 | `start_time` | string (RFC3339) | Transcript start time |
 | `total_size` | int64 | Total size in bytes |
-| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
@@ -755,7 +755,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform` | string | Meeting platform (always `"Zoom"`) |
 | `zoom_config` | object | Zoom identifiers (has `meeting_id` string and `meeting_uuid` string) |
 | `email_sent` | bool | Whether a summary notification email has been sent |
-| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 | `created_by` | object | User who created the record (see [User Reference schema](#user-reference-schema)) |
@@ -835,7 +835,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_content_type` | string (optional) | MIME content type |
 | `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
 | `file_uploaded_at` | string (RFC3339) (optional) | Time the file was uploaded |
-| `committees` | []object | Associated committees sourced from the parent meeting (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees sourced from the parent meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `modified_at` | string (RFC3339) | Last modification time |
 | `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |
@@ -915,7 +915,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `file_content_type` | string (optional) | MIME content type |
 | `file_uploaded_by` | object (optional) | User who uploaded the file (see [User Reference schema](#user-reference-schema)) |
 | `file_uploaded_at` | string (RFC3339) (optional) | Time the file was uploaded |
-| `committees` | []object | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
+| `committees` | []object (optional) | Associated committees sourced from the parent past meeting (see [Committee schema](#committee-schema)) |
 | `created_at` | string (RFC3339) | Creation time |
 | `modified_at` | string (RFC3339) | Last modification time |
 | `created_by` | object | User who created the attachment (see [User Reference schema](#user-reference-schema)) |

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -1178,28 +1178,29 @@ type SummaryZoomConfig struct {
 
 // MeetingAttachmentEventData represents an attachment on an active meeting
 type MeetingAttachmentEventData struct {
-	UID              string     `json:"uid"`
-	MeetingID        string     `json:"meeting_id"`
-	ProjectUID       string     `json:"project_uid,omitempty"`
-	ProjectSlug      string     `json:"project_slug,omitempty"`
-	Type             string     `json:"type"`
-	Category         string     `json:"category,omitempty"`
-	Link             string     `json:"link,omitempty"`
-	Name             string     `json:"name"`
-	Description      string     `json:"description,omitempty"`
-	Source           string     `json:"source,omitempty"`
-	FileName         string     `json:"file_name,omitempty"`
-	FileSize         int        `json:"file_size,omitempty"`
-	FileURL          string     `json:"file_url,omitempty"`
-	FileUploaded     *bool      `json:"file_uploaded,omitempty"`
-	FileUploadStatus string     `json:"file_upload_status,omitempty"`
-	FileContentType  string     `json:"file_content_type,omitempty"`
-	FileUploadedBy   *CreatedBy `json:"file_uploaded_by,omitempty"`
-	FileUploadedAt   *time.Time `json:"file_uploaded_at,omitempty"`
-	CreatedAt        time.Time  `json:"created_at"`
-	ModifiedAt       time.Time  `json:"modified_at"`
-	CreatedBy        CreatedBy  `json:"created_by"`
-	UpdatedBy        UpdatedBy  `json:"updated_by"`
+	UID              string      `json:"uid"`
+	MeetingID        string      `json:"meeting_id"`
+	ProjectUID       string      `json:"project_uid,omitempty"`
+	ProjectSlug      string      `json:"project_slug,omitempty"`
+	Type             string      `json:"type"`
+	Category         string      `json:"category,omitempty"`
+	Link             string      `json:"link,omitempty"`
+	Name             string      `json:"name"`
+	Description      string      `json:"description,omitempty"`
+	Source           string      `json:"source,omitempty"`
+	FileName         string      `json:"file_name,omitempty"`
+	FileSize         int         `json:"file_size,omitempty"`
+	FileURL          string      `json:"file_url,omitempty"`
+	FileUploaded     *bool       `json:"file_uploaded,omitempty"`
+	FileUploadStatus string      `json:"file_upload_status,omitempty"`
+	FileContentType  string      `json:"file_content_type,omitempty"`
+	FileUploadedBy   *CreatedBy  `json:"file_uploaded_by,omitempty"`
+	FileUploadedAt   *time.Time  `json:"file_uploaded_at,omitempty"`
+	Committees       []Committee `json:"committees"`
+	CreatedAt        time.Time   `json:"created_at"`
+	ModifiedAt       time.Time   `json:"modified_at"`
+	CreatedBy        CreatedBy   `json:"created_by"`
+	UpdatedBy        UpdatedBy   `json:"updated_by"`
 }
 
 // SortName returns the primary sort name for this meeting attachment.
@@ -1252,6 +1253,11 @@ func (a *MeetingAttachmentEventData) Tags() []string {
 	if a.Type != "" {
 		tags = append(tags, "type:"+a.Type)
 	}
+	for _, c := range a.Committees {
+		if c.UID != "" {
+			tags = append(tags, "committee_uid:"+c.UID)
+		}
+	}
 	return tags
 }
 
@@ -1260,6 +1266,11 @@ func (a *MeetingAttachmentEventData) ParentRefs() []string {
 	refs := []string{"meeting:" + a.MeetingID}
 	if a.ProjectUID != "" {
 		refs = append(refs, "project:"+a.ProjectUID)
+	}
+	for _, c := range a.Committees {
+		if c.UID != "" {
+			refs = append(refs, "committee:"+c.UID)
+		}
 	}
 	return refs
 }

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -663,7 +663,7 @@ type PastMeetingEventData struct {
 	Duration                 int                  `json:"duration"` // Actual duration in minutes
 	Timezone                 string               `json:"timezone"`
 	MeetingType              string               `json:"meeting_type,omitempty"`
-	Committees               []Committee          `json:"committees"`
+	Committees               []Committee          `json:"committees,omitempty"`
 	Visibility               string               `json:"visibility,omitempty"`
 	ArtifactVisibility       string               `json:"artifact_visibility,omitempty"`
 	Restricted               bool                 `json:"restricted"`
@@ -886,7 +886,7 @@ type RecordingEventData struct {
 	Sessions               []RecordingSession `json:"sessions"`
 	StartTime              time.Time          `json:"start_time"`
 	TotalSize              int64              `json:"total_size"`
-	Committees             []Committee        `json:"committees"`
+	Committees             []Committee        `json:"committees,omitempty"`
 	CreatedAt              time.Time          `json:"created_at"`
 	UpdatedAt              time.Time          `json:"updated_at"`
 	CreatedBy              CreatedBy          `json:"created_by"`
@@ -1000,7 +1000,7 @@ type TranscriptEventData struct {
 	Sessions               []RecordingSession `json:"sessions"`
 	StartTime              time.Time          `json:"start_time"`
 	TotalSize              int64              `json:"total_size"`
-	Committees             []Committee        `json:"committees"`
+	Committees             []Committee        `json:"committees,omitempty"`
 	CreatedAt              time.Time          `json:"created_at"`
 	UpdatedAt              time.Time          `json:"updated_at"`
 	CreatedBy              CreatedBy          `json:"created_by"`
@@ -1097,7 +1097,7 @@ type SummaryEventData struct {
 	Platform                string            `json:"platform"` // Always "Zoom"
 	ZoomConfig              SummaryZoomConfig `json:"zoom_config"`
 	EmailSent               bool              `json:"email_sent"`
-	Committees              []Committee       `json:"committees"`
+	Committees              []Committee       `json:"committees,omitempty"`
 	CreatedAt               time.Time         `json:"created_at"`
 	UpdatedAt               time.Time         `json:"updated_at"`
 	CreatedBy               CreatedBy         `json:"created_by"`
@@ -1196,7 +1196,7 @@ type MeetingAttachmentEventData struct {
 	FileContentType  string      `json:"file_content_type,omitempty"`
 	FileUploadedBy   *CreatedBy  `json:"file_uploaded_by,omitempty"`
 	FileUploadedAt   *time.Time  `json:"file_uploaded_at,omitempty"`
-	Committees       []Committee `json:"committees"`
+	Committees       []Committee `json:"committees,omitempty"`
 	CreatedAt        time.Time   `json:"created_at"`
 	ModifiedAt       time.Time   `json:"modified_at"`
 	CreatedBy        CreatedBy   `json:"created_by"`
@@ -1296,7 +1296,7 @@ type PastMeetingAttachmentEventData struct {
 	FileContentType        string      `json:"file_content_type,omitempty"`
 	FileUploadedBy         *CreatedBy  `json:"file_uploaded_by,omitempty"`
 	FileUploadedAt         *time.Time  `json:"file_uploaded_at,omitempty"`
-	Committees             []Committee `json:"committees"`
+	Committees             []Committee `json:"committees,omitempty"`
 	CreatedAt              time.Time   `json:"created_at"`
 	ModifiedAt             time.Time   `json:"modified_at"`
 	CreatedBy              CreatedBy   `json:"created_by"`

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -886,6 +886,7 @@ type RecordingEventData struct {
 	Sessions               []RecordingSession `json:"sessions"`
 	StartTime              time.Time          `json:"start_time"`
 	TotalSize              int64              `json:"total_size"`
+	Committees             []Committee        `json:"committees"`
 	CreatedAt              time.Time          `json:"created_at"`
 	UpdatedAt              time.Time          `json:"updated_at"`
 	CreatedBy              CreatedBy          `json:"created_by"`
@@ -936,6 +937,11 @@ func (r *RecordingEventData) Tags() []string {
 	for _, session := range r.Sessions {
 		tags = append(tags, "platform_meeting_instance_id:"+session.UUID)
 	}
+	for _, c := range r.Committees {
+		if c.UID != "" {
+			tags = append(tags, "committee_uid:"+c.UID)
+		}
+	}
 	return tags
 }
 
@@ -944,6 +950,11 @@ func (r *RecordingEventData) ParentRefs() []string {
 	refs := []string{"past_meeting:" + r.MeetingAndOccurrenceID}
 	if r.ProjectUID != "" {
 		refs = append(refs, "project:"+r.ProjectUID)
+	}
+	for _, c := range r.Committees {
+		if c.UID != "" {
+			refs = append(refs, "committee:"+c.UID)
+		}
 	}
 	return refs
 }
@@ -989,6 +1000,7 @@ type TranscriptEventData struct {
 	Sessions               []RecordingSession `json:"sessions"`
 	StartTime              time.Time          `json:"start_time"`
 	TotalSize              int64              `json:"total_size"`
+	Committees             []Committee        `json:"committees"`
 	CreatedAt              time.Time          `json:"created_at"`
 	UpdatedAt              time.Time          `json:"updated_at"`
 	CreatedBy              CreatedBy          `json:"created_by"`
@@ -1038,6 +1050,11 @@ func (t *TranscriptEventData) Tags() []string {
 	for _, session := range t.Sessions {
 		tags = append(tags, "platform_meeting_instance_id:"+session.UUID)
 	}
+	for _, c := range t.Committees {
+		if c.UID != "" {
+			tags = append(tags, "committee_uid:"+c.UID)
+		}
+	}
 	return tags
 }
 
@@ -1046,6 +1063,11 @@ func (t *TranscriptEventData) ParentRefs() []string {
 	refs := []string{"past_meeting:" + t.MeetingAndOccurrenceID}
 	if t.ProjectUID != "" {
 		refs = append(refs, "project:"+t.ProjectUID)
+	}
+	for _, c := range t.Committees {
+		if c.UID != "" {
+			refs = append(refs, "committee:"+c.UID)
+		}
 	}
 	return refs
 }
@@ -1075,6 +1097,7 @@ type SummaryEventData struct {
 	Platform                string            `json:"platform"` // Always "Zoom"
 	ZoomConfig              SummaryZoomConfig `json:"zoom_config"`
 	EmailSent               bool              `json:"email_sent"`
+	Committees              []Committee       `json:"committees"`
 	CreatedAt               time.Time         `json:"created_at"`
 	UpdatedAt               time.Time         `json:"updated_at"`
 	CreatedBy               CreatedBy         `json:"created_by"`
@@ -1125,6 +1148,11 @@ func (s *SummaryEventData) Tags() []string {
 	if s.ZoomMeetingTopic != "" {
 		tags = append(tags, "title:"+s.ZoomMeetingTopic)
 	}
+	for _, c := range s.Committees {
+		if c.UID != "" {
+			tags = append(tags, "committee_uid:"+c.UID)
+		}
+	}
 	return tags
 }
 
@@ -1133,6 +1161,11 @@ func (s *SummaryEventData) ParentRefs() []string {
 	refs := []string{"past_meeting:" + s.MeetingAndOccurrenceID}
 	if s.ProjectUID != "" {
 		refs = append(refs, "project:"+s.ProjectUID)
+	}
+	for _, c := range s.Committees {
+		if c.UID != "" {
+			refs = append(refs, "committee:"+c.UID)
+		}
 	}
 	return refs
 }
@@ -1233,29 +1266,30 @@ func (a *MeetingAttachmentEventData) ParentRefs() []string {
 
 // PastMeetingAttachmentEventData represents an attachment on a past meeting
 type PastMeetingAttachmentEventData struct {
-	UID                    string     `json:"uid"`
-	MeetingAndOccurrenceID string     `json:"meeting_and_occurrence_id"`
-	MeetingID              string     `json:"meeting_id"`
-	ProjectUID             string     `json:"project_uid"`
-	ProjectSlug            string     `json:"project_slug"`
-	Type                   string     `json:"type"`
-	Category               string     `json:"category,omitempty"`
-	Link                   string     `json:"link,omitempty"`
-	Name                   string     `json:"name"`
-	Description            string     `json:"description,omitempty"`
-	Source                 string     `json:"source,omitempty"`
-	FileName               string     `json:"file_name,omitempty"`
-	FileSize               int        `json:"file_size,omitempty"`
-	FileURL                string     `json:"file_url,omitempty"`
-	FileUploaded           *bool      `json:"file_uploaded,omitempty"`
-	FileUploadStatus       string     `json:"file_upload_status,omitempty"`
-	FileContentType        string     `json:"file_content_type,omitempty"`
-	FileUploadedBy         *CreatedBy `json:"file_uploaded_by,omitempty"`
-	FileUploadedAt         *time.Time `json:"file_uploaded_at,omitempty"`
-	CreatedAt              time.Time  `json:"created_at"`
-	ModifiedAt             time.Time  `json:"modified_at"`
-	CreatedBy              CreatedBy  `json:"created_by"`
-	UpdatedBy              UpdatedBy  `json:"updated_by"`
+	UID                    string      `json:"uid"`
+	MeetingAndOccurrenceID string      `json:"meeting_and_occurrence_id"`
+	MeetingID              string      `json:"meeting_id"`
+	ProjectUID             string      `json:"project_uid"`
+	ProjectSlug            string      `json:"project_slug"`
+	Type                   string      `json:"type"`
+	Category               string      `json:"category,omitempty"`
+	Link                   string      `json:"link,omitempty"`
+	Name                   string      `json:"name"`
+	Description            string      `json:"description,omitempty"`
+	Source                 string      `json:"source,omitempty"`
+	FileName               string      `json:"file_name,omitempty"`
+	FileSize               int         `json:"file_size,omitempty"`
+	FileURL                string      `json:"file_url,omitempty"`
+	FileUploaded           *bool       `json:"file_uploaded,omitempty"`
+	FileUploadStatus       string      `json:"file_upload_status,omitempty"`
+	FileContentType        string      `json:"file_content_type,omitempty"`
+	FileUploadedBy         *CreatedBy  `json:"file_uploaded_by,omitempty"`
+	FileUploadedAt         *time.Time  `json:"file_uploaded_at,omitempty"`
+	Committees             []Committee `json:"committees"`
+	CreatedAt              time.Time   `json:"created_at"`
+	ModifiedAt             time.Time   `json:"modified_at"`
+	CreatedBy              CreatedBy   `json:"created_by"`
+	UpdatedBy              UpdatedBy   `json:"updated_by"`
 }
 
 // SortName returns the primary sort name for this past meeting attachment.
@@ -1309,6 +1343,11 @@ func (a *PastMeetingAttachmentEventData) Tags() []string {
 	if a.Type != "" {
 		tags = append(tags, "type:"+a.Type)
 	}
+	for _, c := range a.Committees {
+		if c.UID != "" {
+			tags = append(tags, "committee_uid:"+c.UID)
+		}
+	}
 	return tags
 }
 
@@ -1317,6 +1356,11 @@ func (a *PastMeetingAttachmentEventData) ParentRefs() []string {
 	refs := []string{"past_meeting:" + a.MeetingAndOccurrenceID}
 	if a.ProjectUID != "" {
 		refs = append(refs, "project:"+a.ProjectUID)
+	}
+	for _, c := range a.Committees {
+		if c.UID != "" {
+			refs = append(refs, "committee:"+c.UID)
+		}
 	}
 	return refs
 }


### PR DESCRIPTION
## Summary

Indexes committee UIDs on all meeting child resource types. Each child resource now inherits committee membership from its parent meeting, enabling committee-scoped queries and access control on these resources.

Committee data is resolved in two steps:
1. The committee-mapping index in the v1-mappings KV bucket is checked first (populated by meeting-committee mapping events)
2. If no mappings exist, the primary `committee` field on the parent meeting record is used as a fallback

### Objects changed

| Object type | New `data` field | New tag | New parent ref |
|---|---|---|---|
| `v1_meeting_attachment` | `committees []Committee` | `committee_uid:{uid}` | `committee:{uid}` |
| `v1_past_meeting_attachment` | `committees []Committee` | `committee_uid:{uid}` | `committee:{uid}` |
| `v1_past_meeting_recording` | `committees []Committee` | `committee_uid:{uid}` | `committee:{uid}`, `project:{project_uid}` |
| `v1_past_meeting_transcript` | `committees []Committee` | `committee_uid:{uid}` | `committee:{uid}`, `project:{project_uid}` |
| `v1_past_meeting_summary` | `committees []Committee` | `committee_uid:{uid}` | `committee:{uid}`, `project:{project_uid}` |

> One tag and one ref entry is emitted per committee. Recordings, transcripts, and summaries were also missing the `project:{project_uid}` parent ref — that is added here as well.

## Ticket

[LFXV2-1540](https://linuxfoundation.atlassian.net/browse/LFXV2-1540)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1540]: https://linuxfoundation.atlassian.net/browse/LFXV2-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ