### PR TITLE
[LFXV2-2004] fix: upgrade Go to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/linuxfoundation/lfx-v2-meeting-service
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/auth0/go-auth0 v1.38.0


### PR DESCRIPTION
## Summary

Closes [LFXV2-2004](https://linuxfoundation.atlassian.net/browse/LFXV2-2004).

Updates `go 1.25.9` to `go 1.25.10` in go.mod to resolve `govulncheck` CI failures. Go 1.25.10 patches 6 standard library vulnerabilities that caused the "Build and Test" job to fail on the LFXV2-1737 otelhttp PR:

- GO-2026-4986 / GO-2026-4977: `net/mail`
- GO-2026-4982 / GO-2026-4980: `html/template`
- GO-2026-4971: `net`
- `net/http` vulnerability

The `actions/setup-go` CI step reads the `go` directive from go.mod and will install go1.25.10 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2004]: https://linuxfoundation.atlassian.net/browse/LFXV2-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ