### PR TITLE
[LFXV2-1831] feat: send LFID invites for no-LFID meeting registrants

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,9 @@ The service can be configured via environment variables:
 | `LOG_ADD_SOURCE` | Add source location to logs | `true` |
 | `LFX_ENVIRONMENT` | LFX environment (dev, staging, prod) | `prod` |
 | `ID_MAPPING_DISABLED` | Disable v1/v2 ID mapping | `false` |
-| `NATS_URL` | NATS server URL (for ID mapping) | `nats://lfx-platform-nats.lfx.svc.cluster.local:4222` |
+| `NATS_URL` | NATS server URL (for ID mapping and invite feature) | `nats://lfx-platform-nats.lfx.svc.cluster.local:4222` |
+| `INVITE_FEATURE_ENABLED` | Send LFID invites for no-LFID registrants (LFXV2-1831) | `true` |
+| `LFX_SELF_SERVE_BASE_URL` | Return URL included in LFID invite emails | `""` |
 
 ### ID Mapping
 

--- a/charts/lfx-v2-meeting-service/values.yaml
+++ b/charts/lfx-v2-meeting-service/values.yaml
@@ -161,6 +161,14 @@ app:
     # (default: 1000)
     EVENT_MAX_ACK_PENDING:
       value: "1000"
+    # INVITE_FEATURE_ENABLED enables/disables the LFID invite flow for no-LFID registrants
+    # (default: true)
+    INVITE_FEATURE_ENABLED:
+      value: "true"
+    # LFX_SELF_SERVE_BASE_URL is the base URL included in LFID invite emails as a return URL
+    # (default: empty)
+    LFX_SELF_SERVE_BASE_URL:
+      value: ""
     # OTEL_SERVICE_NAME is the service name for OpenTelemetry resource identification
     # (default: "lfx-v2-meeting-service")
     # OTEL_SERVICE_NAME:

--- a/cmd/meeting-api/config.go
+++ b/cmd/meeting-api/config.go
@@ -30,6 +30,13 @@ type environment struct {
 	ITXConfig          itxConfig
 	IDMappingDisabled  bool
 	EventConfig        eventConfig
+	InviteConfig       inviteConfig
+}
+
+// inviteConfig holds LFID invite feature configuration
+type inviteConfig struct {
+	Enabled          bool
+	SelfServeBaseURL string
 }
 
 // itxConfig holds ITX proxy configuration
@@ -127,6 +134,7 @@ func parseEnv() environment {
 		ITXConfig:          parseITXConfig(),
 		IDMappingDisabled:  idMappingDisabled,
 		EventConfig:        parseEventConfig(),
+		InviteConfig:       parseInviteConfig(),
 	}
 }
 
@@ -233,5 +241,17 @@ func parseEventConfig() eventConfig {
 		AckWait:              ackWait,
 		MaxAckPending:        maxAckPending,
 		V1MappingsBucketName: v1MappingsBucketName,
+	}
+}
+
+// parseInviteConfig parses LFID invite feature configuration from environment variables
+func parseInviteConfig() inviteConfig {
+	enabled := os.Getenv("INVITE_FEATURE_ENABLED") != "false" // Default: true
+
+	selfServeBaseURL := os.Getenv("LFX_SELF_SERVE_BASE_URL")
+
+	return inviteConfig{
+		Enabled:          enabled,
+		SelfServeBaseURL: selfServeBaseURL,
 	}
 }

--- a/cmd/meeting-api/eventing/event_processor.go
+++ b/cmd/meeting-api/eventing/event_processor.go
@@ -102,6 +102,12 @@ func NewEventProcessor(config eventing.Config, idMapper domain.IDMapper, logger 
 	return ep, nil
 }
 
+// Publisher returns the event publisher used by this processor, so callers can share it
+// with other subsystems (e.g. the invite_accepted subscriber).
+func (ep *EventProcessor) Publisher() domain.EventPublisher {
+	return ep.publisher
+}
+
 // Start begins processing events from the NATS JetStream.
 // If the consumer is deleted on the server at runtime, it is automatically
 // recreated and consumption resumes without requiring a service restart.

--- a/cmd/meeting-api/eventing/invite_accepted_subscriber.go
+++ b/cmd/meeting-api/eventing/invite_accepted_subscriber.go
@@ -1,0 +1,139 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package eventing
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	indexerConstants "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
+	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
+	natsgo "github.com/nats-io/nats.go"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/models"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+const inviteAcceptedQueueGroup = "meeting-service-invite-accepted"
+
+// inviteAcceptedPayload is the NATS event published by the LFX self-serve web app.
+// The invite-service is expected to enrich this with email, resource_uid, and resource_type.
+type inviteAcceptedPayload struct {
+	InviteUID    string `json:"invite_uid"`
+	Username     string `json:"username"`
+	Email        string `json:"email"`
+	ResourceUID  string `json:"resource_uid"`
+	ResourceType string `json:"resource_type"`
+}
+
+// registrantReconciler is the subset of RegistrantService used by the subscriber.
+type registrantReconciler interface {
+	ReconcileAcceptedInvite(ctx context.Context, email, username string) ([]*itx.ZoomMeetingRegistrant, error)
+}
+
+// InviteAcceptedSubscriber subscribes to lfx.invite.accepted and reconciles LFID
+// username updates across all ITX meeting registrants for the accepted email.
+type InviteAcceptedSubscriber struct {
+	nc         *natsgo.Conn
+	reconciler registrantReconciler
+	publisher  domain.EventPublisher
+	sub        *natsgo.Subscription
+}
+
+// NewInviteAcceptedSubscriber creates the subscriber. Call Start to begin consuming.
+func NewInviteAcceptedSubscriber(
+	nc *natsgo.Conn,
+	reconciler registrantReconciler,
+	publisher domain.EventPublisher,
+) *InviteAcceptedSubscriber {
+	return &InviteAcceptedSubscriber{
+		nc:         nc,
+		reconciler: reconciler,
+		publisher:  publisher,
+	}
+}
+
+// Start registers the queue subscription. The ctx is passed to each handler invocation.
+func (s *InviteAcceptedSubscriber) Start(ctx context.Context) error {
+	sub, err := s.nc.QueueSubscribe(inviteapi.InviteAcceptedSubject, inviteAcceptedQueueGroup, func(msg *natsgo.Msg) {
+		s.handle(ctx, msg)
+	})
+	if err != nil {
+		return err
+	}
+	s.sub = sub
+	slog.InfoContext(ctx, "invite_accepted subscriber started",
+		"subject", inviteapi.InviteAcceptedSubject,
+		"queue", inviteAcceptedQueueGroup)
+	return nil
+}
+
+// Stop drains and unsubscribes.
+func (s *InviteAcceptedSubscriber) Stop() {
+	if s.sub != nil {
+		if err := s.sub.Drain(); err != nil {
+			slog.Warn("error draining invite_accepted subscription", "err", err)
+		}
+	}
+}
+
+func (s *InviteAcceptedSubscriber) handle(ctx context.Context, msg *natsgo.Msg) {
+	var evt inviteAcceptedPayload
+	if err := json.Unmarshal(msg.Data, &evt); err != nil {
+		slog.WarnContext(ctx, "invite_accepted: failed to unmarshal payload", "err", err)
+		return
+	}
+
+	if evt.InviteUID == "" || evt.Username == "" {
+		slog.WarnContext(ctx, "invite_accepted: missing invite_uid or username — discarding",
+			"invite_uid", evt.InviteUID)
+		return
+	}
+	if evt.Email == "" {
+		slog.WarnContext(ctx, "invite_accepted: missing email — cannot fan out; invite-service may need updating",
+			"invite_uid", evt.InviteUID)
+		return
+	}
+
+	updated, err := s.reconciler.ReconcileAcceptedInvite(ctx, evt.Email, evt.Username)
+	if err != nil {
+		slog.WarnContext(ctx, "invite_accepted: ITX reconcile failed",
+			"invite_uid", evt.InviteUID, "email", evt.Email, "err", err)
+		return
+	}
+
+	for _, reg := range updated {
+		eventData := itxRegistrantToEventData(reg)
+		if err := s.publisher.PublishRegistrantEvent(ctx, string(indexerConstants.ActionUpdated), eventData); err != nil {
+			slog.WarnContext(ctx, "invite_accepted: failed to publish registrant event",
+				"registrant_id", reg.ID, "meeting_id", reg.MeetingID, "err", err)
+		}
+	}
+}
+
+// itxRegistrantToEventData converts an ITX registrant to a RegistrantEventData for publishing.
+func itxRegistrantToEventData(reg *itx.ZoomMeetingRegistrant) *models.RegistrantEventData {
+	email := strings.ToLower(reg.Email)
+	return &models.RegistrantEventData{
+		UID:                  reg.ID,
+		MeetingID:            reg.MeetingID,
+		Type:                 string(reg.Type),
+		CommitteeUID:         reg.CommitteeID,
+		UserID:               reg.UserID,
+		Email:                reg.Email,
+		CaseInsensitiveEmail: email,
+		FirstName:            reg.FirstName,
+		LastName:             reg.LastName,
+		JobTitle:             reg.JobTitle,
+		Host:                 reg.Host,
+		Occurrence:           reg.Occurrence,
+		AvatarURL:            reg.ProfilePicture,
+		Username:             reg.Username,
+		CreatedAt:            reg.CreatedAt,
+		UpdatedAt:            reg.ModifiedAt,
+	}
+}

--- a/cmd/meeting-api/eventing/invite_accepted_subscriber.go
+++ b/cmd/meeting-api/eventing/invite_accepted_subscriber.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/models"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
 )
 
@@ -96,6 +97,11 @@ func (s *InviteAcceptedSubscriber) handle(ctx context.Context, msg *natsgo.Msg) 
 	if evt.Email == "" {
 		slog.WarnContext(ctx, "invite_accepted: missing email — cannot fan out; invite-service may need updating",
 			"invite_uid", evt.InviteUID)
+		return
+	}
+	if evt.ResourceType != "" && evt.ResourceType != constants.ResourceTypeMeeting {
+		slog.DebugContext(ctx, "invite_accepted: skipping non-meeting resource type",
+			"resource_type", evt.ResourceType, "invite_uid", evt.InviteUID)
 		return
 	}
 

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -15,10 +15,13 @@ import (
 	"syscall"
 	"time"
 
+	natsgo "github.com/nats-io/nats.go"
+
 	apieventing "github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/eventing"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/eventing"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/idmapper"
+	infraNATS "github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/nats"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/proxy"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/service"
@@ -115,8 +118,40 @@ func run() int {
 		Timeout:     30 * time.Second,
 	}
 	itxProxyClient := proxy.NewClient(itxProxyConfig)
+
+	// Build invite-feature options for the registrant service.
+	// A shared NATS connection is opened here if NATS_URL is set; the ID mapper may have
+	// already opened its own connection — we open a second here to keep concerns separate
+	// and avoid coupling the invite lifecycle to ID-mapping availability.
+	var inviteNC *natsgo.Conn
+	registrantOpts := []itxservice.Option{
+		itxservice.WithInviteFeatureEnabled(env.InviteConfig.Enabled),
+	}
+	if env.InviteConfig.Enabled {
+		natsURL := os.Getenv("NATS_URL")
+		if natsURL != "" {
+			nc, ncErr := natsgo.Connect(natsURL,
+				natsgo.Name("lfx-v2-meeting-service-invite"),
+				natsgo.MaxReconnects(-1),
+			)
+			if ncErr != nil {
+				slog.With(logging.ErrKey, ncErr).Warn("failed to connect to NATS for invite feature; invite sending will be disabled")
+			} else {
+				inviteNC = nc
+				registrantOpts = append(registrantOpts,
+					itxservice.WithUserReader(infraNATS.NewUserReader(nc)),
+					itxservice.WithInviteSender(infraNATS.NewInviteSender(nc)),
+					itxservice.WithSelfServeBaseURL(env.InviteConfig.SelfServeBaseURL),
+				)
+				slog.InfoContext(ctx, "NATS invite connection established")
+			}
+		} else {
+			slog.WarnContext(ctx, "INVITE_FEATURE_ENABLED but NATS_URL not set; invite sending disabled")
+		}
+	}
+
 	itxMeetingService := itxservice.NewMeetingService(itxProxyClient, idMapper)
-	itxRegistrantService := itxservice.NewRegistrantService(itxProxyClient, idMapper)
+	itxRegistrantService := itxservice.NewRegistrantService(itxProxyClient, idMapper, registrantOpts...)
 	itxPastMeetingService := itxservice.NewPastMeetingService(itxProxyClient, idMapper)
 	itxPastMeetingSummaryService := itxservice.NewPastMeetingSummaryService(itxProxyClient)
 	itxPastMeetingParticipantService := itxservice.NewPastMeetingParticipantService(itxProxyClient, idMapper)
@@ -171,6 +206,24 @@ func run() int {
 		slog.InfoContext(ctx, "event processing is disabled")
 	}
 
+	// Start invite-accepted subscriber if NATS is available and the event processor is wired.
+	// The subscriber shares the inviteNC connection and relies on the event publisher from
+	// the event processor. We only start it when both the invite feature is on and we have
+	// a publisher to forward the reconciled events.
+	var inviteSubscriber *apieventing.InviteAcceptedSubscriber
+	if inviteNC != nil && eventProcessor != nil {
+		pub := eventProcessor.Publisher()
+		if pub != nil {
+			inviteSubscriber = apieventing.NewInviteAcceptedSubscriber(inviteNC, itxRegistrantService, pub)
+			if subErr := inviteSubscriber.Start(ctx); subErr != nil {
+				slog.With(logging.ErrKey, subErr).Error("failed to start invite_accepted subscriber")
+				return 1
+			}
+		} else {
+			slog.WarnContext(ctx, "event publisher not available; invite_accepted subscriber not started")
+		}
+	}
+
 	svc := NewMeetingsAPI(
 		authService,
 		itxMeetingService,
@@ -194,13 +247,29 @@ func run() int {
 	// This next line blocks until SIGINT or SIGTERM is received.
 	<-done
 
-	gracefulShutdown(httpServer, &gracefulCloseWG, cancel, eventProcessor, eventProcessorCancel)
+	gracefulShutdown(httpServer, &gracefulCloseWG, cancel, eventProcessor, eventProcessorCancel, inviteSubscriber, inviteNC)
 
 	return 0
 }
 
 // gracefulShutdown handles graceful shutdown of the application
-func gracefulShutdown(httpServer *http.Server, gracefulCloseWG *sync.WaitGroup, cancel context.CancelFunc, eventProcessor *apieventing.EventProcessor, eventProcessorCancel context.CancelFunc) {
+func gracefulShutdown(
+	httpServer *http.Server,
+	gracefulCloseWG *sync.WaitGroup,
+	cancel context.CancelFunc,
+	eventProcessor *apieventing.EventProcessor,
+	eventProcessorCancel context.CancelFunc,
+	inviteSubscriber *apieventing.InviteAcceptedSubscriber,
+	inviteNC *natsgo.Conn,
+) {
+	// Stop invite subscriber before closing the NATS connection.
+	if inviteSubscriber != nil {
+		inviteSubscriber.Stop()
+	}
+	if inviteNC != nil {
+		inviteNC.Close()
+	}
+
 	// Shutdown event processor first if it exists
 	if eventProcessor != nil {
 		slog.Info("shutting down event processor")

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/linuxfoundation/lfx-v2-fga-sync v0.3.0
 	github.com/linuxfoundation/lfx-v2-indexer-service v0.4.20
+	github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305
 	github.com/nats-io/nats.go v1.51.0
 	github.com/remychantenay/slog-otel v1.3.5
 	github.com/stretchr/testify v1.11.1
@@ -61,6 +62,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.devnw.com/structs v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/linuxfoundation/lfx-v2-fga-sync v0.3.0 h1:a4Bf3soIN1tHL/VVXTM2SgNVmJK
 github.com/linuxfoundation/lfx-v2-fga-sync v0.3.0/go.mod h1:075J7/39UbsuLsJCXgVkbpKK1VIuPa7gbyhLsoTBAXo=
 github.com/linuxfoundation/lfx-v2-indexer-service v0.4.20 h1:ax2EAw3RxGuYxlDbnp0cxf/PdkMzSlfuZq0RcqR933M=
 github.com/linuxfoundation/lfx-v2-indexer-service v0.4.20/go.mod h1:GDeUXHTijd4h1BchxWwQNHHRuk+/95nmG5vebfzMCoM=
+github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305 h1:jHNYpxuJ5re8Wjidk59AvlH83ILnyDQrQF5jfV17zSg=
+github.com/linuxfoundation/lfx-v2-invite-service v0.0.0-20260520171722-e76421ce1305/go.mod h1:YJ/st6t/Vjt3+t7jel6/hVLPwvcKdgAkVbbJVw3PGtE=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqCDBcAhLXoi3TzC27Zad/Vn+gnVQ=
 github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
 github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b h1:3E44bLeN8uKYdfQqVQycPnaVviZdBLbizFhU49mtbe4=
@@ -87,6 +89,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/domain/invite_sender.go
+++ b/internal/domain/invite_sender.go
@@ -1,0 +1,24 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package domain
+
+import (
+	"context"
+	"time"
+
+	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
+)
+
+// InviteResult holds the invite metadata returned by the invite service.
+type InviteResult struct {
+	InviteUID      string
+	RecipientEmail string
+	ExpiresAt      time.Time
+}
+
+// InviteSender sends LFID invite requests via the invite service for users who
+// do not yet have an LFID account.
+type InviteSender interface {
+	SendInvite(ctx context.Context, req inviteapi.SendInviteRequest) (InviteResult, error)
+}

--- a/internal/domain/itx_proxy.go
+++ b/internal/domain/itx_proxy.go
@@ -24,6 +24,18 @@ type ITXMeetingClient interface {
 	SubmitMeetingResponse(ctx context.Context, meetingAndOccurrenceID string, req *itx.MeetingResponseRequest) (*itx.MeetingResponseResult, error)
 }
 
+// ITXRegistrantInviteFields holds the LFID invite metadata written to an ITX registrant on invite issuance.
+type ITXRegistrantInviteFields struct {
+	LFIDInviteUID       string
+	LFIDInviteEmail     string
+	LFIDInviteExpiresAt string // RFC3339
+}
+
+// ITXAcceptInviteResult holds the registrants updated by AcceptInvite.
+type ITXAcceptInviteResult struct {
+	Updated []*itx.ZoomMeetingRegistrant
+}
+
 // ITXRegistrantClient defines the interface for ITX registrant operations
 type ITXRegistrantClient interface {
 	CreateRegistrant(ctx context.Context, meetingID string, req *itx.ZoomMeetingRegistrant) (*itx.ZoomMeetingRegistrant, error)
@@ -32,6 +44,15 @@ type ITXRegistrantClient interface {
 	DeleteRegistrant(ctx context.Context, meetingID, registrantID string) error
 	GetRegistrantICS(ctx context.Context, meetingID, registrantID string) (*itx.RegistrantICS, error)
 	ResendRegistrantInvitation(ctx context.Context, meetingID, registrantID string) error
+
+	// UpdateRegistrantInvite writes LFID invite fields onto a registrant after an invite is issued.
+	// Corresponds to PUT /v2/zoom/registrants/{registrantID}/invite on the ITX side.
+	UpdateRegistrantInvite(ctx context.Context, registrantID string, fields ITXRegistrantInviteFields) error
+
+	// AcceptInvite fans out a username update across all registrants with the given
+	// lfid_invite_email, clears their invite fields, and returns the updated records.
+	// Corresponds to POST /v2/zoom/registrants/accept-invite on the ITX side.
+	AcceptInvite(ctx context.Context, email, username string) (*ITXAcceptInviteResult, error)
 }
 
 // ITXPastMeetingClient defines the interface for ITX past meeting operations

--- a/internal/domain/mocks/id_mapper.go
+++ b/internal/domain/mocks/id_mapper.go
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockIDMapper implements domain.IDMapper for testing.
+type MockIDMapper struct {
+	mock.Mock
+}
+
+func (m *MockIDMapper) MapProjectV2ToV1(ctx context.Context, v2UID string) (string, error) {
+	args := m.Called(ctx, v2UID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapProjectV1ToV2(ctx context.Context, v1SFID string) (string, error) {
+	args := m.Called(ctx, v1SFID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapCommitteeV2ToV1(ctx context.Context, v2UID string) (string, error) {
+	args := m.Called(ctx, v2UID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapCommitteeV1ToV2(ctx context.Context, v1SFID string) (string, error) {
+	args := m.Called(ctx, v1SFID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapInviteeIDToParticipantV2(ctx context.Context, inviteeID string) (string, error) {
+	args := m.Called(ctx, inviteeID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapAttendeeIDToParticipantV2(ctx context.Context, attendeeID string) (string, error) {
+	args := m.Called(ctx, attendeeID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapParticipantV2ToInviteeID(ctx context.Context, v2ParticipantID string) (string, error) {
+	args := m.Called(ctx, v2ParticipantID)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockIDMapper) MapParticipantV2ToAttendeeID(ctx context.Context, v2ParticipantID string) (string, error) {
+	args := m.Called(ctx, v2ParticipantID)
+	return args.String(0), args.Error(1)
+}

--- a/internal/domain/mocks/invite_sender.go
+++ b/internal/domain/mocks/invite_sender.go
@@ -1,0 +1,23 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package mocks
+
+import (
+	"context"
+
+	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+// MockInviteSender implements domain.InviteSender for testing.
+type MockInviteSender struct {
+	mock.Mock
+}
+
+func (m *MockInviteSender) SendInvite(ctx context.Context, req inviteapi.SendInviteRequest) (domain.InviteResult, error) {
+	args := m.Called(ctx, req)
+	return args.Get(0).(domain.InviteResult), args.Error(1)
+}

--- a/internal/domain/mocks/itx_registrant_client.go
+++ b/internal/domain/mocks/itx_registrant_client.go
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// MockITXRegistrantClient implements domain.ITXRegistrantClient for testing.
+type MockITXRegistrantClient struct {
+	mock.Mock
+}
+
+func (m *MockITXRegistrantClient) CreateRegistrant(ctx context.Context, meetingID string, req *itx.ZoomMeetingRegistrant) (*itx.ZoomMeetingRegistrant, error) {
+	args := m.Called(ctx, meetingID, req)
+	if v := args.Get(0); v != nil {
+		return v.(*itx.ZoomMeetingRegistrant), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockITXRegistrantClient) GetRegistrant(ctx context.Context, meetingID, registrantID string) (*itx.ZoomMeetingRegistrant, error) {
+	args := m.Called(ctx, meetingID, registrantID)
+	if v := args.Get(0); v != nil {
+		return v.(*itx.ZoomMeetingRegistrant), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockITXRegistrantClient) UpdateRegistrant(ctx context.Context, meetingID, registrantID string, req *itx.ZoomMeetingRegistrant) error {
+	args := m.Called(ctx, meetingID, registrantID, req)
+	return args.Error(0)
+}
+
+func (m *MockITXRegistrantClient) DeleteRegistrant(ctx context.Context, meetingID, registrantID string) error {
+	args := m.Called(ctx, meetingID, registrantID)
+	return args.Error(0)
+}
+
+func (m *MockITXRegistrantClient) GetRegistrantICS(ctx context.Context, meetingID, registrantID string) (*itx.RegistrantICS, error) {
+	args := m.Called(ctx, meetingID, registrantID)
+	if v := args.Get(0); v != nil {
+		return v.(*itx.RegistrantICS), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockITXRegistrantClient) ResendRegistrantInvitation(ctx context.Context, meetingID, registrantID string) error {
+	args := m.Called(ctx, meetingID, registrantID)
+	return args.Error(0)
+}
+
+func (m *MockITXRegistrantClient) UpdateRegistrantInvite(ctx context.Context, registrantID string, fields domain.ITXRegistrantInviteFields) error {
+	args := m.Called(ctx, registrantID, fields)
+	return args.Error(0)
+}
+
+func (m *MockITXRegistrantClient) AcceptInvite(ctx context.Context, email, username string) (*domain.ITXAcceptInviteResult, error) {
+	args := m.Called(ctx, email, username)
+	if v := args.Get(0); v != nil {
+		return v.(*domain.ITXAcceptInviteResult), args.Error(1)
+	}
+	return nil, args.Error(1)
+}

--- a/internal/domain/mocks/user_reader.go
+++ b/internal/domain/mocks/user_reader.go
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockUserReader implements domain.UserReader for testing.
+type MockUserReader struct {
+	mock.Mock
+}
+
+func (m *MockUserReader) SubByEmail(ctx context.Context, email string) (string, error) {
+	args := m.Called(ctx, email)
+	return args.String(0), args.Error(1)
+}

--- a/internal/domain/user_reader.go
+++ b/internal/domain/user_reader.go
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package domain
+
+import "context"
+
+// ErrUserNotFound is returned when an email address has no associated LFID.
+var ErrUserNotFound = NewNotFoundError("user not found by email")
+
+// UserReader resolves Auth0 subs from email addresses via the auth service.
+type UserReader interface {
+	// SubByEmail returns the Auth0 sub for the given primary email address.
+	// Returns ErrUserNotFound when no LFID is associated with the email.
+	// Transport errors are returned unwrapped so callers can fail fast.
+	SubByEmail(ctx context.Context, email string) (string, error)
+}

--- a/internal/infrastructure/nats/invite_sender.go
+++ b/internal/infrastructure/nats/invite_sender.go
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"log/slog"
+
+	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
+	natsgo "github.com/nats-io/nats.go"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+type inviteSender struct {
+	nc *natsgo.Conn
+}
+
+// SendInvite sends a request/reply to the invite service for a user who does not
+// yet have an LFID and returns the invite metadata from the response.
+func (s *inviteSender) SendInvite(ctx context.Context, req inviteapi.SendInviteRequest) (domain.InviteResult, error) {
+	if s.nc == nil {
+		return domain.InviteResult{}, domain.NewUnavailableError("invite sender is not configured")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return domain.InviteResult{}, domain.NewUnavailableError("context cancelled before sending invite", err)
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to marshal invite request", "error", err)
+		return domain.InviteResult{}, domain.NewInternalError("failed to marshal invite request", err)
+	}
+
+	reply, err := s.nc.RequestMsgWithContext(ctx, &natsgo.Msg{
+		Subject: inviteapi.SendInviteSubject,
+		Data:    data,
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "invite service request failed", "error", err)
+		return domain.InviteResult{}, domain.NewUnavailableError("invite service unavailable", err)
+	}
+
+	var resp inviteapi.SendInviteResponse
+	if len(reply.Data) > 0 {
+		if jsonErr := json.Unmarshal(reply.Data, &resp); jsonErr != nil {
+			slog.ErrorContext(ctx, "error unmarshalling invite response", "error", jsonErr)
+			return domain.InviteResult{}, domain.NewInternalError("failed to parse invite service response", jsonErr)
+		}
+		if resp.Error != "" {
+			return domain.InviteResult{}, domain.NewInternalError("invite service returned an error", stderrors.New(resp.Error))
+		}
+	}
+
+	var result domain.InviteResult
+	if resp.Invite != nil {
+		result.InviteUID = resp.Invite.UID
+		result.RecipientEmail = resp.Invite.Email
+		result.ExpiresAt = resp.Invite.ExpiresAt
+	}
+	slog.DebugContext(ctx, "invite service replied", "invite_uid", result.InviteUID, "expires_at", result.ExpiresAt)
+	return result, nil
+}
+
+// NewInviteSender creates a NATS-backed InviteSender.
+func NewInviteSender(nc *natsgo.Conn) domain.InviteSender {
+	return &inviteSender{nc: nc}
+}

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -28,6 +28,9 @@ type errorEnvelope struct {
 // SubByEmail resolves the Auth0 sub for the given primary email address.
 // The auth service replies with a plain-text sub on success, or a JSON error envelope on miss.
 func (u *userReader) SubByEmail(ctx context.Context, email string) (string, error) {
+	if u.nc == nil {
+		return "", domain.NewUnavailableError("user reader is not configured")
+	}
 	reply, err := u.nc.RequestMsgWithContext(ctx, &natsgo.Msg{
 		Subject: constants.AuthEmailToSubSubject,
 		Data:    []byte(email),

--- a/internal/infrastructure/nats/user_reader.go
+++ b/internal/infrastructure/nats/user_reader.go
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	natsgo "github.com/nats-io/nats.go"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
+)
+
+type userReader struct {
+	nc *natsgo.Conn
+}
+
+// errorEnvelope matches the JSON error envelope returned by the auth service on miss.
+type errorEnvelope struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+}
+
+// SubByEmail resolves the Auth0 sub for the given primary email address.
+// The auth service replies with a plain-text sub on success, or a JSON error envelope on miss.
+func (u *userReader) SubByEmail(ctx context.Context, email string) (string, error) {
+	reply, err := u.nc.RequestMsgWithContext(ctx, &natsgo.Msg{
+		Subject: constants.AuthEmailToSubSubject,
+		Data:    []byte(email),
+	})
+	if err != nil {
+		return "", fmt.Errorf("email_to_sub request failed: %w", err)
+	}
+
+	body := strings.TrimSpace(string(reply.Data))
+	if body == "" {
+		return "", domain.ErrUserNotFound
+	}
+
+	// Any object-shaped response (starts with '{') is a JSON error envelope.
+	if body[0] == '{' {
+		var env errorEnvelope
+		if jsonErr := json.Unmarshal([]byte(body), &env); jsonErr == nil && !env.Success {
+			return "", domain.ErrUserNotFound
+		}
+		return "", domain.ErrUserNotFound
+	}
+
+	return body, nil
+}
+
+// NewUserReader creates a NATS-backed UserReader.
+func NewUserReader(nc *natsgo.Conn) domain.UserReader {
+	return &userReader{nc: nc}
+}

--- a/internal/infrastructure/proxy/client.go
+++ b/internal/infrastructure/proxy/client.go
@@ -2054,3 +2054,93 @@ func (c *Client) DeletePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	return nil
 }
+
+// registrantInviteBody is the JSON payload for PUT /v2/zoom/registrants/{id}/invite.
+type registrantInviteBody struct {
+	LFIDInviteUID       string `json:"lfid_invite_uid"`
+	LFIDInviteEmail     string `json:"lfid_invite_email"`
+	LFIDInviteExpiresAt string `json:"lfid_invite_expires_at"`
+}
+
+// UpdateRegistrantInvite writes LFID invite fields onto a registrant after an invite is issued.
+func (c *Client) UpdateRegistrantInvite(ctx context.Context, registrantID string, fields domain.ITXRegistrantInviteFields) error {
+	body, err := json.Marshal(registrantInviteBody{
+		LFIDInviteUID:       fields.LFIDInviteUID,
+		LFIDInviteEmail:     fields.LFIDInviteEmail,
+		LFIDInviteExpiresAt: fields.LFIDInviteExpiresAt,
+	})
+	if err != nil {
+		return domain.NewInternalError("failed to marshal invite fields", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/v2/zoom/registrants/%s/invite", c.config.BaseURL, registrantID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return domain.NewInternalError("failed to create request", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-scope", "manage:zoom")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return domain.NewUnavailableError("ITX service request failed", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return domain.NewInternalError("failed to read response", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.mapHTTPError(resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+// acceptInviteRequest is the JSON payload for POST /v2/zoom/registrants/accept-invite.
+type acceptInviteRequest struct {
+	Email    string `json:"email"`
+	Username string `json:"username"`
+}
+
+// acceptInviteResponse is the JSON response from POST /v2/zoom/registrants/accept-invite.
+type acceptInviteResponse struct {
+	Updated []*itx.ZoomMeetingRegistrant `json:"updated"`
+}
+
+// AcceptInvite fans out a username update across all registrants with the given lfid_invite_email.
+func (c *Client) AcceptInvite(ctx context.Context, email, username string) (*domain.ITXAcceptInviteResult, error) {
+	body, err := json.Marshal(acceptInviteRequest{Email: email, Username: username})
+	if err != nil {
+		return nil, domain.NewInternalError("failed to marshal accept-invite request", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/v2/zoom/registrants/accept-invite", c.config.BaseURL)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, domain.NewInternalError("failed to create request", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("x-scope", "manage:zoom")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, domain.NewUnavailableError("ITX service request failed", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, domain.NewInternalError("failed to read response", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+	}
+
+	var result acceptInviteResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, domain.NewInternalError("failed to parse accept-invite response", err)
+	}
+	return &domain.ITXAcceptInviteResult{Updated: result.Updated}, nil
+}

--- a/internal/service/itx/registrant_service.go
+++ b/internal/service/itx/registrant_service.go
@@ -12,6 +12,7 @@ import (
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
 )
 
@@ -43,7 +44,7 @@ func WithSelfServeBaseURL(u string) Option {
 	return func(s *RegistrantService) { s.selfServeBaseURL = u }
 }
 
-// WithInviteFeatureEnabled controls whether the invite flow is active (default true).
+// WithInviteFeatureEnabled controls whether the invite flow is active (default false).
 func WithInviteFeatureEnabled(enabled bool) Option {
 	return func(s *RegistrantService) { s.inviteFeatureEnabled = enabled }
 }
@@ -136,7 +137,7 @@ func (s *RegistrantService) issueInvite(ctx context.Context, meetingID string, r
 		RecipientName:  name,
 		ResourceUID:    meetingID,
 		ResourceName:   meetingID,
-		ResourceType:   "meeting",
+		ResourceType:   constants.ResourceTypeMeeting,
 		Role:           "Member",
 		ReturnURL:      s.selfServeBaseURL,
 		ExpirationDays: 30,

--- a/internal/service/itx/registrant_service.go
+++ b/internal/service/itx/registrant_service.go
@@ -6,28 +6,70 @@ package itx
 import (
 	"context"
 	"log/slog"
+	"strings"
+	"time"
+
+	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
 )
 
-// RegistrantService handles ITX Zoom registrant operations
+// RegistrantService handles ITX Zoom registrant operations.
 type RegistrantService struct {
-	registrantClient domain.ITXRegistrantClient
-	idMapper         domain.IDMapper
+	registrantClient     domain.ITXRegistrantClient
+	idMapper             domain.IDMapper
+	userReader           domain.UserReader
+	inviteSender         domain.InviteSender
+	selfServeBaseURL     string
+	inviteFeatureEnabled bool
 }
 
-// NewRegistrantService creates a new ITX registrant service
-func NewRegistrantService(registrantClient domain.ITXRegistrantClient, idMapper domain.IDMapper) *RegistrantService {
-	return &RegistrantService{
-		registrantClient: registrantClient,
-		idMapper:         idMapper,
+// Option configures optional invite-related dependencies on RegistrantService.
+type Option func(*RegistrantService)
+
+// WithUserReader sets the NATS-backed user-reader for email → Auth0-sub lookups.
+func WithUserReader(ur domain.UserReader) Option {
+	return func(s *RegistrantService) { s.userReader = ur }
+}
+
+// WithInviteSender sets the NATS-backed invite sender.
+func WithInviteSender(is domain.InviteSender) Option {
+	return func(s *RegistrantService) { s.inviteSender = is }
+}
+
+// WithSelfServeBaseURL sets the LFX self-serve base URL included in invite emails.
+func WithSelfServeBaseURL(u string) Option {
+	return func(s *RegistrantService) { s.selfServeBaseURL = u }
+}
+
+// WithInviteFeatureEnabled controls whether the invite flow is active (default true).
+func WithInviteFeatureEnabled(enabled bool) Option {
+	return func(s *RegistrantService) { s.inviteFeatureEnabled = enabled }
+}
+
+// NewRegistrantService creates a new ITX registrant service.
+// The invite feature is disabled by default when no options are provided;
+// supply WithInviteFeatureEnabled(true) along with WithUserReader and WithInviteSender to activate it.
+func NewRegistrantService(registrantClient domain.ITXRegistrantClient, idMapper domain.IDMapper, opts ...Option) *RegistrantService {
+	s := &RegistrantService{
+		registrantClient:     registrantClient,
+		idMapper:             idMapper,
+		inviteFeatureEnabled: false,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
-// CreateRegistrant creates a meeting registrant via ITX proxy
+// CreateRegistrant creates a meeting registrant via ITX proxy.
+// If the request has no Username and the invite feature is enabled, the service
+// attempts to resolve the email via auth-service (NATS). On hit it sets the
+// username directly. On miss it creates the registrant and then issues an LFID
+// invite, storing invite metadata on the ITX record.
 func (s *RegistrantService) CreateRegistrant(ctx context.Context, meetingID string, req *itx.ZoomMeetingRegistrant) (*itx.ZoomMeetingRegistrant, error) {
-	// Map committee UID to committee SFID if present
+	// Map committee UID to committee SFID if present.
 	if req.CommitteeID != "" {
 		v1SFID, err := s.idMapper.MapCommitteeV2ToV1(ctx, req.CommitteeID)
 		if err != nil {
@@ -36,13 +78,26 @@ func (s *RegistrantService) CreateRegistrant(ctx context.Context, meetingID stri
 		req.CommitteeID = v1SFID
 	}
 
+	// --- LFID invite flow ---
+	if s.inviteFeatureEnabled && req.Username == "" && req.Email != "" {
+		sub, err := s.lookupAuthSub(ctx, req.Email)
+		switch {
+		case err == nil:
+			req.Username = sub
+		case domain.GetErrorType(err) == domain.ErrorTypeNotFound:
+			// No LFID for this email — proceed; invite will be issued after ITX create.
+		default:
+			// Transport / timeout — fail the request (same policy as project-service).
+			return nil, domain.NewUnavailableError("failed to resolve LFID for email", err)
+		}
+	}
+
 	resp, err := s.registrantClient.CreateRegistrant(ctx, meetingID, req)
 	if err != nil {
 		return nil, err
 	}
 
-	// Map committee SFID back to committee UID if present. On any mapping failure, log a warning
-	// and leave the committee UID empty so the caller still receives the full registrant response.
+	// Map committee SFID back to committee UID if present.
 	if resp.CommitteeID != "" {
 		v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.CommitteeID)
 		if err != nil {
@@ -54,18 +109,88 @@ func (s *RegistrantService) CreateRegistrant(ctx context.Context, meetingID stri
 		}
 	}
 
+	// Issue LFID invite if the registrant still has no username after the ITX round-trip.
+	if s.inviteFeatureEnabled && s.inviteSender != nil && resp.Username == "" && resp.Email != "" {
+		s.issueInvite(ctx, meetingID, resp)
+	}
+
 	return resp, nil
 }
 
-// GetRegistrant retrieves a meeting registrant via ITX proxy
+// lookupAuthSub resolves the Auth0 sub for an email, returning ErrUserNotFound when
+// no LFID exists or a transport error otherwise.
+func (s *RegistrantService) lookupAuthSub(ctx context.Context, email string) (string, error) {
+	if s.userReader == nil {
+		return "", domain.ErrUserNotFound
+	}
+	return s.userReader.SubByEmail(ctx, email)
+}
+
+// issueInvite calls the invite service and, on success, writes the invite metadata
+// back to the ITX registrant. Errors are logged but never surfaced to the caller —
+// the registrant already exists in ITX; the invite lifecycle is best-effort.
+func (s *RegistrantService) issueInvite(ctx context.Context, meetingID string, reg *itx.ZoomMeetingRegistrant) {
+	name := strings.TrimSpace(reg.FirstName + " " + reg.LastName)
+	result, err := s.inviteSender.SendInvite(ctx, inviteapi.SendInviteRequest{
+		RecipientEmail: reg.Email,
+		RecipientName:  name,
+		ResourceUID:    meetingID,
+		ResourceName:   meetingID,
+		ResourceType:   "meeting",
+		Role:           "Member",
+		ReturnURL:      s.selfServeBaseURL,
+		ExpirationDays: 30,
+	})
+	if err != nil {
+		slog.WarnContext(ctx, "failed to send LFID invite for registrant",
+			"registrant_id", reg.ID, "email", reg.Email, "meeting_id", meetingID, "err", err)
+		return
+	}
+
+	expiresAt := ""
+	if !result.ExpiresAt.IsZero() {
+		expiresAt = result.ExpiresAt.Format(time.RFC3339)
+	}
+	if itxErr := s.registrantClient.UpdateRegistrantInvite(ctx, reg.ID, domain.ITXRegistrantInviteFields{
+		LFIDInviteUID:       result.InviteUID,
+		LFIDInviteEmail:     reg.Email,
+		LFIDInviteExpiresAt: expiresAt,
+	}); itxErr != nil {
+		slog.WarnContext(ctx, "failed to store invite fields on ITX registrant",
+			"registrant_id", reg.ID, "invite_uid", result.InviteUID, "err", itxErr)
+		return
+	}
+
+	slog.DebugContext(ctx, "LFID invite issued for registrant",
+		"registrant_id", reg.ID, "invite_uid", result.InviteUID, "meeting_id", meetingID)
+}
+
+// ReconcileAcceptedInvite is called by the InviteAcceptedSubscriber when invite-service
+// publishes an acceptance event. It calls ITX to fan out the username update across all
+// registrants with the given invite email, then returns the updated registrants so the
+// caller can publish FGA + indexer events.
+func (s *RegistrantService) ReconcileAcceptedInvite(ctx context.Context, email, username string) ([]*itx.ZoomMeetingRegistrant, error) {
+	result, err := s.registrantClient.AcceptInvite(ctx, email, username)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Updated) == 0 {
+		slog.DebugContext(ctx, "accept-invite: no registrants matched; already reconciled or not ours",
+			"email", email)
+		return nil, nil
+	}
+	slog.InfoContext(ctx, "accept-invite: reconciled registrants",
+		"count", len(result.Updated), "email", email, "username", username)
+	return result.Updated, nil
+}
+
+// GetRegistrant retrieves a meeting registrant via ITX proxy.
 func (s *RegistrantService) GetRegistrant(ctx context.Context, meetingID, registrantID string) (*itx.ZoomMeetingRegistrant, error) {
 	resp, err := s.registrantClient.GetRegistrant(ctx, meetingID, registrantID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Map committee SFID back to committee UID if present. On any mapping failure, log a warning
-	// and leave the committee UID empty so the caller still receives the full registrant response.
 	if resp.CommitteeID != "" {
 		v2UID, err := s.idMapper.MapCommitteeV1ToV2(ctx, resp.CommitteeID)
 		if err != nil {
@@ -80,9 +205,8 @@ func (s *RegistrantService) GetRegistrant(ctx context.Context, meetingID, regist
 	return resp, nil
 }
 
-// UpdateRegistrant updates a meeting registrant via ITX proxy
+// UpdateRegistrant updates a meeting registrant via ITX proxy.
 func (s *RegistrantService) UpdateRegistrant(ctx context.Context, meetingID, registrantID string, req *itx.ZoomMeetingRegistrant) error {
-	// Map committee UID to committee SFID if present
 	if req.CommitteeID != "" {
 		v1SFID, err := s.idMapper.MapCommitteeV2ToV1(ctx, req.CommitteeID)
 		if err != nil {
@@ -90,21 +214,20 @@ func (s *RegistrantService) UpdateRegistrant(ctx context.Context, meetingID, reg
 		}
 		req.CommitteeID = v1SFID
 	}
-
 	return s.registrantClient.UpdateRegistrant(ctx, meetingID, registrantID, req)
 }
 
-// DeleteRegistrant deletes a meeting registrant via ITX proxy
+// DeleteRegistrant deletes a meeting registrant via ITX proxy.
 func (s *RegistrantService) DeleteRegistrant(ctx context.Context, meetingID, registrantID string) error {
 	return s.registrantClient.DeleteRegistrant(ctx, meetingID, registrantID)
 }
 
-// GetRegistrantICS retrieves an ICS calendar file for a meeting registrant via ITX proxy
+// GetRegistrantICS retrieves an ICS calendar file for a meeting registrant via ITX proxy.
 func (s *RegistrantService) GetRegistrantICS(ctx context.Context, meetingID, registrantID string) (*itx.RegistrantICS, error) {
 	return s.registrantClient.GetRegistrantICS(ctx, meetingID, registrantID)
 }
 
-// ResendRegistrantInvitation resends a meeting invitation to a registrant via ITX proxy
+// ResendRegistrantInvitation resends a meeting invitation to a registrant via ITX proxy.
 func (s *RegistrantService) ResendRegistrantInvitation(ctx context.Context, meetingID, registrantID string) error {
 	return s.registrantClient.ResendRegistrantInvitation(ctx, meetingID, registrantID)
 }

--- a/internal/service/itx/registrant_service_test.go
+++ b/internal/service/itx/registrant_service_test.go
@@ -1,0 +1,283 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/mocks"
+	svc "github.com/linuxfoundation/lfx-v2-meeting-service/internal/service/itx"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// newService is a test helper that wires up a RegistrantService with all mocks.
+func newService(
+	client *mocks.MockITXRegistrantClient,
+	idMapper *mocks.MockIDMapper,
+	userReader *mocks.MockUserReader,
+	inviteSender *mocks.MockInviteSender,
+	selfServeURL string,
+	inviteEnabled bool,
+) *svc.RegistrantService {
+	opts := []svc.Option{
+		svc.WithUserReader(userReader),
+		svc.WithInviteSender(inviteSender),
+		svc.WithSelfServeBaseURL(selfServeURL),
+		svc.WithInviteFeatureEnabled(inviteEnabled),
+	}
+	return svc.NewRegistrantService(client, idMapper, opts...)
+}
+
+// ---- CreateRegistrant tests ----
+
+// LFID-known path: SubByEmail returns a sub → username set on request before ITX call.
+func TestCreateRegistrant_LFIDKnown(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "alice@example.com", FirstName: "Alice"}
+	// userReader returns a sub for the email
+	userReader.On("SubByEmail", ctx, "alice@example.com").Return("auth0|alice", nil)
+
+	// ITX receives the request with Username already populated
+	resp := &itx.ZoomMeetingRegistrant{ID: "reg-1", Email: "alice@example.com", Username: "auth0|alice"}
+	client.On("CreateRegistrant", ctx, "meet-1", req).Return(resp, nil)
+
+	s := newService(client, idMapper, userReader, inviteSender, "", true)
+	got, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "auth0|alice", got.Username)
+	assert.Equal(t, "auth0|alice", req.Username) // mutated before ITX call
+	client.AssertExpectations(t)
+	userReader.AssertExpectations(t)
+	inviteSender.AssertNotCalled(t, "SendInvite")
+}
+
+// Invite path: SubByEmail returns ErrUserNotFound → ITX call proceeds without username → invite issued.
+func TestCreateRegistrant_InvitePath(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "new@example.com", FirstName: "New", LastName: "User"}
+	userReader.On("SubByEmail", ctx, "new@example.com").Return("", domain.ErrUserNotFound)
+
+	// Response carries names back so issueInvite can build RecipientName.
+	resp := &itx.ZoomMeetingRegistrant{ID: "reg-2", Email: "new@example.com", FirstName: "New", LastName: "User"}
+	client.On("CreateRegistrant", ctx, "meet-1", req).Return(resp, nil)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour)
+	inviteSender.On("SendInvite", ctx, inviteapi.SendInviteRequest{
+		RecipientEmail: "new@example.com",
+		RecipientName:  "New User",
+		ResourceUID:    "meet-1",
+		ResourceName:   "meet-1",
+		ResourceType:   "meeting",
+		Role:           "Member",
+		ReturnURL:      "",
+		ExpirationDays: 30,
+	}).Return(domain.InviteResult{InviteUID: "inv-abc", ExpiresAt: expiresAt}, nil)
+
+	client.On("UpdateRegistrantInvite", ctx, "reg-2", domain.ITXRegistrantInviteFields{
+		LFIDInviteUID:       "inv-abc",
+		LFIDInviteEmail:     "new@example.com",
+		LFIDInviteExpiresAt: expiresAt.Format(time.RFC3339),
+	}).Return(nil)
+
+	s := newService(client, idMapper, userReader, inviteSender, "", true)
+	got, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "reg-2", got.ID)
+	assert.Empty(t, got.Username)
+	client.AssertExpectations(t)
+	userReader.AssertExpectations(t)
+	inviteSender.AssertExpectations(t)
+}
+
+// Transport error from SubByEmail → fail the request with UnavailableError (503).
+func TestCreateRegistrant_LookupTransportError(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "bob@example.com"}
+	transportErr := errors.New("nats: timeout")
+	userReader.On("SubByEmail", ctx, "bob@example.com").Return("", transportErr)
+
+	s := newService(client, idMapper, userReader, inviteSender, "", true)
+	_, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	require.Error(t, err)
+	assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
+	client.AssertNotCalled(t, "CreateRegistrant")
+	inviteSender.AssertNotCalled(t, "SendInvite")
+}
+
+// SendInvite failure → warn-log but return 201 (registrant already created in ITX).
+func TestCreateRegistrant_SendInviteFailure(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "carol@example.com"}
+	userReader.On("SubByEmail", ctx, "carol@example.com").Return("", domain.ErrUserNotFound)
+
+	resp := &itx.ZoomMeetingRegistrant{ID: "reg-3", Email: "carol@example.com"}
+	client.On("CreateRegistrant", ctx, "meet-1", req).Return(resp, nil)
+
+	inviteSender.On("SendInvite", ctx, mock.AnythingOfType("api.SendInviteRequest")).
+		Return(domain.InviteResult{}, errors.New("invite service unavailable"))
+
+	s := newService(client, idMapper, userReader, inviteSender, "", true)
+	got, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	// The registrant is returned despite the invite failure
+	require.NoError(t, err)
+	assert.Equal(t, "reg-3", got.ID)
+	client.AssertNotCalled(t, "UpdateRegistrantInvite")
+}
+
+// UpdateRegistrantInvite failure → warn-log but return 201 (registrant + invite exist, metadata missing).
+func TestCreateRegistrant_UpdateInviteFailure(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "dave@example.com"}
+	userReader.On("SubByEmail", ctx, "dave@example.com").Return("", domain.ErrUserNotFound)
+
+	resp := &itx.ZoomMeetingRegistrant{ID: "reg-4", Email: "dave@example.com"}
+	client.On("CreateRegistrant", ctx, "meet-1", req).Return(resp, nil)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour)
+	inviteSender.On("SendInvite", ctx, mock.AnythingOfType("api.SendInviteRequest")).
+		Return(domain.InviteResult{InviteUID: "inv-xyz", ExpiresAt: expiresAt}, nil)
+
+	client.On("UpdateRegistrantInvite", ctx, "reg-4", mock.AnythingOfType("domain.ITXRegistrantInviteFields")).
+		Return(errors.New("itx: 500 internal server error"))
+
+	s := newService(client, idMapper, userReader, inviteSender, "", true)
+	got, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "reg-4", got.ID)
+}
+
+// Invite feature disabled → no lookup, no invite, pass-through.
+func TestCreateRegistrant_FeatureDisabled(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "eve@example.com"}
+	resp := &itx.ZoomMeetingRegistrant{ID: "reg-5", Email: "eve@example.com"}
+	client.On("CreateRegistrant", ctx, "meet-1", req).Return(resp, nil)
+
+	s := newService(client, idMapper, userReader, inviteSender, "", false)
+	got, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "reg-5", got.ID)
+	userReader.AssertNotCalled(t, "SubByEmail")
+	inviteSender.AssertNotCalled(t, "SendInvite")
+}
+
+// Username already set on request → no lookup, no invite.
+func TestCreateRegistrant_UsernamePrePopulated(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+	userReader := &mocks.MockUserReader{}
+	inviteSender := &mocks.MockInviteSender{}
+
+	req := &itx.ZoomMeetingRegistrant{Email: "frank@example.com", Username: "frank-lfid"}
+	resp := &itx.ZoomMeetingRegistrant{ID: "reg-6", Email: "frank@example.com", Username: "frank-lfid"}
+	client.On("CreateRegistrant", ctx, "meet-1", req).Return(resp, nil)
+
+	s := newService(client, idMapper, userReader, inviteSender, "", true)
+	got, err := s.CreateRegistrant(ctx, "meet-1", req)
+
+	require.NoError(t, err)
+	assert.Equal(t, "frank-lfid", got.Username)
+	userReader.AssertNotCalled(t, "SubByEmail")
+	inviteSender.AssertNotCalled(t, "SendInvite")
+}
+
+// ---- ReconcileAcceptedInvite tests ----
+
+func TestReconcileAcceptedInvite_Success(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+
+	updated := []*itx.ZoomMeetingRegistrant{
+		{ID: "reg-1", MeetingID: "meet-1", Email: "grace@example.com", Username: "grace-lfid"},
+		{ID: "reg-2", MeetingID: "meet-2", Email: "grace@example.com", Username: "grace-lfid"},
+	}
+	client.On("AcceptInvite", ctx, "grace@example.com", "grace-lfid").
+		Return(&domain.ITXAcceptInviteResult{Updated: updated}, nil)
+
+	s := svc.NewRegistrantService(client, idMapper)
+	got, err := s.ReconcileAcceptedInvite(ctx, "grace@example.com", "grace-lfid")
+
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "grace-lfid", got[0].Username)
+	client.AssertExpectations(t)
+}
+
+// ITX returns empty updated list → already reconciled; no error returned.
+func TestReconcileAcceptedInvite_AlreadyReconciled(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+
+	client.On("AcceptInvite", ctx, "grace@example.com", "grace-lfid").
+		Return(&domain.ITXAcceptInviteResult{Updated: nil}, nil)
+
+	s := svc.NewRegistrantService(client, idMapper)
+	got, err := s.ReconcileAcceptedInvite(ctx, "grace@example.com", "grace-lfid")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// ITX returns an error → propagated to caller.
+func TestReconcileAcceptedInvite_ITXError(t *testing.T) {
+	ctx := context.Background()
+	client := &mocks.MockITXRegistrantClient{}
+	idMapper := &mocks.MockIDMapper{}
+
+	client.On("AcceptInvite", ctx, "grace@example.com", "grace-lfid").
+		Return((*domain.ITXAcceptInviteResult)(nil), errors.New("itx: 503"))
+
+	s := svc.NewRegistrantService(client, idMapper)
+	_, err := s.ReconcileAcceptedInvite(ctx, "grace@example.com", "grace-lfid")
+
+	require.Error(t, err)
+}

--- a/pkg/constants/meeting.go
+++ b/pkg/constants/meeting.go
@@ -11,3 +11,6 @@ const (
 	// MaxMeetingDurationMinutes is the maximum duration of a meeting in minutes
 	MaxMeetingDurationMinutes = 600
 )
+
+// ResourceTypeMeeting is the resource_type value used in invite payloads for meeting registrant invites.
+const ResourceTypeMeeting = "meeting"

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -1,0 +1,10 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package constants
+
+const (
+	// AuthEmailToSubSubject resolves an Auth0 sub by primary email.
+	// Request: plain-text email. Reply: plain-text sub on success, JSON error envelope on miss.
+	AuthEmailToSubSubject = "lfx.auth-service.email_to_sub"
+)

--- a/pkg/models/itx/meeting_registrants.go
+++ b/pkg/models/itx/meeting_registrants.go
@@ -16,8 +16,9 @@ const (
 // ZoomMeetingRegistrant represents a meeting registrant in ITX
 type ZoomMeetingRegistrant struct {
 	// Read-only fields
-	ID   string         `json:"id,omitempty"`   // Registrant ID (read-only)
-	Type RegistrantType `json:"type,omitempty"` // read-only
+	ID        string         `json:"id,omitempty"`         // Registrant ID (read-only)
+	MeetingID string         `json:"meeting_id,omitempty"` // Meeting ID (read-only; populated in accept-invite responses)
+	Type      RegistrantType `json:"type,omitempty"`       // read-only
 
 	// Identity fields
 	CommitteeID string `json:"committee_id,omitempty"` // Committee ID (for committee registrants)
@@ -49,6 +50,12 @@ type ZoomMeetingRegistrant struct {
 	CreatedBy  *User  `json:"created_by,omitempty"`  // Creator user info
 	ModifiedAt string `json:"modified_at,omitempty"` // Last modified timestamp (RFC3339)
 	UpdatedBy  *User  `json:"updated_by,omitempty"`  // Last updater user info
+
+	// LFID invite fields (response-side only; written via UpdateRegistrantInvite).
+	// Set when an invite has been issued for a no-LFID registrant; cleared on acceptance.
+	LFIDInviteUID       string `json:"lfid_invite_uid,omitempty"`
+	LFIDInviteEmail     string `json:"lfid_invite_email,omitempty"`
+	LFIDInviteExpiresAt string `json:"lfid_invite_expires_at,omitempty"` // RFC3339
 }
 
 // RegistrantICS represents an ICS calendar file response from ITX


### PR DESCRIPTION
## Summary

- When an admin registers a meeting attendee whose email has no LFID, the service now issues an LFID invite via `lfx-v2-invite-service` and stores invite metadata on the ITX registrant record (in ITX's DynamoDB)
- On acceptance (`lfx.invite.accepted` NATS broadcast), a new subscriber fans out the username update across **all** ITX registrant records for that email, then publishes per-registrant FGA + indexer events
- New `INVITE_FEATURE_ENABLED` (default: `true`) and `LFX_SELF_SERVE_BASE_URL` env vars for controlling the feature and configuring the return URL in invite emails
- 10 unit tests covering all invite path branches

## Ticket

[LFXV2-1831](https://linuxfoundation.atlassian.net/browse/LFXV2-1831)

## Cross-repo dependencies

This PR is **blocked** on two sibling PRs that must be merged first (or deployed to staging):

| Repo | PR | What it adds |
|------|----|--------------|
| `linuxfoundation-it/itx-service-zoom` | [#907](https://github.com/linuxfoundation-it/itx-service-zoom/pull/907) | Three LFID invite fields on `ZoomMeetingRegistrant`; `PUT /v2/zoom/registrants/{id}/invite`; `POST /v2/zoom/registrants/accept-invite` |
| `linuxfoundation/lfx-v2-invite-service` | _pending_ | Enriches `lfx.invite.accepted` broadcast with `email` field (required for fan-out lookup) |

## Architecture

```
POST /itx/meetings/{id}/registrants
  1. SubByEmail(email) via NATS [lfx.auth-service.email_to_sub]
       hit  → set Username on request (no invite needed)
       miss → proceed without username
       err  → fail 503
  2. ITX CreateRegistrant
  3. If resp.Username == "" → issueInvite (best-effort)
       SendInvite [lfx.invite-service.send_invite]
       ITX PUT /v2/zoom/registrants/{id}/invite

NATS subscribe: lfx.invite.accepted  {invite_uid, username, email, ...}
  → ITX POST /v2/zoom/registrants/accept-invite  {email, username}
  → For each updated registrant: publish FGA + indexer event
```

## Files changed

| File | Change |
|------|--------|
| `internal/domain/invite_sender.go` | New `InviteSender` interface + `InviteResult` |
| `internal/domain/user_reader.go` | New `UserReader` interface + `ErrUserNotFound` |
| `internal/domain/itx_proxy.go` | Add `UpdateRegistrantInvite`, `AcceptInvite` to `ITXRegistrantClient`; new domain types |
| `pkg/models/itx/meeting_registrants.go` | Add `ID`, `MeetingID`, and three LFID invite fields (omitempty, not exposed via REST) |
| `internal/infrastructure/nats/invite_sender.go` | NATS adapter for invite issuance |
| `internal/infrastructure/nats/user_reader.go` | NATS adapter for email→sub lookup |
| `internal/infrastructure/proxy/client.go` | `UpdateRegistrantInvite` and `AcceptInvite` HTTP calls to ITX |
| `internal/service/itx/registrant_service.go` | Functional-options constructor; invite flow in `CreateRegistrant`; `ReconcileAcceptedInvite` |
| `cmd/meeting-api/eventing/invite_accepted_subscriber.go` | Core-NATS subscriber on `lfx.invite.accepted` |
| `cmd/meeting-api/eventing/event_processor.go` | Add `Publisher()` accessor |
| `cmd/meeting-api/main.go` | Wire invite feature at startup; graceful shutdown |
| `cmd/meeting-api/config.go` | `INVITE_FEATURE_ENABLED`, `LFX_SELF_SERVE_BASE_URL` |
| `charts/.../values.yaml` | Two new env vars |
| `README.md` | Document new optional env vars |
| `internal/domain/mocks/` | `MockITXRegistrantClient`, `MockIDMapper`, `MockInviteSender`, `MockUserReader` |
| `internal/service/itx/registrant_service_test.go` | 10 unit tests |
| `pkg/constants/nats.go` | `AuthEmailToSubSubject` constant |

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1831]: https://linuxfoundation.atlassian.net/browse/LFXV2-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ