### PR TITLE
[LFXV2-1737] feat(otel): instrument outbound HTTP clients

### DIFF
--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -11,9 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"net/http"
+
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 )
 
@@ -92,7 +95,8 @@ func NewJWTAuth(config JWTAuthConfig) (*JWTAuth, error) {
 		slog.Error("unexpected URL parsing of default issuer", logging.ErrKey, err)
 		return nil, err
 	}
-	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL))
+	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL), jwks.WithCustomClient(otelClient))
 
 	// Set up the JWT validator.
 	jwtValidator, err := validator.New(

--- a/internal/infrastructure/auth/jwt.go
+++ b/internal/infrastructure/auth/jwt.go
@@ -7,17 +7,16 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"net/http"
-
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 const (
@@ -26,6 +25,7 @@ const (
 	defaultIssuer      = "heimdall"
 	defaultAudience    = "lfx-v2-meeting-service"
 	defaultJWKSURL     = "http://heimdall:4457/.well-known/jwks"
+	jwksClientTimeout  = 10 * time.Second
 )
 
 // JWTAuthConfig holds the configuration parameters for JWT authentication.
@@ -95,7 +95,10 @@ func NewJWTAuth(config JWTAuthConfig) (*JWTAuth, error) {
 		slog.Error("unexpected URL parsing of default issuer", logging.ErrKey, err)
 		return nil, err
 	}
-	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	otelClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   jwksClientTimeout,
+	}
 	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL), jwks.WithCustomClient(otelClient))
 
 	// Set up the JWT validator.

--- a/internal/infrastructure/proxy/client.go
+++ b/internal/infrastructure/proxy/client.go
@@ -89,8 +89,8 @@ func NewClient(config Config) *Client {
 		panic("ITX_CLIENT_PRIVATE_KEY is required but not set")
 	}
 
-	// Create otel-instrumented HTTP client to use for both Auth0 token
-	// requests and ITX API calls, so both appear as child spans in traces.
+	// Create an otel-instrumented HTTP client for Auth0 token requests;
+	// ITX API calls are instrumented separately via httpClient below.
 	otelClient := &http.Client{
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 		Timeout:   config.Timeout,

--- a/internal/infrastructure/proxy/client.go
+++ b/internal/infrastructure/proxy/client.go
@@ -91,7 +91,10 @@ func NewClient(config Config) *Client {
 
 	// Create otel-instrumented HTTP client to use for both Auth0 token
 	// requests and ITX API calls, so both appear as child spans in traces.
-	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+	otelClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   config.Timeout,
+	}
 
 	// Create Auth0 authentication client with private key assertion (JWT)
 	// The private key should be in PEM format (raw, not base64-encoded)

--- a/internal/infrastructure/proxy/client.go
+++ b/internal/infrastructure/proxy/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
 )
 
@@ -88,6 +89,10 @@ func NewClient(config Config) *Client {
 		panic("ITX_CLIENT_PRIVATE_KEY is required but not set")
 	}
 
+	// Create otel-instrumented HTTP client to use for both Auth0 token
+	// requests and ITX API calls, so both appear as child spans in traces.
+	otelClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+
 	// Create Auth0 authentication client with private key assertion (JWT)
 	// The private key should be in PEM format (raw, not base64-encoded)
 	authConfig, err := authentication.New(
@@ -95,6 +100,7 @@ func NewClient(config Config) *Client {
 		config.Auth0Domain,
 		authentication.WithClientID(config.ClientID),
 		authentication.WithClientAssertion(config.PrivateKey, "RS256"),
+		authentication.WithClient(otelClient),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create Auth0 client: %v (ensure ITX_CLIENT_PRIVATE_KEY contains a valid RSA private key in PEM format)", err))
@@ -110,8 +116,10 @@ func NewClient(config Config) *Client {
 	// Wrap with oauth2.ReuseTokenSource for automatic caching and renewal
 	reuseTokenSource := oauth2.ReuseTokenSource(nil, tokenSource)
 
-	// Create HTTP client that automatically handles token management
+	// Create HTTP client that automatically handles token management.
+	// Wrap the oauth2 transport with otelhttp so ITX API calls appear in traces.
 	httpClient := oauth2.NewClient(ctx, reuseTokenSource)
+	httpClient.Transport = otelhttp.NewTransport(httpClient.Transport)
 	httpClient.Timeout = config.Timeout
 
 	return &Client{


### PR DESCRIPTION
## Summary

Part of [LFXV2-1737](https://linuxfoundation.atlassian.net/browse/LFXV2-1737).

- Wraps the JWKS HTTP client with `otelhttp.NewTransport` so Heimdall key-fetch requests appear as child spans in distributed traces
- Wraps the Auth0 HTTP client with `otelhttp.NewTransport` so token acquisition appears in traces; Auth0 spans are **independent** (not child spans of inbound requests) because the token source uses `context.Background()` — it is shared and cached across requests
- Wraps the ITX API HTTP client with `otelhttp.NewTransport` so ITX calls appear as **child spans** of inbound request spans
- Adds `jwksClientTimeout` (10s) to bound JWKS fetch time; uses `config.Timeout` for the Auth0 client
- Fixes stdlib import grouping (`net/http` moved into stdlib group per `goimports`)

> **Note:** CI govulncheck failures are pre-existing stdlib vulnerabilities in go1.25.9 (fixed in go1.25.10), tracked in [LFXV2-2004](https://linuxfoundation.atlassian.net/browse/LFXV2-2004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1737]: https://linuxfoundation.atlassian.net/browse/LFXV2-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-2004]: https://linuxfoundation.atlassian.net/browse/LFXV2-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ