### PR TITLE
[LFXV2-1559] Sort v1_past_meeting index by scheduled start time instead of title

### DIFF
--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -435,7 +435,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 
 | Field | Value |
 |---|---|
-| `sort_name` | `title` (trimmed) |
+| `sort_name` | `start_time` formatted as RFC3339 (UTC); empty string when `start_time` is zero |
 | `name_and_aliases` | `[title]` (omitted when empty) |
 | `fulltext` | `title` + `description` (space-joined, deduplicated, omits empty values) |
 

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -738,9 +738,12 @@ type PastMeetingSession struct {
 	EndTime   time.Time `json:"end_time"`
 }
 
-// SortName returns the primary sort name for this past meeting.
+// SortName returns the scheduled start time in RFC3339 format for chronological sorting.
 func (m *PastMeetingEventData) SortName() string {
-	return strings.TrimSpace(m.Title)
+	if m.StartTime.IsZero() {
+		return ""
+	}
+	return m.StartTime.UTC().Format(time.RFC3339)
 }
 
 // NameAndAliases returns the searchable name aliases for this past meeting.

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -758,7 +758,7 @@ func (m *PastMeetingEventData) NameAndAliases() []string {
 func (m *PastMeetingEventData) FullText() string {
 	seen := make(map[string]bool)
 	var parts []string
-	for _, v := range append([]string{m.SortName()}, m.NameAndAliases()...) {
+	for _, v := range m.NameAndAliases() {
 		if v != "" && !seen[v] {
 			parts = append(parts, v)
 			seen[v] = true


### PR DESCRIPTION
## Summary
- Changes `PastMeetingEventData.SortName()` to return `start_time` as RFC3339 (UTC) instead of the trimmed meeting title
- Enables chronological ordering of past meetings in the OpenSearch index
- Updates the indexer contract documentation to reflect the new `sort_name` behavior

## Ticket
[LFXV2-1559](https://linuxfoundation.atlassian.net/browse/LFXV2-1559)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1559]: https://linuxfoundation.atlassian.net/browse/LFXV2-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ