### PR TITLE
[LFXV2-1743] feat(otel): add NATS span instrumentation

### DIFF
--- a/internal/infrastructure/eventing/nats_publisher.go
+++ b/internal/infrastructure/eventing/nats_publisher.go
@@ -10,6 +10,10 @@ import (
 	"log/slog"
 
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
 	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
@@ -596,9 +600,34 @@ func (p *NATSPublisher) PublishIndexerDelete(ctx context.Context, subject, id st
 // PublishAccessDelete sends a pre-built access control message payload to subject.
 // The caller is responsible for marshalling the payload; pass []byte(id) for simple deletes.
 func (p *NATSPublisher) PublishAccessDelete(ctx context.Context, subject string, payload []byte) error {
-	if err := p.nc.Publish(subject, payload); err != nil {
+	if err := p.publishWithSpan(ctx, subject, payload); err != nil {
 		p.logger.With(logging.ErrKey, err).ErrorContext(ctx, "failed to publish access delete", "subject", subject)
-		return fmt.Errorf("failed to publish to %s: %w", subject, err)
+		return err
+	}
+	return nil
+}
+
+// publishWithSpan wraps conn.PublishMsg with an OTel producer span and injects
+// trace context into the NATS message headers.
+func (p *NATSPublisher) publishWithSpan(ctx context.Context, subject string, data []byte) error {
+	ctx, span := tracer.Start(ctx, "nats.publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", subject),
+			attribute.Int("messaging.message.body.size", len(data)),
+		),
+	)
+	defer span.End()
+
+	msg := nats.NewMsg(subject)
+	msg.Data = data
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
+
+	if err := p.nc.PublishMsg(msg); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return domain.NewInternalError(fmt.Sprintf("failed to publish to subject %s", subject), err)
 	}
 	return nil
 }
@@ -611,9 +640,9 @@ func (p *NATSPublisher) publish(ctx context.Context, subject string, data interf
 		return fmt.Errorf("failed to marshal event data: %w", err)
 	}
 
-	if err := p.nc.Publish(subject, payload); err != nil {
+	if err := p.publishWithSpan(ctx, subject, payload); err != nil {
 		p.logger.With(logging.ErrKey, err).ErrorContext(ctx, "failed to publish event", "subject", subject)
-		return fmt.Errorf("failed to publish to %s: %w", subject, err)
+		return err
 	}
 
 	p.logger.DebugContext(ctx, "successfully published event", "subject", subject, "payload_size", len(payload))

--- a/internal/infrastructure/eventing/tracing.go
+++ b/internal/infrastructure/eventing/tracing.go
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package eventing
+
+import (
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// tracer is safe to initialize at package level — otel.Tracer() returns a
+// delegating tracer that forwards to whatever TracerProvider is registered at
+// call time, so otel.SetTracerProvider() updates it regardless of init order.
+var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/eventing")
+
+// natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
+// so trace context can be injected into NATS message headers.
+type natsHeaderCarrier nats.Header
+
+func (c natsHeaderCarrier) Get(key string) string {
+	vals := c[key]
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+func (c natsHeaderCarrier) Set(key string, value string) {
+	if c == nil {
+		return
+	}
+	c[key] = []string{value}
+}
+
+func (c natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}

--- a/internal/infrastructure/eventing/tracing_test.go
+++ b/internal/infrastructure/eventing/tracing_test.go
@@ -1,0 +1,104 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package eventing
+
+import (
+	"testing"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TestNatsHeaderCarrier_Get(t *testing.T) {
+	t.Run("returns empty string for missing key", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		assert.Equal(t, "", carrier.Get("missing-key"))
+	})
+
+	t.Run("returns value for existing key", func(t *testing.T) {
+		carrier := natsHeaderCarrier(natsgo.Header{
+			"traceparent": []string{"00-trace-id-span-id-01"},
+		})
+		assert.Equal(t, "00-trace-id-span-id-01", carrier.Get("traceparent"))
+	})
+
+	t.Run("returns first value when multiple values set", func(t *testing.T) {
+		carrier := natsHeaderCarrier(natsgo.Header{
+			"key1": []string{"first", "second"},
+		})
+		assert.Equal(t, "first", carrier.Get("key1"))
+	})
+
+	t.Run("returns empty string for nil header", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		assert.Equal(t, "", carrier.Get("any-key"))
+	})
+}
+
+func TestNatsHeaderCarrier_Set(t *testing.T) {
+	t.Run("sets value on new key", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		carrier.Set("traceparent", "00-abc-def-01")
+		assert.Equal(t, "00-abc-def-01", carrier.Get("traceparent"))
+	})
+
+	t.Run("overwrites existing value", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		carrier.Set("key", "value1")
+		carrier.Set("key", "value2")
+		assert.Equal(t, "value2", carrier.Get("key"))
+		assert.Equal(t, []string{"value2"}, natsgo.Header(carrier)["key"])
+	})
+
+	t.Run("stores full header state correctly", func(t *testing.T) {
+		header := make(natsgo.Header)
+		carrier := natsHeaderCarrier(header)
+		carrier.Set("traceparent", "00-trace-span-01")
+		carrier.Set("tracestate", "vendor=value")
+		assert.Len(t, header, 2)
+		assert.Equal(t, []string{"00-trace-span-01"}, header["traceparent"])
+		assert.Equal(t, []string{"vendor=value"}, header["tracestate"])
+	})
+}
+
+func TestNatsHeaderCarrier_Keys(t *testing.T) {
+	t.Run("returns empty slice for empty header", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		assert.Empty(t, carrier.Keys())
+	})
+
+	t.Run("returns all keys for populated header", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		carrier.Set("key1", "v1")
+		carrier.Set("key2", "v2")
+		keys := carrier.Keys()
+		assert.Len(t, keys, 2)
+		assert.Contains(t, keys, "key1")
+		assert.Contains(t, keys, "key2")
+	})
+
+	t.Run("returns empty slice for nil header", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		assert.Empty(t, carrier.Keys())
+	})
+}
+
+func TestNatsHeaderCarrier_TextMapCarrier(t *testing.T) {
+	t.Run("satisfies TextMapCarrier interface", func(t *testing.T) {
+		var _ propagation.TextMapCarrier = natsHeaderCarrier{}
+	})
+
+	t.Run("Set/Get round-trip preserves values", func(t *testing.T) {
+		header := make(natsgo.Header)
+		carrier := natsHeaderCarrier(header)
+
+		carrier.Set("traceparent", "00-trace-id-span-id-01")
+		carrier.Set("tracestate", "vendor=value")
+
+		assert.Equal(t, "00-trace-id-span-id-01", carrier.Get("traceparent"))
+		assert.Equal(t, "vendor=value", carrier.Get("tracestate"))
+		assert.Len(t, header, 2)
+	})
+}

--- a/internal/infrastructure/eventing/tracing_test.go
+++ b/internal/infrastructure/eventing/tracing_test.go
@@ -61,6 +61,11 @@ func TestNatsHeaderCarrier_Set(t *testing.T) {
 		assert.Equal(t, []string{"00-trace-span-01"}, header["traceparent"])
 		assert.Equal(t, []string{"vendor=value"}, header["tracestate"])
 	})
+
+	t.Run("no-op on nil carrier", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		assert.NotPanics(t, func() { carrier.Set("key", "value") })
+	})
 }
 
 func TestNatsHeaderCarrier_Keys(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add \`tracing.go\` with \`natsHeaderCarrier\` (OTel TextMapCarrier adaptor) and package-level \`tracer\`
- Wrap NATS publish operations with Producer spans, injecting trace context into message headers
- \`nats.NewMsg\` initializes \`Header\` automatically; nil guard on \`natsHeaderCarrier.Set\` provides additional safety

## Out of scope

Request/reply (Client span) instrumentation for \`NATSProjectLookup\` is not included in this change set. The publish Producer span covers the primary event-publishing path; request/reply instrumentation can be added in a follow-up PR when needed.

## Test plan

- [ ] \`make build\` passes
- [ ] Trace spans appear in Datadog APM for NATS-triggered operations