### PR TITLE
fix(ci): compile SLSA generator when workflow is SHA-pinned

### DIFF
--- a/.github/workflows/ko-build-tag.yaml
+++ b/.github/workflows/ko-build-tag.yaml
@@ -138,5 +138,6 @@ jobs:
       image: ${{ needs.release-helm-chart.outputs.image_name }}
       digest: ${{ needs.release-helm-chart.outputs.digest }}
       registry-username: ${{ github.actor }}
+      compile-generator: true
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes the `create-ghcr-helm-provenance` failure on tagged releases (e.g. v0.11.1)
- Sets `compile-generator: true` on the SLSA reusable workflow so the generator is built from source when the workflow is pinned to a commit SHA instead of a tag

## Root cause
Pinning `slsa-github-generator` to commit `f7dd8c54` (v2.1.0) left `compile-generator` at its default of `false`. In that mode the generator expects a **tag ref** and downloads a prebuilt release binary. With a SHA ref, `generate-builder.sh` exits early and provenance signing fails with:

```
slsa-generator-container-linux-amd64: No such file or directory
```

This has broken every tagged release since v0.9.15.

Made with [Cursor](https://cursor.com)