### PR TITLE
[LFXV2-1547] Fix empty tags and parent refs; add missing committee_uid tags and refs

### DIFF
--- a/cmd/meeting-api/eventing/participant_event_handler.go
+++ b/cmd/meeting-api/eventing/participant_event_handler.go
@@ -695,6 +695,21 @@ func convertMapToInviteeParticipantData(
 		return nil, fmt.Errorf("failed to map project ID (transient): %w", err)
 	}
 
+	// Map the invitee's own committee_id to a v2 UID. Only set when the invitee record carries a
+	// committee_id — a missing mapping is non-fatal.
+	var committeeUID string
+	if rawInvitee.CommitteeID != "" {
+		uid, mapErr := idMapper.MapCommitteeV1ToV2(ctx, rawInvitee.CommitteeID)
+		if mapErr != nil {
+			if domain.GetErrorType(mapErr) != domain.ErrorTypeValidation {
+				return nil, fmt.Errorf("failed to map committee ID (transient): %w", mapErr)
+			}
+			logger.With(logging.ErrKey, mapErr).WarnContext(ctx, "committee mapping not found for invitee", "v1_id", rawInvitee.CommitteeID)
+		} else {
+			committeeUID = uid
+		}
+	}
+
 	// Determine if host (lookup registrant if available)
 	isHost := false
 	if rawInvitee.RegistrantID != "" {
@@ -748,6 +763,7 @@ func convertMapToInviteeParticipantData(
 		MeetingID:              rawInvitee.MeetingID,
 		ProjectUID:             projectUID,
 		ProjectSlug:            projectSlug,
+		CommitteeUID:           committeeUID,
 		Email:                  rawInvitee.Email,
 		FirstName:              firstName,
 		LastName:               lastName,
@@ -805,6 +821,21 @@ func convertMapToAttendeeParticipantData(
 	projectUID, err := idMapper.MapProjectV1ToV2(ctx, projectSFID)
 	if err != nil && domain.GetErrorType(err) != domain.ErrorTypeValidation {
 		return nil, fmt.Errorf("failed to map project ID (transient): %w", err)
+	}
+
+	// Map the attendee's own committee_id to a v2 UID. Only set when the attendee record carries a
+	// committee_id — a missing mapping is non-fatal.
+	var committeeUID string
+	if rawAttendee.CommitteeID != "" {
+		uid, mapErr := idMapper.MapCommitteeV1ToV2(ctx, rawAttendee.CommitteeID)
+		if mapErr != nil {
+			if domain.GetErrorType(mapErr) != domain.ErrorTypeValidation {
+				return nil, fmt.Errorf("failed to map committee ID (transient): %w", mapErr)
+			}
+			logger.With(logging.ErrKey, mapErr).WarnContext(ctx, "committee mapping not found for attendee", "v1_id", rawAttendee.CommitteeID)
+		} else {
+			committeeUID = uid
+		}
 	}
 
 	// Check if this user was also invited (registrant_id present)
@@ -867,6 +898,7 @@ func convertMapToAttendeeParticipantData(
 		MeetingID:              rawAttendee.MeetingID,
 		ProjectUID:             projectUID,
 		ProjectSlug:            projectSlug,
+		CommitteeUID:           committeeUID,
 		Email:                  rawAttendee.Email,
 		FirstName:              firstName,
 		LastName:               lastName,

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -483,6 +483,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `zoom_user_name` | string | Zoom display name of the attendee (attendee records only; `""` for invitee-only records) |
 | `mapped_invitee_name` | string | Full name of the invitee the attendee was auto-matched to (attendee records only; `""` for invitee-only records) |
 | `sessions` | []object (optional) | Join/leave sessions (each has `uid`, `join_time`, `leave_time`, `leave_reason`) |
+| `committee_uid` | string (optional) | v2 UUID of the committee the participant is associated with; sourced from the participant's own `committee_id` field |
 | `created_at` | string (RFC3339) | Creation time |
 | `updated_at` | string (RFC3339) | Last update time |
 
@@ -494,6 +495,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `meeting_and_occurrence_id:{value}` | `meeting_and_occurrence_id:93699735000:1700000000` | Find participants for a past meeting |
 | `project_uid:{value}` | `project_uid:cbef1ed5-...` | Find participants for a project |
 | `project_slug:{value}` | `project_slug:my-project` | Find participants by project slug |
+| `committee_uid:{value}` | `committee_uid:061a110a-...` | Find participants by committee |
 | `username:{value}` | `username:jdoe` | Find participants by username |
 | `email:{value}` | `email:jdoe@example.com` | Find participants by email |
 | `is_invited:true` | `is_invited:true` | Find invited participants |
@@ -523,6 +525,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 |---|---|
 | `past_meeting:{meeting_and_occurrence_id}` | Only when `meeting_and_occurrence_id` is non-empty |
 | `project:{project_uid}` | Only when `project_uid` is non-empty |
+| `committee:{committee_uid}` | Only when `committee_uid` is non-empty |
 
 ---
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -171,8 +171,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `title:{value}` | `title:TSC Monthly Meeting` | Find meetings by title |
 | `visibility:{value}` | `visibility:public` | Find meetings by visibility |
 | `meeting_type:{value}` | `meeting_type:recurring` | Find meetings by type |
-
-> `visibility` and `meeting_type` tags are only emitted when the value is non-empty.
+| `committee_uid:{value}` | `committee_uid:061a110a-...` | Find meetings by committee |
 
 ### Access Control (IndexingConfig)
 
@@ -196,7 +195,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 | Ref | Condition |
 |---|---|
-| `project:{project_uid}` | Always set |
+| `project:{project_uid}` | Only when `project_uid` is non-empty |
 | `committee:{uid}` | For each entry in `committees` with a non-empty `uid` |
 
 ---
@@ -251,11 +250,10 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Tag Format | Example | Purpose |
 |---|---|---|
 | `registrant_uid:{uid}` | `registrant_uid:a1b2c3d4-...` | Lookup by registrant UID |
+| `committee_uid:{value}` | `committee_uid:061a110a-...` | Find registrants by committee |
 | `username:{value}` | `username:jdoe` | Find registrants by username |
 | `email:{value}` | `email:jdoe@example.com` | Find registrants by email |
 | `host:true` | `host:true` | Find registrants who are hosts |
-
-> `username` and `email` tags are only emitted when non-empty. `host:true` is only emitted when `host` is `true`.
 
 ### Access Control (IndexingConfig)
 
@@ -279,7 +277,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 | Ref | Condition |
 |---|---|
-| `meeting:{meeting_id}` | Always set |
+| `meeting:{meeting_id}` | Only when `meeting_id` is non-empty |
 | `committee:{committee_uid}` | Only when `committee_uid` is non-empty |
 
 ---
@@ -328,8 +326,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `email:{value}` | `email:jdoe@example.com` | Find RSVPs by email |
 | `username:{value}` | `username:jdoe` | Find RSVPs by username |
 
-> `username` is only emitted when non-empty.
-
 ### Access Control (IndexingConfig)
 
 | Field | Value |
@@ -352,7 +348,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 | Ref | Condition |
 |---|---|
-| `meeting:{meeting_id}` | Always set |
+| `meeting:{meeting_id}` | Only when `meeting_id` is non-empty |
 
 ---
 
@@ -423,8 +419,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `timezone:{value}` | `timezone:America/Los_Angeles` | Find past meetings by timezone |
 | `committee_uid:{value}` | `committee_uid:061a110a-...` | Find past meetings for a committee |
 
-> `timezone` is only emitted when non-empty. One `committee_uid` tag is emitted per committee in `committees` with a non-empty `uid`.
-
 ### Access Control (IndexingConfig)
 
 | Field | Value |
@@ -447,7 +441,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 | Ref | Condition |
 |---|---|
-| `project:{project_uid}` | Always set |
+| `project:{project_uid}` | Only when `project_uid` is non-empty |
 | `committee:{uid}` | For each entry in `committees` with a non-empty `uid` |
 
 ---
@@ -505,8 +499,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `is_invited:true` | `is_invited:true` | Find invited participants |
 | `is_attended:true` | `is_attended:true` | Find attendees |
 
-> `project_slug`, `username`, and `email` tags are only emitted when non-empty. `is_invited:true` and `is_attended:true` are only emitted when the corresponding flag is `true`.
-
 ### Access Control (IndexingConfig)
 
 | Field | Value |
@@ -529,7 +521,8 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 | Ref | Condition |
 |---|---|
-| `past_meeting:{meeting_and_occurrence_id}` | Always set |
+| `past_meeting:{meeting_and_occurrence_id}` | Only when `meeting_and_occurrence_id` is non-empty |
+| `project:{project_uid}` | Only when `project_uid` is non-empty |
 
 ---
 
@@ -610,8 +603,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform_meeting_instance_id:{uuid}` | `platform_meeting_instance_id:abc...` | Find recordings by Zoom session UUID |
 | `committee_uid:{value}` | `committee_uid:abc123...` | Find recordings by committee |
 
-> One `platform_meeting_instance_id` tag is emitted per session in `sessions`. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
-
 ### Access Control (IndexingConfig)
 
 | Field | Value |
@@ -687,8 +678,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform_meeting_instance_id:{uuid}` | `platform_meeting_instance_id:abc...` | Find transcripts by Zoom session UUID |
 | `committee_uid:{value}` | `committee_uid:abc123...` | Find transcripts by committee |
 
-> One `platform_meeting_instance_id` tag is emitted per session in `sessions`. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
-
 ### Access Control (IndexingConfig)
 
 | Field | Value |
@@ -726,8 +715,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 **Source struct:** `internal/domain/models/event_models.go` — `SummaryEventData`
 
 **Indexed on:** create, update, delete of an AI-generated past meeting summary.
-
-> The `public` flag is derived from the **parent past meeting's** `ai_summary_access` field, not from a field on the summary itself.
 
 ### Data Schema
 
@@ -772,8 +759,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `platform:Zoom` | `platform:Zoom` | All summaries (platform is always Zoom) |
 | `title:{value}` | `title:TSC Monthly Meeting` | Find summaries by Zoom meeting topic |
 | `committee_uid:{value}` | `committee_uid:abc123...` | Find summaries by committee |
-
-> `title` tag uses `zoom_meeting_topic` and is only emitted when non-empty. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -851,8 +836,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `project_slug:{value}` | `project_slug:cncf` | Find attachments by project slug |
 | `type:{value}` | `type:file` | Find attachments by type |
 | `committee_uid:{value}` | `committee_uid:abc123...` | Find attachments by committee |
-
-> `project_uid`, `project_slug`, `type`, and `committee_uid` tags are only emitted when non-empty. `project_slug` is resolved at event-processing time via the `lfx.projects-api.get_slug` NATS subject. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 
@@ -932,8 +915,6 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `project_slug:{value}` | `project_slug:my-project` | Find attachments by project slug |
 | `type:{value}` | `type:link` | Find attachments by type |
 | `committee_uid:{value}` | `committee_uid:abc123...` | Find attachments by committee |
-
-> `project_uid`, `project_slug`, `type`, and `committee_uid` tags are only emitted when non-empty. One `committee_uid` tag is emitted per entry in `committees` with a non-empty `uid`.
 
 ### Access Control (IndexingConfig)
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -4,6 +4,8 @@ This document is the authoritative reference for all data the meeting service se
 
 **Update this document in the same PR as any change to indexer message construction.**
 
+**Convention:** Tags and parent refs containing a `{value}` placeholder are only emitted when the corresponding field is non-empty.
+
 ---
 
 ## Resource Types

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -385,9 +385,15 @@ func (m *MeetingEventData) Tags() []string {
 	if m.MeetingType != "" {
 		tags = append(tags, "meeting_type:"+m.MeetingType)
 	}
+	seenCommitteeUIDs := make(map[string]bool)
+	if m.CommitteeUID != "" {
+		tags = append(tags, "committee_uid:"+m.CommitteeUID)
+		seenCommitteeUIDs[m.CommitteeUID] = true
+	}
 	for _, c := range m.Committees {
-		if c.UID != "" {
+		if c.UID != "" && !seenCommitteeUIDs[c.UID] {
 			tags = append(tags, "committee_uid:"+c.UID)
+			seenCommitteeUIDs[c.UID] = true
 		}
 	}
 	return tags
@@ -399,9 +405,15 @@ func (m *MeetingEventData) ParentRefs() []string {
 	if m.ProjectUID != "" {
 		refs = append(refs, "project:"+m.ProjectUID)
 	}
+	seenCommitteeUIDs := make(map[string]bool)
+	if m.CommitteeUID != "" {
+		refs = append(refs, "committee:"+m.CommitteeUID)
+		seenCommitteeUIDs[m.CommitteeUID] = true
+	}
 	for _, c := range m.Committees {
-		if c.UID != "" {
+		if c.UID != "" && !seenCommitteeUIDs[c.UID] {
 			refs = append(refs, "committee:"+c.UID)
+			seenCommitteeUIDs[c.UID] = true
 		}
 	}
 	return refs
@@ -775,9 +787,15 @@ func (m *PastMeetingEventData) Tags() []string {
 	if m.Timezone != "" {
 		tags = append(tags, "timezone:"+m.Timezone)
 	}
+	seenCommitteeUIDs := make(map[string]bool)
+	if m.CommitteeUID != "" {
+		tags = append(tags, "committee_uid:"+m.CommitteeUID)
+		seenCommitteeUIDs[m.CommitteeUID] = true
+	}
 	for _, c := range m.Committees {
-		if c.UID != "" {
+		if c.UID != "" && !seenCommitteeUIDs[c.UID] {
 			tags = append(tags, "committee_uid:"+c.UID)
+			seenCommitteeUIDs[c.UID] = true
 		}
 	}
 	return tags
@@ -789,9 +807,15 @@ func (m *PastMeetingEventData) ParentRefs() []string {
 	if m.ProjectUID != "" {
 		refs = append(refs, "project:"+m.ProjectUID)
 	}
+	seenCommitteeUIDs := make(map[string]bool)
+	if m.CommitteeUID != "" {
+		refs = append(refs, "committee:"+m.CommitteeUID)
+		seenCommitteeUIDs[m.CommitteeUID] = true
+	}
 	for _, c := range m.Committees {
-		if c.UID != "" {
+		if c.UID != "" && !seenCommitteeUIDs[c.UID] {
 			refs = append(refs, "committee:"+c.UID)
+			seenCommitteeUIDs[c.UID] = true
 		}
 	}
 	return refs

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -372,8 +372,12 @@ func (m *MeetingEventData) Tags() []string {
 	tags := []string{
 		m.ID,
 		"meeting_id:" + m.ID,
-		"project_uid:" + m.ProjectUID,
-		"title:" + m.Title,
+	}
+	if m.ProjectUID != "" {
+		tags = append(tags, "project_uid:"+m.ProjectUID)
+	}
+	if m.Title != "" {
+		tags = append(tags, "title:"+m.Title)
 	}
 	if m.Visibility != "" {
 		tags = append(tags, "visibility:"+m.Visibility)
@@ -381,12 +385,20 @@ func (m *MeetingEventData) Tags() []string {
 	if m.MeetingType != "" {
 		tags = append(tags, "meeting_type:"+m.MeetingType)
 	}
+	for _, c := range m.Committees {
+		if c.UID != "" {
+			tags = append(tags, "committee_uid:"+c.UID)
+		}
+	}
 	return tags
 }
 
 // ParentRefs returns the indexer parent references for this meeting.
 func (m *MeetingEventData) ParentRefs() []string {
-	refs := []string{"project:" + m.ProjectUID}
+	var refs []string
+	if m.ProjectUID != "" {
+		refs = append(refs, "project:"+m.ProjectUID)
+	}
 	for _, c := range m.Committees {
 		if c.UID != "" {
 			refs = append(refs, "committee:"+c.UID)
@@ -549,6 +561,9 @@ func (r *RegistrantEventData) FullText() string {
 // Tags returns the indexer tags for this registrant.
 func (r *RegistrantEventData) Tags() []string {
 	tags := []string{"registrant_uid:" + r.UID}
+	if r.CommitteeUID != "" {
+		tags = append(tags, "committee_uid:"+r.CommitteeUID)
+	}
 	if r.Username != "" {
 		tags = append(tags, "username:"+r.Username)
 	}
@@ -563,7 +578,10 @@ func (r *RegistrantEventData) Tags() []string {
 
 // ParentRefs returns the indexer parent references for this registrant.
 func (r *RegistrantEventData) ParentRefs() []string {
-	refs := []string{"meeting:" + r.MeetingID}
+	var refs []string
+	if r.MeetingID != "" {
+		refs = append(refs, "meeting:"+r.MeetingID)
+	}
 	if r.CommitteeUID != "" {
 		refs = append(refs, "committee:"+r.CommitteeUID)
 	}
@@ -628,10 +646,18 @@ func (r *InviteResponseEventData) Tags() []string {
 	tags := []string{
 		r.ID,
 		"invite_response_uid:" + r.ID,
-		"meeting_and_occurrence_id:" + r.MeetingAndOccurrenceID,
-		"meeting_id:" + r.MeetingID,
-		"registrant_uid:" + r.RegistrantID,
-		"email:" + r.Email,
+	}
+	if r.MeetingAndOccurrenceID != "" {
+		tags = append(tags, "meeting_and_occurrence_id:"+r.MeetingAndOccurrenceID)
+	}
+	if r.MeetingID != "" {
+		tags = append(tags, "meeting_id:"+r.MeetingID)
+	}
+	if r.RegistrantID != "" {
+		tags = append(tags, "registrant_uid:"+r.RegistrantID)
+	}
+	if r.Email != "" {
+		tags = append(tags, "email:"+r.Email)
 	}
 	if r.Username != "" {
 		tags = append(tags, "username:"+r.Username)
@@ -641,7 +667,10 @@ func (r *InviteResponseEventData) Tags() []string {
 
 // ParentRefs returns the indexer parent references for this invite response.
 func (r *InviteResponseEventData) ParentRefs() []string {
-	return []string{"meeting:" + r.MeetingID}
+	if r.MeetingID != "" {
+		return []string{"meeting:" + r.MeetingID}
+	}
+	return nil
 }
 
 // PastMeetingEventData represents a past meeting event for indexing and access control
@@ -730,9 +759,15 @@ func (m *PastMeetingEventData) FullText() string {
 func (m *PastMeetingEventData) Tags() []string {
 	tags := []string{
 		"past_meeting_id:" + m.ID,
-		"meeting_id:" + m.MeetingID,
-		"project_uid:" + m.ProjectUID,
-		"title:" + m.Title,
+	}
+	if m.MeetingID != "" {
+		tags = append(tags, "meeting_id:"+m.MeetingID)
+	}
+	if m.ProjectUID != "" {
+		tags = append(tags, "project_uid:"+m.ProjectUID)
+	}
+	if m.Title != "" {
+		tags = append(tags, "title:"+m.Title)
 	}
 	if m.ProjectSlug != "" {
 		tags = append(tags, "project_slug:"+m.ProjectSlug)
@@ -750,7 +785,10 @@ func (m *PastMeetingEventData) Tags() []string {
 
 // ParentRefs returns the indexer parent references for this past meeting.
 func (m *PastMeetingEventData) ParentRefs() []string {
-	refs := []string{"project:" + m.ProjectUID}
+	var refs []string
+	if m.ProjectUID != "" {
+		refs = append(refs, "project:"+m.ProjectUID)
+	}
 	for _, c := range m.Committees {
 		if c.UID != "" {
 			refs = append(refs, "committee:"+c.UID)
@@ -849,7 +887,10 @@ func (p *PastMeetingParticipantEventData) Tags() []string {
 
 // ParentRefs returns the indexer parent references for this past meeting participant.
 func (p *PastMeetingParticipantEventData) ParentRefs() []string {
-	refs := []string{"past_meeting:" + p.MeetingAndOccurrenceID}
+	var refs []string
+	if p.MeetingAndOccurrenceID != "" {
+		refs = append(refs, "past_meeting:"+p.MeetingAndOccurrenceID)
+	}
 	if p.ProjectUID != "" {
 		refs = append(refs, "project:"+p.ProjectUID)
 	}

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -804,6 +804,7 @@ type PastMeetingParticipantEventData struct {
 	MeetingID              string               `json:"meeting_id"`
 	ProjectUID             string               `json:"project_uid"`
 	ProjectSlug            string               `json:"project_slug,omitempty"`
+	CommitteeUID           string               `json:"committee_uid,omitempty"`
 	Email                  string               `json:"email"`
 	FirstName              string               `json:"first_name"`
 	LastName               string               `json:"last_name"`
@@ -867,6 +868,9 @@ func (p *PastMeetingParticipantEventData) Tags() []string {
 	if p.ProjectUID != "" {
 		tags = append(tags, "project_uid:"+p.ProjectUID)
 	}
+	if p.CommitteeUID != "" {
+		tags = append(tags, "committee_uid:"+p.CommitteeUID)
+	}
 	if p.ProjectSlug != "" {
 		tags = append(tags, "project_slug:"+p.ProjectSlug)
 	}
@@ -893,6 +897,9 @@ func (p *PastMeetingParticipantEventData) ParentRefs() []string {
 	}
 	if p.ProjectUID != "" {
 		refs = append(refs, "project:"+p.ProjectUID)
+	}
+	if p.CommitteeUID != "" {
+		refs = append(refs, "committee:"+p.CommitteeUID)
 	}
 	return refs
 }


### PR DESCRIPTION
## Ticket

[LFXV2-1547 — Fix empty tags and parent refs when referenced object does not exist](https://linuxfoundation.atlassian.net/browse/LFXV2-1547)

## Summary

Two related fixes:

**1. Guard empty tags and parent refs**

The indexer was writing tags and parent refs with empty values when the referenced field was absent (e.g. `project_uid:` with no value). This caused 2,877+ `v1_past_meeting` docs in prod OpenSearch to carry a meaningless `project_uid:` tag, and similar garbage entries across other resource types.

**2. Add missing committee_uid tags and refs**

Several resource types were missing `committee_uid:` tags or `committee:` parent refs entirely.

### Changes per resource type

| Resource | What was wrong | Fix |
|---|---|---|
| `v1_meeting` | `project_uid:` and `title:` emitted even when empty; `project:` parent ref always set; `committee_uid:` tag missing entirely | Guard all three; add `committee_uid:` tag per committee |
| `v1_meeting_registrant` | `meeting:` parent ref always set; `committee_uid:` tag missing entirely | Guard `meeting:`; add `committee_uid:` tag |
| `v1_meeting_rsvp` | `meeting_and_occurrence_id:`, `meeting_id:`, `registrant_uid:`, `email:` emitted even when empty; `meeting:` parent ref always set | Guard all four tags and the parent ref |
| `v1_past_meeting` | `meeting_id:`, `project_uid:`, `title:` emitted even when empty; `project:` parent ref always set | Guard all three tags and the parent ref |
| `v1_past_meeting_participant` | `past_meeting:` parent ref always set; `committee_uid:` tag and `committee:` parent ref missing entirely | Guard `past_meeting:`; add `committee_uid:` tag and `committee:` ref sourced from each participant's own `committee_id` field |

The `indexer-contract.md` is updated in the same PR to reflect all of these corrections.

🤖 Generated with [Claude Code](https://claude.ai/code)