### PR TITLE
fix(build): bump Go to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/linuxfoundation/lfx-v2-meeting-service
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/auth0/go-auth0 v1.38.0


### PR DESCRIPTION
## Summary

- Bumps Go from `1.25.10` to `1.25.11` in `go.mod`
- Fixes `govulncheck` CI failures affecting all PRs

## Motivation

`govulncheck` detects 2 Go stdlib vulnerabilities in go1.25.10, both fixed in go1.25.11:
- **GO-2026-5039**: Arbitrary inputs in errors without escaping in `net/textproto`
- **GO-2026-5037**: Inefficient candidate hostname parsing in `crypto/x509`

## Test plan

- [x] `go mod tidy` — no changes needed
- [x] `make build` — succeeds
- [x] `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)