### PR TITLE
feat: allow committee writers to create meetings for their committee (LFXV2-2395)

### DIFF
--- a/charts/lfx-v2-meeting-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-meeting-service/templates/ruleset.yaml
@@ -48,11 +48,13 @@ spec:
         {{- end }}
         {{- if .Values.openfga.enabled }}
         - authorizer: json_content_type
-        - authorizer: openfga_check
+        - authorizer: openfga_or_check
           config:
             values:
               relation: meetings_creator
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
+              or_relation: "{{ "{{- if and .Request.Body.committees (gt (len .Request.Body.committees) 0) -}}writer{{- end -}}" }}"
+              or_object: "{{ "{{- if and .Request.Body.committees (gt (len .Request.Body.committees) 0) -}}committee:{{- (index .Request.Body.committees 0).uid -}}{{- end -}}" }}"
         {{- else }}
         {{/*
           When OpenFGA is disabled, allow all requests
@@ -576,11 +578,13 @@ spec:
         {{- end }}
         {{- if .Values.openfga.enabled }}
         - authorizer: json_content_type
-        - authorizer: openfga_check
+        - authorizer: openfga_or_check
           config:
             values:
               relation: meetings_creator
               object: "project:{{ "{{- .Request.Body.project_uid -}}" }}"
+              or_relation: "{{ "{{- if and .Request.Body.committees (gt (len .Request.Body.committees) 0) -}}writer{{- end -}}" }}"
+              or_object: "{{ "{{- if and .Request.Body.committees (gt (len .Request.Body.committees) 0) -}}committee:{{- (index .Request.Body.committees 0).uid -}}{{- end -}}" }}"
         {{- else }}
         {{/*
           When OpenFGA is disabled, allow all requests


### PR DESCRIPTION
## Summary

- Replaces `openfga_check` with the new `openfga_or_check` authorizer on `POST /itx/meetings` and `POST /itx/past_meetings`
- Committee writers (`committee:<uid>#writer`) can now create meetings that list their committee, without requiring project-level `meetings_creator` rights
- The secondary FGA check uses `committees[0].uid` from the request body; it is omitted when the array is empty, preserving the existing project-only path unchanged
- Update/delete/registrant endpoints are unaffected — the FGA model already grants committee writers `organizer` on `v1_meeting` via `writer from committee`

**Depends on:** `openfga_or_check` authorizer being deployed via the companion lfx-v2-argocd and lfx-v2-helm PRs for [LFXV2-2395](https://linuxfoundation.atlassian.net/browse/LFXV2-2395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-2395]: https://linuxfoundation.atlassian.net/browse/LFXV2-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ