### PR TITLE
fix(meetings): drop omitempty on require_ai_summary_approval (LFXV2-2375)

### DIFF
--- a/pkg/models/itx/meetings.go
+++ b/pkg/models/itx/meetings.go
@@ -68,7 +68,7 @@ type CreateZoomMeetingRequest struct {
 
 	// AI features
 	ZoomAIEnabled            bool           `json:"zoom_ai_enabled"`
-	RequireAISummaryApproval bool           `json:"require_ai_summary_approval,omitempty"`
+	RequireAISummaryApproval bool           `json:"require_ai_summary_approval"`
 	AISummaryAccess          ArtifactAccess `json:"ai_summary_access,omitempty"`
 
 	// Email reminders


### PR DESCRIPTION
# Summary

Removes `omitempty` from the `RequireAISummaryApproval` field on `CreateZoomMeetingRequest`. With `omitempty`, a `false` value was dropped from the marshalled JSON entirely, so a client explicitly disabling AI-summary approval sent a payload with the field absent and ITX fell back to its default (`true`). Dropping `omitempty` forces `false` to be serialized so the client's intent is honored on both create and update (the struct is shared by both flows). This also makes the field consistent with the sibling boolean flags in the same request struct.