### PR TITLE
fix: remove cooldown from unsupported dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,19 +20,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
 
   # Helm chart dependencies
   - package-ecosystem: "helm"
     directory: "/charts/lfx-v2-meeting-service"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3


### PR DESCRIPTION
## Summary

- Remove `cooldown` configuration from `github-actions` and `helm` package ecosystems in `dependabot.yml`
- `cooldown` is only supported for SemVer-enabled ecosystems (e.g. `gomod`); it is not supported for `github-actions` or `helm` (reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown)
- This fixes the failing `.github/dependabot.yml` validation check seen in #143

🤖 Generated with [Claude Code](https://claude.ai/code)