### PR TITLE
[LFXV2-1647] chore: group dependabot updates by ecosystem to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,27 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    groups:
+      go-modules:
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Helm chart dependencies
   - package-ecosystem: "helm"
     directory: "/charts/lfx-v2-meeting-service"
     schedule:
       interval: "daily"
+    groups:
+      helm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Groups Go module dependabot updates into a single PR per update cycle
- Groups GitHub Actions dependabot updates into a single PR per update cycle
- Groups Helm chart dependabot updates into a single PR per update cycle

This reduces the number of dependabot PRs from one-per-dependency to one-per-ecosystem, significantly cutting down on PR noise.

## Ticket

[LFXV2-1647](https://linuxfoundation.atlassian.net/browse/LFXV2-1647)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1647]: https://linuxfoundation.atlassian.net/browse/LFXV2-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ