### PR TITLE
feat: add preferred meeting-invite email NATS RPC (LFXV2-2599)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,17 +45,10 @@ OTEL_METRICS_EXPORTER=none                                 # Metrics exporter "o
 OTEL_LOGS_EXPORTER=none                                    # Logs exporter "otlp" or "none" (default: "none")
 
 # User Service Configuration
-# Enables the preferred meeting-invite email NATS RPC
-# (lfx.meeting-service.preferred_email.get/set), which proxies to the v1
-# user-service preferences API. The responder starts only when USER_SERVICE_CLIENT_ID
-# and a credential (private key or client secret) are set AND NATS_URL is configured.
-# Base URL of the v1 API gateway (defaults per LFX_ENVIRONMENT)
+# Backs the preferred meeting-invite email NATS RPC
+# (lfx.meeting-service.preferred_email.get/set). The RPC calls the v1 user-service
+# preferences API AS the user, using the bearer token forwarded in the request from
+# self-serve, so no service credentials are needed here. The responder starts when
+# NATS_URL is configured.
+# Base URL of the v1 API gateway (optional; defaults per LFX_ENVIRONMENT)
 USER_SERVICE_BASE_URL=https://api-gw.dev.platform.linuxfoundation.org
-# OAuth2 M2M client ID authorized for the API gateway
-USER_SERVICE_CLIENT_ID=
-# Provide EITHER a private key (RS256 client-assertion) OR a client secret
-USER_SERVICE_CLIENT_PRIVATE_KEY=
-USER_SERVICE_CLIENT_SECRET=
-USER_SERVICE_AUTH0_DOMAIN=linuxfoundation-dev.auth0.com
-# OAuth2 audience for the API gateway (defaults to the base URL)
-USER_SERVICE_AUDIENCE=https://api-gw.dev.platform.linuxfoundation.org/

--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,19 @@ OTEL_EXPORTER_OTLP_INSECURE=true                           # Set to "true" for i
 OTEL_TRACES_EXPORTER=none                                  # Traces exporter "otlp" or "none" (default: "none")
 OTEL_METRICS_EXPORTER=none                                 # Metrics exporter "otlp" or "none" (default: "none")
 OTEL_LOGS_EXPORTER=none                                    # Logs exporter "otlp" or "none" (default: "none")
+
+# User Service Configuration
+# Enables the preferred meeting-invite email NATS RPC
+# (lfx.meeting-service.preferred_email.get/set), which proxies to the v1
+# user-service preferences API. The responder starts only when USER_SERVICE_CLIENT_ID
+# and a credential (private key or client secret) are set AND NATS_URL is configured.
+# Base URL of the v1 API gateway (defaults per LFX_ENVIRONMENT)
+USER_SERVICE_BASE_URL=https://api-gw.dev.platform.linuxfoundation.org
+# OAuth2 M2M client ID authorized for the API gateway
+USER_SERVICE_CLIENT_ID=
+# Provide EITHER a private key (RS256 client-assertion) OR a client secret
+USER_SERVICE_CLIENT_PRIVATE_KEY=
+USER_SERVICE_CLIENT_SECRET=
+USER_SERVICE_AUTH0_DOMAIN=linuxfoundation-dev.auth0.com
+# OAuth2 audience for the API gateway (defaults to the base URL)
+USER_SERVICE_AUDIENCE=https://api-gw.dev.platform.linuxfoundation.org/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,17 @@ For ITX proxy functionality, configure these environment variables:
 - `ITX_AUTH0_DOMAIN`: Auth0 domain for OAuth2 (e.g., `linuxfoundation.auth0.com`)
 - `ITX_AUDIENCE`: OAuth2 audience for ITX service (e.g., `https://api.itx.linuxfoundation.org/`)
 
+### User Service Configuration (Optional)
+
+Backs the preferred meeting-invite email NATS RPC (LFXV2-2599) by proxying to the v1 user-service preferences API. The responder starts only when `USER_SERVICE_CLIENT_ID` and a credential (private key **or** client secret) are set **and** `NATS_URL` is configured; otherwise it is skipped with a log line.
+
+- `USER_SERVICE_BASE_URL`: v1 API-gateway base URL (defaults per `LFX_ENVIRONMENT`, e.g. `https://api-gw.dev.platform.linuxfoundation.org`)
+- `USER_SERVICE_CLIENT_ID`: OAuth2 M2M client ID authorized for the API gateway
+- `USER_SERVICE_CLIENT_PRIVATE_KEY`: RSA private key in PEM format for RS256 client-assertion (preferred)
+- `USER_SERVICE_CLIENT_SECRET`: client secret, used when a private key is not provided
+- `USER_SERVICE_AUTH0_DOMAIN`: Auth0 domain for the API-gateway M2M client
+- `USER_SERVICE_AUDIENCE`: OAuth2 audience for the API gateway (defaults to the base URL)
+
 ### ID Mapping Configuration (Optional)
 
 The service supports optional ID mapping between v1 and v2 systems:
@@ -283,3 +294,10 @@ All V2 functionality has been removed. The service is now a lightweight stateles
 - `GET /itx/past_meetings/{past_meeting_id}` - Get past meeting
 - `PUT /itx/past_meetings/{past_meeting_id}` - Update past meeting
 - `DELETE /itx/past_meetings/{past_meeting_id}` - Delete past meeting
+
+### NATS RPC (preferred meeting-invite email — LFXV2-2599)
+
+Request/reply subjects served by the preferred-email responder (see User Service Configuration). The caller sends an LFID/username; meeting-service resolves the Salesforce ID via the v1 user-service and proxies to its preferences API (Phase 1 storage).
+
+- `lfx.meeting-service.preferred_email.get` — request `{"user":"<lfid|username>"}` → reply `{"email_id":string|null,"email":string|null}` (`null` ⇒ use primary)
+- `lfx.meeting-service.preferred_email.set` — request `{"user":"<lfid|username>","email":"<verified-address>"}` (or `{"...","email_id":<sfid>}`; `email` wins, `null`/`"primary"` clears) → reply `{"email_id","email"}` or `{"error":"..."}`. A verified `email` is resolved to its (auth0→SFDC synced) email-record ID; a not-yet-synced address returns a retryable error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,14 +151,9 @@ For ITX proxy functionality, configure these environment variables:
 
 ### User Service Configuration (Optional)
 
-Backs the preferred meeting-invite email NATS RPC (LFXV2-2599) by proxying to the v1 user-service preferences API. The responder starts only when `USER_SERVICE_CLIENT_ID` and a credential (private key **or** client secret) are set **and** `NATS_URL` is configured; otherwise it is skipped with a log line.
+Backs the preferred meeting-invite email NATS RPC (LFXV2-2599). The RPC calls the v1 user-service preferences API **as the user**, using the bearer token forwarded in the request payload by self-serve (`{"token": "..."}`) — so no service credentials are configured here. The responder starts whenever `NATS_URL` is configured.
 
 - `USER_SERVICE_BASE_URL`: v1 API-gateway base URL (defaults per `LFX_ENVIRONMENT`, e.g. `https://api-gw.dev.platform.linuxfoundation.org`)
-- `USER_SERVICE_CLIENT_ID`: OAuth2 M2M client ID authorized for the API gateway
-- `USER_SERVICE_CLIENT_PRIVATE_KEY`: RSA private key in PEM format for RS256 client-assertion (preferred)
-- `USER_SERVICE_CLIENT_SECRET`: client secret, used when a private key is not provided
-- `USER_SERVICE_AUTH0_DOMAIN`: Auth0 domain for the API-gateway M2M client
-- `USER_SERVICE_AUDIENCE`: OAuth2 audience for the API gateway (defaults to the base URL)
 
 ### ID Mapping Configuration (Optional)
 
@@ -297,7 +292,7 @@ All V2 functionality has been removed. The service is now a lightweight stateles
 
 ### NATS RPC (preferred meeting-invite email — LFXV2-2599)
 
-Request/reply subjects served by the preferred-email responder (see User Service Configuration). The caller sends an LFID/username; meeting-service resolves the Salesforce ID via the v1 user-service and proxies to its preferences API (Phase 1 storage).
+Request/reply subjects served by the preferred-email responder (see User Service Configuration). The caller forwards the user's bearer token; meeting-service resolves the user (SFID + emails) from it via `GET /v1/me` and proxies to the user-service preferences API **as the user** (Phase 1 storage).
 
-- `lfx.meeting-service.preferred_email.get` — request `{"user":"<lfid|username>"}` → reply `{"email_id":string|null,"email":string|null}` (`null` ⇒ use primary)
-- `lfx.meeting-service.preferred_email.set` — request `{"user":"<lfid|username>","email":"<verified-address>"}` (or `{"...","email_id":<sfid>}`; `email` wins, `null`/`"primary"` clears) → reply `{"email_id","email"}` or `{"error":"..."}`. A verified `email` is resolved to its (auth0→SFDC synced) email-record ID; a not-yet-synced address returns a retryable error.
+- `lfx.meeting-service.preferred_email.get` — request `{"token":"<user bearer token>"}` → reply `{"email_id":string|null,"email":string|null}` (`null` ⇒ use primary)
+- `lfx.meeting-service.preferred_email.set` — request `{"token":"<user bearer token>","email":"<verified-address>"}` (or `{"token":"...","email_id":<sfid>}`; `email` wins, `null`/`"primary"` clears) → reply `{"email_id","email"}` or `{"error":"..."}`. A verified `email` is resolved to its (auth0→SFDC synced) email-record ID; a not-yet-synced address returns a retryable error.

--- a/charts/lfx-v2-meeting-service/values.yaml
+++ b/charts/lfx-v2-meeting-service/values.yaml
@@ -144,40 +144,13 @@ app:
     ITX_AUDIENCE:
       value: https://api.dev.itx.linuxfoundation.org/
     # User Service (LFXV2-2599): backs the preferred meeting-invite email NATS RPC
-    # (lfx.meeting-service.preferred_email.get/set) by proxying to the v1 user-service
-    # preferences API. The responder starts only when USER_SERVICE_CLIENT_ID and a
-    # credential are set AND NATS_URL is configured; otherwise it is skipped.
+    # (lfx.meeting-service.preferred_email.get/set). The RPC calls the v1 user-service
+    # preferences API AS the user, using the bearer token forwarded in the request from
+    # self-serve, so no service credentials are configured here. The responder starts
+    # whenever NATS_URL is configured.
     # USER_SERVICE_BASE_URL is the v1 API-gateway base URL
     USER_SERVICE_BASE_URL:
       value: https://api-gw.dev.platform.linuxfoundation.org
-    # USER_SERVICE_CLIENT_ID is the OAuth2 M2M client ID authorized for the API gateway
-    USER_SERVICE_CLIENT_ID:
-      valueFrom:
-        secretKeyRef:
-          name: meeting-secrets
-          key: user_service_client_id
-          optional: true
-    # USER_SERVICE_CLIENT_PRIVATE_KEY is an RSA private key (PEM) for RS256 client-assertion.
-    # Provide this OR USER_SERVICE_CLIENT_SECRET.
-    USER_SERVICE_CLIENT_PRIVATE_KEY:
-      valueFrom:
-        secretKeyRef:
-          name: meeting-secrets
-          key: user_service_client_private_key
-          optional: true
-    # USER_SERVICE_CLIENT_SECRET is used when a private key is not provided.
-    USER_SERVICE_CLIENT_SECRET:
-      valueFrom:
-        secretKeyRef:
-          name: meeting-secrets
-          key: user_service_client_secret
-          optional: true
-    # USER_SERVICE_AUTH0_DOMAIN is the Auth0 domain for the API-gateway M2M client
-    USER_SERVICE_AUTH0_DOMAIN:
-      value: linuxfoundation-dev.auth0.com
-    # USER_SERVICE_AUDIENCE is the OAuth2 audience for the API gateway (defaults to base URL)
-    USER_SERVICE_AUDIENCE:
-      value: https://api-gw.dev.platform.linuxfoundation.org/
     # ID_MAPPING_DISABLED disables v1/v2 ID mapping (optional, defaults to false)
     # Set to "true" to disable ID mapping and pass IDs through unchanged
     ID_MAPPING_DISABLED:

--- a/charts/lfx-v2-meeting-service/values.yaml
+++ b/charts/lfx-v2-meeting-service/values.yaml
@@ -143,6 +143,41 @@ app:
     # ITX_AUDIENCE is the OAuth2 audience for ITX service
     ITX_AUDIENCE:
       value: https://api.dev.itx.linuxfoundation.org/
+    # User Service (LFXV2-2599): backs the preferred meeting-invite email NATS RPC
+    # (lfx.meeting-service.preferred_email.get/set) by proxying to the v1 user-service
+    # preferences API. The responder starts only when USER_SERVICE_CLIENT_ID and a
+    # credential are set AND NATS_URL is configured; otherwise it is skipped.
+    # USER_SERVICE_BASE_URL is the v1 API-gateway base URL
+    USER_SERVICE_BASE_URL:
+      value: https://api-gw.dev.platform.linuxfoundation.org
+    # USER_SERVICE_CLIENT_ID is the OAuth2 M2M client ID authorized for the API gateway
+    USER_SERVICE_CLIENT_ID:
+      valueFrom:
+        secretKeyRef:
+          name: meeting-secrets
+          key: user_service_client_id
+          optional: true
+    # USER_SERVICE_CLIENT_PRIVATE_KEY is an RSA private key (PEM) for RS256 client-assertion.
+    # Provide this OR USER_SERVICE_CLIENT_SECRET.
+    USER_SERVICE_CLIENT_PRIVATE_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: meeting-secrets
+          key: user_service_client_private_key
+          optional: true
+    # USER_SERVICE_CLIENT_SECRET is used when a private key is not provided.
+    USER_SERVICE_CLIENT_SECRET:
+      valueFrom:
+        secretKeyRef:
+          name: meeting-secrets
+          key: user_service_client_secret
+          optional: true
+    # USER_SERVICE_AUTH0_DOMAIN is the Auth0 domain for the API-gateway M2M client
+    USER_SERVICE_AUTH0_DOMAIN:
+      value: linuxfoundation-dev.auth0.com
+    # USER_SERVICE_AUDIENCE is the OAuth2 audience for the API gateway (defaults to base URL)
+    USER_SERVICE_AUDIENCE:
+      value: https://api-gw.dev.platform.linuxfoundation.org/
     # ID_MAPPING_DISABLED disables v1/v2 ID mapping (optional, defaults to false)
     # Set to "true" to disable ID mapping and pass IDs through unchanged
     ID_MAPPING_DISABLED:

--- a/cmd/meeting-api/config.go
+++ b/cmd/meeting-api/config.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	apieventing "github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/eventing"
@@ -46,20 +45,10 @@ type itxConfig struct {
 }
 
 // userServiceConfig holds v1 user-service (API-gateway) client configuration for
-// the preferred meeting-invite email RPC. When ClientID and a credential
-// (PrivateKey or ClientSecret) are unset, the preferred-email responder is skipped.
+// the preferred meeting-invite email RPC. The RPC calls user-service AS the user via a
+// bearer token forwarded by self-serve, so only the gateway base URL is needed.
 type userServiceConfig struct {
-	BaseURL      string
-	ClientID     string
-	PrivateKey   string
-	ClientSecret string
-	Auth0Domain  string
-	Audience     string
-}
-
-// Configured reports whether enough config is present to build the user-service client.
-func (c userServiceConfig) Configured() bool {
-	return c.ClientID != "" && (c.PrivateKey != "" || c.ClientSecret != "")
+	BaseURL string
 }
 
 // eventConfig holds event processing configuration
@@ -195,9 +184,8 @@ func parseITXConfig() itxConfig {
 }
 
 // parseUserServiceConfig parses v1 user-service (API-gateway) configuration for the
-// preferred meeting-invite email RPC. Unlike ITX config it never exits on missing
-// values: when unset, the preferred-email responder is simply not started.
-// lfxEnvironment must be the normalized value from normalizeLFXEnvironment.
+// preferred meeting-invite email RPC. lfxEnvironment must be the normalized value from
+// normalizeLFXEnvironment.
 func parseUserServiceConfig(lfxEnvironment string) userServiceConfig {
 	baseURL := os.Getenv("USER_SERVICE_BASE_URL")
 	if baseURL == "" {
@@ -211,29 +199,7 @@ func parseUserServiceConfig(lfxEnvironment string) userServiceConfig {
 		}
 	}
 
-	audience := os.Getenv("USER_SERVICE_AUDIENCE")
-	if audience == "" {
-		// The API-gateway audience is the gateway URL itself (trailing slash).
-		audience = strings.TrimRight(baseURL, "/") + "/"
-	}
-
-	auth0Domain := os.Getenv("USER_SERVICE_AUTH0_DOMAIN")
-	if auth0Domain == "" {
-		if lfxEnvironment == "prod" {
-			auth0Domain = "linuxfoundation.auth0.com"
-		} else {
-			auth0Domain = "linuxfoundation-dev.auth0.com"
-		}
-	}
-
-	return userServiceConfig{
-		BaseURL:      baseURL,
-		ClientID:     os.Getenv("USER_SERVICE_CLIENT_ID"),
-		PrivateKey:   os.Getenv("USER_SERVICE_CLIENT_PRIVATE_KEY"),
-		ClientSecret: os.Getenv("USER_SERVICE_CLIENT_SECRET"),
-		Auth0Domain:  auth0Domain,
-		Audience:     audience,
-	}
+	return userServiceConfig{BaseURL: baseURL}
 }
 
 // parseEventConfig parses event processing configuration from environment variables

--- a/cmd/meeting-api/config.go
+++ b/cmd/meeting-api/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	apieventing "github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/eventing"
@@ -29,6 +30,7 @@ type environment struct {
 	ProjectLogoBaseURL string
 	LFXAppOrigin       string
 	ITXConfig          itxConfig
+	UserServiceConfig  userServiceConfig
 	IDMappingDisabled  bool
 	EventConfig        eventConfig
 	InviteConfig       apieventing.InviteFeatureConfig
@@ -41,6 +43,23 @@ type itxConfig struct {
 	PrivateKey  string
 	Auth0Domain string
 	Audience    string
+}
+
+// userServiceConfig holds v1 user-service (API-gateway) client configuration for
+// the preferred meeting-invite email RPC. When ClientID and a credential
+// (PrivateKey or ClientSecret) are unset, the preferred-email responder is skipped.
+type userServiceConfig struct {
+	BaseURL      string
+	ClientID     string
+	PrivateKey   string
+	ClientSecret string
+	Auth0Domain  string
+	Audience     string
+}
+
+// Configured reports whether enough config is present to build the user-service client.
+func (c userServiceConfig) Configured() bool {
+	return c.ClientID != "" && (c.PrivateKey != "" || c.ClientSecret != "")
 }
 
 // eventConfig holds event processing configuration
@@ -116,6 +135,7 @@ func parseEnv() environment {
 		ProjectLogoBaseURL: projectLogoBaseURL,
 		LFXAppOrigin:       lfxAppOrigin,
 		ITXConfig:          parseITXConfig(),
+		UserServiceConfig:  parseUserServiceConfig(lfxEnvironment),
 		IDMappingDisabled:  idMappingDisabled,
 		EventConfig:        parseEventConfig(),
 		InviteConfig:       parseInviteConfig(lfxEnvironment),
@@ -171,6 +191,48 @@ func parseITXConfig() itxConfig {
 		PrivateKey:  privateKey,
 		Auth0Domain: auth0Domain,
 		Audience:    audience,
+	}
+}
+
+// parseUserServiceConfig parses v1 user-service (API-gateway) configuration for the
+// preferred meeting-invite email RPC. Unlike ITX config it never exits on missing
+// values: when unset, the preferred-email responder is simply not started.
+// lfxEnvironment must be the normalized value from normalizeLFXEnvironment.
+func parseUserServiceConfig(lfxEnvironment string) userServiceConfig {
+	baseURL := os.Getenv("USER_SERVICE_BASE_URL")
+	if baseURL == "" {
+		switch lfxEnvironment {
+		case "prod":
+			baseURL = "https://api-gw.platform.linuxfoundation.org"
+		case "staging":
+			baseURL = "https://api-gw.staging.platform.linuxfoundation.org"
+		default:
+			baseURL = "https://api-gw.dev.platform.linuxfoundation.org"
+		}
+	}
+
+	audience := os.Getenv("USER_SERVICE_AUDIENCE")
+	if audience == "" {
+		// The API-gateway audience is the gateway URL itself (trailing slash).
+		audience = strings.TrimRight(baseURL, "/") + "/"
+	}
+
+	auth0Domain := os.Getenv("USER_SERVICE_AUTH0_DOMAIN")
+	if auth0Domain == "" {
+		if lfxEnvironment == "prod" {
+			auth0Domain = "linuxfoundation.auth0.com"
+		} else {
+			auth0Domain = "linuxfoundation-dev.auth0.com"
+		}
+	}
+
+	return userServiceConfig{
+		BaseURL:      baseURL,
+		ClientID:     os.Getenv("USER_SERVICE_CLIENT_ID"),
+		PrivateKey:   os.Getenv("USER_SERVICE_CLIENT_PRIVATE_KEY"),
+		ClientSecret: os.Getenv("USER_SERVICE_CLIENT_SECRET"),
+		Auth0Domain:  auth0Domain,
+		Audience:     audience,
 	}
 }
 

--- a/cmd/meeting-api/config_test.go
+++ b/cmd/meeting-api/config_test.go
@@ -31,6 +31,30 @@ func TestNormalizeLFXEnvironment(t *testing.T) {
 	}
 }
 
+func TestParseUserServiceConfig_DefaultBaseURLPerEnvironment(t *testing.T) {
+	tests := []struct {
+		env  string
+		want string
+	}{
+		{"prod", "https://api-gw.platform.linuxfoundation.org"},
+		{"staging", "https://api-gw.staging.platform.linuxfoundation.org"},
+		{"dev", "https://api-gw.dev.platform.linuxfoundation.org"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			t.Setenv("USER_SERVICE_BASE_URL", "")
+			got := parseUserServiceConfig(tt.env)
+			assert.Equal(t, tt.want, got.BaseURL)
+		})
+	}
+}
+
+func TestParseUserServiceConfig_EnvOverridesDefault(t *testing.T) {
+	t.Setenv("USER_SERVICE_BASE_URL", "https://api-gw.custom.example.org")
+	got := parseUserServiceConfig("prod")
+	assert.Equal(t, "https://api-gw.custom.example.org", got.BaseURL)
+}
+
 func TestParseInviteConfig_DefaultURLUsesNormalizedEnvironment(t *testing.T) {
 	t.Setenv("INVITES_ENABLED", "true")
 	t.Setenv("LFX_SELF_SERVE_BASE_URL", "")

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -157,41 +157,7 @@ func run() int {
 
 	// Start preferred-email RPC responder (LFXV2-2599) independently of KV event processing.
 	// It proxies get/set of a user's preferred meeting-invite email to the v1 user-service.
-	var preferredEmailResponder *natsinfra.PreferredEmailResponder
-	var preferredEmailNatsConn *natsgo.Conn
-	if env.UserServiceConfig.Configured() {
-		if natsURL == "" {
-			slog.WarnContext(ctx, "user-service configured but NATS_URL not set; preferred_email RPC responder will not start")
-		} else if userServiceClient, err := userservice.NewClient(userservice.Config{
-			BaseURL:      env.UserServiceConfig.BaseURL,
-			ClientID:     env.UserServiceConfig.ClientID,
-			PrivateKey:   env.UserServiceConfig.PrivateKey,
-			ClientSecret: env.UserServiceConfig.ClientSecret,
-			Auth0Domain:  env.UserServiceConfig.Auth0Domain,
-			Audience:     env.UserServiceConfig.Audience,
-			Timeout:      30 * time.Second,
-		}); err != nil {
-			slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to create user-service client; preferred_email RPC responder will not start")
-		} else {
-			nc, err := natsgo.Connect(natsURL)
-			if err != nil {
-				slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to connect to NATS for preferred_email responder; continuing without it")
-			} else {
-				preferredEmailService := service.NewPreferredEmailService(userServiceClient, slog.Default())
-				responder := natsinfra.NewPreferredEmailResponder(nc, preferredEmailService, slog.Default())
-				if err := responder.Start(ctx); err != nil {
-					nc.Close()
-					slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to start preferred_email responder; continuing without it")
-				} else {
-					preferredEmailNatsConn = nc
-					preferredEmailResponder = responder
-					slog.InfoContext(ctx, "preferred_email RPC responder initialized")
-				}
-			}
-		}
-	} else {
-		slog.InfoContext(ctx, "user-service not configured; preferred_email RPC responder disabled")
-	}
+	preferredEmailResponder, preferredEmailNatsConn := startPreferredEmailResponder(ctx, env, natsURL)
 
 	// Initialize event processor if enabled
 	var eventProcessor *apieventing.EventProcessor
@@ -327,4 +293,49 @@ func gracefulShutdown(
 
 	// Wait for the HTTP graceful shutdown
 	gracefulCloseWG.Wait()
+}
+
+// startPreferredEmailResponder builds the user-service client and starts the preferred-email
+// NATS responder (LFXV2-2599). It is best-effort: any missing config or startup failure is
+// logged and the service continues without the responder (returns nil, nil).
+func startPreferredEmailResponder(ctx context.Context, env environment, natsURL string) (*natsinfra.PreferredEmailResponder, *natsgo.Conn) {
+	if !env.UserServiceConfig.Configured() {
+		slog.InfoContext(ctx, "user-service not configured; preferred_email RPC responder disabled")
+		return nil, nil
+	}
+	if natsURL == "" {
+		slog.WarnContext(ctx, "user-service configured but NATS_URL not set; preferred_email RPC responder will not start")
+		return nil, nil
+	}
+
+	userServiceClient, err := userservice.NewClient(userservice.Config{
+		BaseURL:      env.UserServiceConfig.BaseURL,
+		ClientID:     env.UserServiceConfig.ClientID,
+		PrivateKey:   env.UserServiceConfig.PrivateKey,
+		ClientSecret: env.UserServiceConfig.ClientSecret,
+		Auth0Domain:  env.UserServiceConfig.Auth0Domain,
+		Audience:     env.UserServiceConfig.Audience,
+		Timeout:      30 * time.Second,
+	})
+	if err != nil {
+		slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to create user-service client; preferred_email RPC responder will not start")
+		return nil, nil
+	}
+
+	nc, err := natsgo.Connect(natsURL)
+	if err != nil {
+		slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to connect to NATS for preferred_email responder; continuing without it")
+		return nil, nil
+	}
+
+	preferredEmailService := service.NewPreferredEmailService(userServiceClient, slog.Default())
+	responder := natsinfra.NewPreferredEmailResponder(nc, preferredEmailService, slog.Default())
+	if err := responder.Start(ctx); err != nil {
+		nc.Close()
+		slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to start preferred_email responder; continuing without it")
+		return nil, nil
+	}
+
+	slog.InfoContext(ctx, "preferred_email RPC responder initialized")
+	return responder, nc
 }

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -20,7 +20,9 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/eventing"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/idmapper"
+	natsinfra "github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/nats"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/proxy"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/infrastructure/userservice"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/service"
 	itxservice "github.com/linuxfoundation/lfx-v2-meeting-service/internal/service/itx"
@@ -153,6 +155,44 @@ func run() int {
 		}
 	}
 
+	// Start preferred-email RPC responder (LFXV2-2599) independently of KV event processing.
+	// It proxies get/set of a user's preferred meeting-invite email to the v1 user-service.
+	var preferredEmailResponder *natsinfra.PreferredEmailResponder
+	var preferredEmailNatsConn *natsgo.Conn
+	if env.UserServiceConfig.Configured() {
+		if natsURL == "" {
+			slog.WarnContext(ctx, "user-service configured but NATS_URL not set; preferred_email RPC responder will not start")
+		} else if userServiceClient, err := userservice.NewClient(userservice.Config{
+			BaseURL:      env.UserServiceConfig.BaseURL,
+			ClientID:     env.UserServiceConfig.ClientID,
+			PrivateKey:   env.UserServiceConfig.PrivateKey,
+			ClientSecret: env.UserServiceConfig.ClientSecret,
+			Auth0Domain:  env.UserServiceConfig.Auth0Domain,
+			Audience:     env.UserServiceConfig.Audience,
+			Timeout:      30 * time.Second,
+		}); err != nil {
+			slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to create user-service client; preferred_email RPC responder will not start")
+		} else {
+			nc, err := natsgo.Connect(natsURL)
+			if err != nil {
+				slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to connect to NATS for preferred_email responder; continuing without it")
+			} else {
+				preferredEmailService := service.NewPreferredEmailService(userServiceClient, slog.Default())
+				responder := natsinfra.NewPreferredEmailResponder(nc, preferredEmailService, slog.Default())
+				if err := responder.Start(ctx); err != nil {
+					nc.Close()
+					slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to start preferred_email responder; continuing without it")
+				} else {
+					preferredEmailNatsConn = nc
+					preferredEmailResponder = responder
+					slog.InfoContext(ctx, "preferred_email RPC responder initialized")
+				}
+			}
+		}
+	} else {
+		slog.InfoContext(ctx, "user-service not configured; preferred_email RPC responder disabled")
+	}
+
 	// Initialize event processor if enabled
 	var eventProcessor *apieventing.EventProcessor
 	var eventProcessorCancel context.CancelFunc
@@ -220,7 +260,7 @@ func run() int {
 	// This next line blocks until SIGINT or SIGTERM is received.
 	<-done
 
-	gracefulShutdown(httpServer, &gracefulCloseWG, cancel, eventProcessor, eventProcessorCancel, inviteAcceptedSub, inviteNatsConn)
+	gracefulShutdown(httpServer, &gracefulCloseWG, cancel, eventProcessor, eventProcessorCancel, inviteAcceptedSub, inviteNatsConn, preferredEmailResponder, preferredEmailNatsConn)
 
 	return 0
 }
@@ -234,6 +274,8 @@ func gracefulShutdown(
 	eventProcessorCancel context.CancelFunc,
 	inviteAcceptedSub *apieventing.InviteAcceptedSubscriber,
 	inviteNatsConn *natsgo.Conn,
+	preferredEmailResponder *natsinfra.PreferredEmailResponder,
+	preferredEmailNatsConn *natsgo.Conn,
 ) {
 	if inviteAcceptedSub != nil {
 		slog.Info("shutting down invite_accepted subscriber")
@@ -242,6 +284,16 @@ func gracefulShutdown(
 	if inviteNatsConn != nil && !inviteNatsConn.IsClosed() {
 		if err := inviteNatsConn.Drain(); err != nil {
 			slog.With(logging.ErrKey, err).Error("error draining invite NATS connection")
+		}
+	}
+
+	if preferredEmailResponder != nil {
+		slog.Info("shutting down preferred_email responder")
+		preferredEmailResponder.Stop()
+	}
+	if preferredEmailNatsConn != nil && !preferredEmailNatsConn.IsClosed() {
+		if err := preferredEmailNatsConn.Drain(); err != nil {
+			slog.With(logging.ErrKey, err).Error("error draining preferred_email NATS connection")
 		}
 	}
 

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -299,23 +299,14 @@ func gracefulShutdown(
 // NATS responder (LFXV2-2599). It is best-effort: any missing config or startup failure is
 // logged and the service continues without the responder (returns nil, nil).
 func startPreferredEmailResponder(ctx context.Context, env environment, natsURL string) (*natsinfra.PreferredEmailResponder, *natsgo.Conn) {
-	if !env.UserServiceConfig.Configured() {
-		slog.InfoContext(ctx, "user-service not configured; preferred_email RPC responder disabled")
-		return nil, nil
-	}
 	if natsURL == "" {
-		slog.WarnContext(ctx, "user-service configured but NATS_URL not set; preferred_email RPC responder will not start")
+		slog.InfoContext(ctx, "NATS_URL not set; preferred_email RPC responder will not start")
 		return nil, nil
 	}
 
 	userServiceClient, err := userservice.NewClient(userservice.Config{
-		BaseURL:      env.UserServiceConfig.BaseURL,
-		ClientID:     env.UserServiceConfig.ClientID,
-		PrivateKey:   env.UserServiceConfig.PrivateKey,
-		ClientSecret: env.UserServiceConfig.ClientSecret,
-		Auth0Domain:  env.UserServiceConfig.Auth0Domain,
-		Audience:     env.UserServiceConfig.Audience,
-		Timeout:      30 * time.Second,
+		BaseURL: env.UserServiceConfig.BaseURL,
+		Timeout: 30 * time.Second,
 	})
 	if err != nil {
 		slog.With(logging.ErrKey, err).WarnContext(ctx, "failed to create user-service client; preferred_email RPC responder will not start")

--- a/internal/domain/user_service.go
+++ b/internal/domain/user_service.go
@@ -19,32 +19,43 @@ type PreferredEmail struct {
 	Email string
 }
 
-// UserServiceClient resolves a user's Salesforce ID and manages their preferred
-// meeting-invite email via the v1 user-service preferences API.
-//
-// Phase 1 storage lives in the v1 user-service (identical to the legacy myprofile
-// path) so itx-service-zoom keeps reading the preference unchanged through cutover.
-type UserServiceClient interface {
-	// ResolveSFIDByUsername returns the Salesforce ID for the given LFID/username.
-	// Returns ErrUserNotFound when no user matches.
-	ResolveSFIDByUsername(ctx context.Context, username string) (string, error)
+// Self is the calling user's identity as resolved from their bearer token via the
+// v1 user-service /v1/me endpoint.
+type Self struct {
+	// SFID is the user's Salesforce ID.
+	SFID string
+	// Emails is the user's email records (used to resolve an address to its EmailID).
+	Emails []SelfEmail
+}
 
-	// ResolveEmailID returns the Salesforce ID of the user's email record matching the
-	// given address. The email must be an active, verified record on the account (invites
-	// must only route to a verified address): a matching-but-unverified address is a
-	// ValidationError, while an unknown address returns a retryable UnavailableError (SFDC
-	// email records sync from auth0 asynchronously). The method never creates records.
-	ResolveEmailID(ctx context.Context, sfid, email string) (string, error)
+// SelfEmail is a single email record on the user's account.
+type SelfEmail struct {
+	ID       string
+	Address  string
+	Active   bool
+	Verified bool
+}
+
+// UserServiceClient reads a user's identity and manages their preferred meeting-invite
+// email via the v1 user-service preferences API, acting AS the user via their bearer token.
+//
+// Phase 1 storage lives in the v1 user-service (identical to the legacy myprofile path)
+// so itx-service-zoom keeps reading the preference unchanged through cutover. Calls use
+// the user's token (forwarded by self-serve), so they run with the user's own identity
+// and authorization.
+type UserServiceClient interface {
+	// GetSelf resolves the calling user (SFID + email records) from their bearer token.
+	GetSelf(ctx context.Context, token string) (*Self, error)
 
 	// GetMeetingEmailPreference returns the user's Type=Meeting email preference.
 	// Returns nil when no override is set (use primary).
-	GetMeetingEmailPreference(ctx context.Context, sfid string) (*PreferredEmail, error)
+	GetMeetingEmailPreference(ctx context.Context, token, sfid string) (*PreferredEmail, error)
 
 	// SetMeetingEmailPreference upserts the user's Type=Meeting email preference to
 	// the given verified-email record ID (EmailID) and returns the resulting selection.
-	SetMeetingEmailPreference(ctx context.Context, sfid, emailID string) (*PreferredEmail, error)
+	SetMeetingEmailPreference(ctx context.Context, token, sfid, emailID string) (*PreferredEmail, error)
 
 	// ClearMeetingEmailPreference removes the user's Type=Meeting email preference so
 	// their primary email is used. It is a no-op when no preference exists.
-	ClearMeetingEmailPreference(ctx context.Context, sfid string) error
+	ClearMeetingEmailPreference(ctx context.Context, token, sfid string) error
 }

--- a/internal/domain/user_service.go
+++ b/internal/domain/user_service.go
@@ -1,0 +1,50 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package domain
+
+import "context"
+
+// PreferredEmail is a user's preferred meeting-invite email selection.
+//
+// A nil *PreferredEmail (or a zero value) means no override is set and the user's
+// primary email should be used.
+type PreferredEmail struct {
+	// PreferenceID is the v1 user-service email-preference record UUID (Type=Meeting).
+	// Empty when no preference record exists.
+	PreferenceID string
+	// EmailID is the Salesforce ID of the verified-email record the user selected.
+	EmailID string
+	// Email is the address of the selected verified email.
+	Email string
+}
+
+// UserServiceClient resolves a user's Salesforce ID and manages their preferred
+// meeting-invite email via the v1 user-service preferences API.
+//
+// Phase 1 storage lives in the v1 user-service (identical to the legacy myprofile
+// path) so itx-service-zoom keeps reading the preference unchanged through cutover.
+type UserServiceClient interface {
+	// ResolveSFIDByUsername returns the Salesforce ID for the given LFID/username.
+	// Returns ErrUserNotFound when no user matches.
+	ResolveSFIDByUsername(ctx context.Context, username string) (string, error)
+
+	// ResolveEmailID returns the Salesforce ID of the user's email record matching the
+	// given address. The email must be an active, verified record on the account (invites
+	// must only route to a verified address): a matching-but-unverified address is a
+	// ValidationError, while an unknown address returns a retryable UnavailableError (SFDC
+	// email records sync from auth0 asynchronously). The method never creates records.
+	ResolveEmailID(ctx context.Context, sfid, email string) (string, error)
+
+	// GetMeetingEmailPreference returns the user's Type=Meeting email preference.
+	// Returns nil when no override is set (use primary).
+	GetMeetingEmailPreference(ctx context.Context, sfid string) (*PreferredEmail, error)
+
+	// SetMeetingEmailPreference upserts the user's Type=Meeting email preference to
+	// the given verified-email record ID (EmailID) and returns the resulting selection.
+	SetMeetingEmailPreference(ctx context.Context, sfid, emailID string) (*PreferredEmail, error)
+
+	// ClearMeetingEmailPreference removes the user's Type=Meeting email preference so
+	// their primary email is used. It is a no-op when no preference exists.
+	ClearMeetingEmailPreference(ctx context.Context, sfid string) error
+}

--- a/internal/infrastructure/nats/preferred_email_responder.go
+++ b/internal/infrastructure/nats/preferred_email_responder.go
@@ -15,23 +15,24 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 )
 
 const preferredEmailCallTimeout = 15 * time.Second
 
-// PreferredEmailProvider is the service behavior the responder needs.
+// PreferredEmailProvider is the service behavior the responder needs. All calls act AS the
+// user via the bearer token forwarded in the request.
 type PreferredEmailProvider interface {
 	// GetPreferredEmail returns the user's preferred meeting-invite email, or nil for primary.
-	GetPreferredEmail(ctx context.Context, username string) (*domain.PreferredEmail, error)
+	GetPreferredEmail(ctx context.Context, token string) (*domain.PreferredEmail, error)
 	// SetPreferredEmail sets the preference from a verified address (email) or an SFDC
 	// email-record ID (emailID); email takes precedence. An empty selection or "primary" clears it.
-	SetPreferredEmail(ctx context.Context, username, email, emailID string) (*domain.PreferredEmail, error)
+	SetPreferredEmail(ctx context.Context, token, email, emailID string) (*domain.PreferredEmail, error)
 }
 
-// preferredEmailRequest is the RPC request payload for get/set.
+// preferredEmailRequest is the RPC request payload for get/set. Token is the user's bearer
+// token, forwarded by self-serve; the user's identity is resolved from it.
 type preferredEmailRequest struct {
-	User    string  `json:"user"`
+	Token   string  `json:"token"`
 	Email   *string `json:"email,omitempty"`
 	EmailID *string `json:"email_id,omitempty"`
 }
@@ -127,9 +128,9 @@ func (r *PreferredEmailResponder) handleGet(msg *natsgo.Msg) {
 		return
 	}
 
-	pref, err := r.service.GetPreferredEmail(ctx, req.User)
+	pref, err := r.service.GetPreferredEmail(ctx, req.Token)
 	if err != nil {
-		r.respondError(msg, req.User, "get", err)
+		r.respondError(msg, "get", err)
 		return
 	}
 	r.respondSuccess(msg, pref)
@@ -157,9 +158,9 @@ func (r *PreferredEmailResponder) handleSet(msg *natsgo.Msg) {
 		emailID = *req.EmailID
 	}
 
-	pref, err := r.service.SetPreferredEmail(ctx, req.User, email, emailID)
+	pref, err := r.service.SetPreferredEmail(ctx, req.Token, email, emailID)
 	if err != nil {
-		r.respondError(msg, req.User, "set", err)
+		r.respondError(msg, "set", err)
 		return
 	}
 	r.respondSuccess(msg, pref)
@@ -194,11 +195,10 @@ func newPreferredEmailReply(pref *domain.PreferredEmail) preferredEmailReply {
 	return reply
 }
 
-// respondError logs and replies with an error envelope.
-func (r *PreferredEmailResponder) respondError(msg *natsgo.Msg, user, op string, err error) {
+// respondError logs and replies with an error envelope. The user's token is never logged.
+func (r *PreferredEmailResponder) respondError(msg *natsgo.Msg, op string, err error) {
 	r.logger.With(logging.ErrKey, err).Warn("preferred_email request failed",
 		"op", op,
-		"user", redaction.Redact(user),
 		"error_type", domain.GetErrorType(err),
 	)
 	r.reply(msg, errorReply{Error: err.Error()})

--- a/internal/infrastructure/nats/preferred_email_responder.go
+++ b/internal/infrastructure/nats/preferred_email_responder.go
@@ -1,0 +1,217 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	natsgo "github.com/nats-io/nats.go"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
+)
+
+const preferredEmailCallTimeout = 15 * time.Second
+
+// PreferredEmailProvider is the service behavior the responder needs.
+type PreferredEmailProvider interface {
+	// GetPreferredEmail returns the user's preferred meeting-invite email, or nil for primary.
+	GetPreferredEmail(ctx context.Context, username string) (*domain.PreferredEmail, error)
+	// SetPreferredEmail sets the preference from a verified address (email) or an SFDC
+	// email-record ID (emailID); email takes precedence. An empty selection or "primary" clears it.
+	SetPreferredEmail(ctx context.Context, username, email, emailID string) (*domain.PreferredEmail, error)
+}
+
+// preferredEmailRequest is the RPC request payload for get/set.
+type preferredEmailRequest struct {
+	User    string  `json:"user"`
+	Email   *string `json:"email,omitempty"`
+	EmailID *string `json:"email_id,omitempty"`
+}
+
+// preferredEmailReply is the RPC success reply payload.
+type preferredEmailReply struct {
+	EmailID *string `json:"email_id"`
+	Email   *string `json:"email"`
+}
+
+// errorReply is the RPC error envelope.
+type errorReply struct {
+	Error string `json:"error"`
+}
+
+// PreferredEmailResponder subscribes to the preferred-email RPC subjects and replies
+// with the user's preferred meeting-invite email selection.
+type PreferredEmailResponder struct {
+	nc      *natsgo.Conn
+	service PreferredEmailProvider
+	logger  *slog.Logger
+
+	subs []*natsgo.Subscription
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewPreferredEmailResponder creates a new responder but does not start it.
+func NewPreferredEmailResponder(nc *natsgo.Conn, service PreferredEmailProvider, logger *slog.Logger) *PreferredEmailResponder {
+	return &PreferredEmailResponder{nc: nc, service: service, logger: logger}
+}
+
+// Start registers the QueueSubscribe handlers for both RPC subjects.
+func (r *PreferredEmailResponder) Start(ctx context.Context) error {
+	r.ctx, r.cancel = context.WithCancel(ctx)
+
+	subjects := map[string]natsgo.MsgHandler{
+		constants.PreferredEmailGetSubject: r.handleGet,
+		constants.PreferredEmailSetSubject: r.handleSet,
+	}
+
+	for subject, handler := range subjects {
+		sub, err := r.nc.QueueSubscribe(subject, constants.PreferredEmailQueueGroup, handler)
+		if err != nil {
+			r.stopSubscriptions()
+			if r.cancel != nil {
+				r.cancel()
+			}
+			return err
+		}
+		r.subs = append(r.subs, sub)
+	}
+
+	r.logger.Info("preferred_email responder started",
+		"get_subject", constants.PreferredEmailGetSubject,
+		"set_subject", constants.PreferredEmailSetSubject,
+	)
+	return nil
+}
+
+// Stop cancels in-flight handlers, drains subscriptions, and waits for completion.
+func (r *PreferredEmailResponder) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.stopSubscriptions()
+	r.wg.Wait()
+}
+
+func (r *PreferredEmailResponder) stopSubscriptions() {
+	for _, sub := range r.subs {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Drain(); err != nil {
+			r.logger.With(logging.ErrKey, err).Warn("error draining preferred_email subscription")
+		}
+	}
+}
+
+// handleGet processes a preferred_email.get request.
+func (r *PreferredEmailResponder) handleGet(msg *natsgo.Msg) {
+	r.wg.Add(1)
+	defer r.wg.Done()
+
+	ctx, cancel := context.WithTimeout(r.ctx, preferredEmailCallTimeout)
+	defer cancel()
+
+	req, ok := r.decode(msg)
+	if !ok {
+		return
+	}
+
+	pref, err := r.service.GetPreferredEmail(ctx, req.User)
+	if err != nil {
+		r.respondError(msg, req.User, "get", err)
+		return
+	}
+	r.respondSuccess(msg, pref)
+}
+
+// handleSet processes a preferred_email.set request.
+func (r *PreferredEmailResponder) handleSet(msg *natsgo.Msg) {
+	r.wg.Add(1)
+	defer r.wg.Done()
+
+	ctx, cancel := context.WithTimeout(r.ctx, preferredEmailCallTimeout)
+	defer cancel()
+
+	req, ok := r.decode(msg)
+	if !ok {
+		return
+	}
+
+	email := ""
+	if req.Email != nil {
+		email = *req.Email
+	}
+	emailID := ""
+	if req.EmailID != nil {
+		emailID = *req.EmailID
+	}
+
+	pref, err := r.service.SetPreferredEmail(ctx, req.User, email, emailID)
+	if err != nil {
+		r.respondError(msg, req.User, "set", err)
+		return
+	}
+	r.respondSuccess(msg, pref)
+}
+
+// decode parses the request payload, replying with an error envelope on failure.
+func (r *PreferredEmailResponder) decode(msg *natsgo.Msg) (preferredEmailRequest, bool) {
+	var req preferredEmailRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		r.logger.With(logging.ErrKey, err).Warn("failed to parse preferred_email request")
+		r.reply(msg, errorReply{Error: "invalid request payload"})
+		return preferredEmailRequest{}, false
+	}
+	return req, true
+}
+
+// respondSuccess replies with the preferred-email selection (null fields for primary).
+func (r *PreferredEmailResponder) respondSuccess(msg *natsgo.Msg, pref *domain.PreferredEmail) {
+	r.reply(msg, newPreferredEmailReply(pref))
+}
+
+// newPreferredEmailReply maps a preferred-email selection to a reply payload. A nil
+// selection (or one without an EmailID) yields null email_id/email, meaning "use primary".
+func newPreferredEmailReply(pref *domain.PreferredEmail) preferredEmailReply {
+	var reply preferredEmailReply
+	if pref != nil && pref.EmailID != "" {
+		emailID := pref.EmailID
+		email := pref.Email
+		reply.EmailID = &emailID
+		reply.Email = &email
+	}
+	return reply
+}
+
+// respondError logs and replies with an error envelope.
+func (r *PreferredEmailResponder) respondError(msg *natsgo.Msg, user, op string, err error) {
+	r.logger.With(logging.ErrKey, err).Warn("preferred_email request failed",
+		"op", op,
+		"user", redaction.Redact(user),
+		"error_type", domain.GetErrorType(err),
+	)
+	r.reply(msg, errorReply{Error: err.Error()})
+}
+
+// reply marshals and sends a response, logging any transport failure.
+func (r *PreferredEmailResponder) reply(msg *natsgo.Msg, payload any) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		r.logger.With(logging.ErrKey, err).Error("failed to marshal preferred_email reply")
+		return
+	}
+	if err := msg.Respond(data); err != nil {
+		r.logger.With(logging.ErrKey, err).Warn("failed to send preferred_email reply")
+	}
+}

--- a/internal/infrastructure/nats/preferred_email_responder_test.go
+++ b/internal/infrastructure/nats/preferred_email_responder_test.go
@@ -1,0 +1,70 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package nats
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+func TestNewPreferredEmailReply(t *testing.T) {
+	t.Run("nil selection yields null fields (use primary)", func(t *testing.T) {
+		reply := newPreferredEmailReply(nil)
+		assert.Nil(t, reply.EmailID)
+		assert.Nil(t, reply.Email)
+
+		data, err := json.Marshal(reply)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"email_id":null,"email":null}`, string(data))
+	})
+
+	t.Run("empty EmailID yields null fields", func(t *testing.T) {
+		reply := newPreferredEmailReply(&domain.PreferredEmail{Email: "x@work.com"})
+		assert.Nil(t, reply.EmailID)
+		assert.Nil(t, reply.Email)
+	})
+
+	t.Run("populated selection yields both fields", func(t *testing.T) {
+		reply := newPreferredEmailReply(&domain.PreferredEmail{EmailID: "e1", Email: "alice@work.com"})
+		require.NotNil(t, reply.EmailID)
+		require.NotNil(t, reply.Email)
+		assert.Equal(t, "e1", *reply.EmailID)
+		assert.Equal(t, "alice@work.com", *reply.Email)
+	})
+}
+
+func TestPreferredEmailRequest_Decoding(t *testing.T) {
+	t.Run("null email_id decodes to nil pointer", func(t *testing.T) {
+		var req preferredEmailRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice","email_id":null}`), &req))
+		assert.Equal(t, "alice", req.User)
+		assert.Nil(t, req.EmailID)
+	})
+
+	t.Run("omitted email_id decodes to nil pointer", func(t *testing.T) {
+		var req preferredEmailRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice"}`), &req))
+		assert.Nil(t, req.EmailID)
+	})
+
+	t.Run("concrete email_id decodes to its value", func(t *testing.T) {
+		var req preferredEmailRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice","email_id":"e1"}`), &req))
+		require.NotNil(t, req.EmailID)
+		assert.Equal(t, "e1", *req.EmailID)
+	})
+
+	t.Run("email address decodes to its value", func(t *testing.T) {
+		var req preferredEmailRequest
+		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice","email":"alice@work.com"}`), &req))
+		require.NotNil(t, req.Email)
+		assert.Equal(t, "alice@work.com", *req.Email)
+		assert.Nil(t, req.EmailID)
+	})
+}

--- a/internal/infrastructure/nats/preferred_email_responder_test.go
+++ b/internal/infrastructure/nats/preferred_email_responder_test.go
@@ -42,27 +42,27 @@ func TestNewPreferredEmailReply(t *testing.T) {
 func TestPreferredEmailRequest_Decoding(t *testing.T) {
 	t.Run("null email_id decodes to nil pointer", func(t *testing.T) {
 		var req preferredEmailRequest
-		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice","email_id":null}`), &req))
-		assert.Equal(t, "alice", req.User)
+		require.NoError(t, json.Unmarshal([]byte(`{"token":"jwt","email_id":null}`), &req))
+		assert.Equal(t, "jwt", req.Token)
 		assert.Nil(t, req.EmailID)
 	})
 
 	t.Run("omitted email_id decodes to nil pointer", func(t *testing.T) {
 		var req preferredEmailRequest
-		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice"}`), &req))
+		require.NoError(t, json.Unmarshal([]byte(`{"token":"jwt"}`), &req))
 		assert.Nil(t, req.EmailID)
 	})
 
 	t.Run("concrete email_id decodes to its value", func(t *testing.T) {
 		var req preferredEmailRequest
-		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice","email_id":"e1"}`), &req))
+		require.NoError(t, json.Unmarshal([]byte(`{"token":"jwt","email_id":"e1"}`), &req))
 		require.NotNil(t, req.EmailID)
 		assert.Equal(t, "e1", *req.EmailID)
 	})
 
 	t.Run("email address decodes to its value", func(t *testing.T) {
 		var req preferredEmailRequest
-		require.NoError(t, json.Unmarshal([]byte(`{"user":"alice","email":"alice@work.com"}`), &req))
+		require.NoError(t, json.Unmarshal([]byte(`{"token":"jwt","email":"alice@work.com"}`), &req))
 		require.NotNil(t, req.Email)
 		assert.Equal(t, "alice@work.com", *req.Email)
 		assert.Nil(t, req.EmailID)

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -391,9 +391,11 @@ func (c *Client) doJSON(ctx context.Context, method, reqURL string, body, out an
 	}
 	httpReq.Header.Set("Accept", "application/json")
 
+	// Log only the URL path (not query) and body length — the query embeds usernames/SFIDs
+	// and response bodies contain email addresses, which are PII we must keep out of logs.
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		slog.DebugContext(ctx, "user-service request errored", "method", method, "url", reqURL, logging.ErrKey, err)
+		slog.DebugContext(ctx, "user-service request errored", "method", method, "path", httpReq.URL.Path, logging.ErrKey, err)
 		return domain.NewUnavailableError("user-service request failed", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -404,7 +406,7 @@ func (c *Client) doJSON(ctx context.Context, method, reqURL string, body, out an
 	}
 
 	slog.DebugContext(ctx, "user-service response",
-		"method", method, "url", reqURL, "status", resp.StatusCode, "body", truncate(string(respBody), 512))
+		"method", method, "path", httpReq.URL.Path, "status", resp.StatusCode, "body_len", len(respBody))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return mapHTTPError(resp.StatusCode, respBody)
@@ -444,12 +446,15 @@ func mapHTTPError(statusCode int, body []byte) error {
 	case http.StatusBadRequest:
 		return domain.NewValidationError(message)
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return domain.NewValidationError(fmt.Sprintf("authentication/authorization failed: %s", message))
+		// The M2M principal (not the RPC caller) failed to auth — a server-side/config
+		// problem, so Internal rather than Validation (which callers read as bad input).
+		return domain.NewInternalError(fmt.Sprintf("user-service authentication/authorization failed: %s", message))
 	case http.StatusNotFound:
 		return domain.NewNotFoundError(message)
 	case http.StatusConflict:
 		return domain.NewConflictError(message)
-	case http.StatusServiceUnavailable:
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		// Transient upstream failures — keep them retryable.
 		return domain.NewUnavailableError(message)
 	default:
 		return domain.NewInternalError(message)

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -3,8 +3,8 @@
 
 // Package userservice provides an HTTP client for the v1 user-service preferences
 // API, used to read and write a user's preferred meeting-invite email (Phase 1
-// storage for LFXV2-2599). It mirrors the ITX proxy client's Auth0 M2M setup but
-// targets the v1 API-gateway audience.
+// storage for LFXV2-2599). It calls the v1 API gateway AS the user, using the bearer
+// token forwarded from self-serve.
 package userservice
 
 import (
@@ -19,19 +19,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/auth0/go-auth0/authentication"
-	"github.com/auth0/go-auth0/authentication/oauth"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"golang.org/x/oauth2"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 )
 
 const (
-	tokenExpiryLeeway = 60 * time.Second
-
 	// apiPath is the user-service prefix behind the LFX API gateway.
 	apiPath = "/user-service/v1"
 
@@ -46,112 +40,32 @@ const (
 type Config struct {
 	// BaseURL is the API-gateway root, e.g. https://api-gw.dev.platform.linuxfoundation.org
 	BaseURL string
-	// ClientID is the Auth0 M2M client ID.
-	ClientID string
-	// PrivateKey is an RSA private key in PEM format for client-assertion (RS256) auth.
-	// Takes precedence over ClientSecret when both are set.
-	PrivateKey string
-	// ClientSecret is the Auth0 M2M client secret, used when PrivateKey is empty.
-	ClientSecret string
-	// Auth0Domain is the Auth0 tenant domain.
-	Auth0Domain string
-	// Audience is the OAuth2 audience for the API gateway.
-	Audience string
 	// Timeout bounds each HTTP request.
 	Timeout time.Duration
 }
 
-// Client implements domain.UserServiceClient against the v1 user-service API.
+// Client implements domain.UserServiceClient against the v1 user-service API, calling
+// it as the user via their bearer token.
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
 }
 
-// auth0TokenSource implements oauth2.TokenSource using the Auth0 SDK.
-type auth0TokenSource struct {
-	ctx        context.Context
-	authConfig *authentication.Authentication
-	audience   string
-}
-
-// Token implements the oauth2.TokenSource interface.
-func (a *auth0TokenSource) Token() (*oauth2.Token, error) {
-	ctx := a.ctx
-	if ctx == nil {
-		ctx = context.TODO()
-	}
-
-	tokenSet, err := a.authConfig.OAuth.LoginWithClientCredentials(ctx, oauth.LoginWithClientCredentialsRequest{
-		Audience: a.audience,
-	}, oauth.IDTokenValidationOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get token from Auth0: %w", err)
-	}
-
-	return &oauth2.Token{
-		AccessToken:  tokenSet.AccessToken,
-		TokenType:    tokenSet.TokenType,
-		RefreshToken: tokenSet.RefreshToken,
-		Expiry:       time.Now().Add(time.Duration(tokenSet.ExpiresIn)*time.Second - tokenExpiryLeeway),
-	}, nil
-}
-
-// NewClient creates a new user-service client with OAuth2 M2M authentication.
-// It uses private-key client-assertion when PrivateKey is set, otherwise a client secret.
+// NewClient creates a new user-service client.
 func NewClient(config Config) (*Client, error) {
-	ctx := context.Background()
-
 	if config.BaseURL == "" {
 		return nil, fmt.Errorf("user-service base URL is required")
 	}
-	if config.Auth0Domain == "" {
-		return nil, fmt.Errorf("user-service Auth0 domain is required")
-	}
-	if config.Audience == "" {
-		return nil, fmt.Errorf("user-service audience is required")
-	}
-	if config.ClientID == "" {
-		return nil, fmt.Errorf("user-service client ID is required")
-	}
-	if config.PrivateKey == "" && config.ClientSecret == "" {
-		return nil, fmt.Errorf("user-service requires either a private key or a client secret")
-	}
 
-	// otel-instrumented HTTP client for the Auth0 token requests.
-	otelClient := &http.Client{
+	httpClient := &http.Client{
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 		Timeout:   config.Timeout,
 	}
-
-	authOpts := []authentication.Option{
-		authentication.WithClientID(config.ClientID),
-		authentication.WithClient(otelClient),
-	}
-	if config.PrivateKey != "" {
-		authOpts = append(authOpts, authentication.WithClientAssertion(config.PrivateKey, "RS256"))
-	} else {
-		authOpts = append(authOpts, authentication.WithClientSecret(config.ClientSecret))
-	}
-
-	authConfig, err := authentication.New(ctx, config.Auth0Domain, authOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Auth0 client: %w", err)
-	}
-
-	tokenSource := &auth0TokenSource{ctx: ctx, authConfig: authConfig, audience: config.Audience}
-	reuseTokenSource := oauth2.ReuseTokenSource(nil, tokenSource)
-
-	// HTTP client that auto-manages tokens; wrap the transport with otelhttp so API
-	// calls appear in traces.
-	httpClient := oauth2.NewClient(ctx, reuseTokenSource)
-	httpClient.Transport = otelhttp.NewTransport(httpClient.Transport)
-	httpClient.Timeout = config.Timeout
-
 	return newClient(httpClient, config.BaseURL), nil
 }
 
 // newClient builds a Client from a ready HTTP client and base URL. It is the shared
-// constructor used by NewClient and tests (which inject an unauthenticated client).
+// constructor used by NewClient and tests.
 func newClient(httpClient *http.Client, baseURL string) *Client {
 	return &Client{
 		httpClient: httpClient,
@@ -161,14 +75,9 @@ func newClient(httpClient *http.Client, baseURL string) *Client {
 
 // --- user-service DTOs (subset of the swagger schema) ---
 
-type userListResponse struct {
-	Data []struct {
-		ID string `json:"ID"`
-	} `json:"Data"`
-}
-
-// userResponse is the subset of GET /v1/users/{sfid} we need: the user's email records.
-type userResponse struct {
+// meResponse is the subset of GET /v1/me (me-user) we need: the SFID and email records.
+type meResponse struct {
+	ID     string      `json:"ID"`
 	Emails []userEmail `json:"Emails"`
 }
 
@@ -205,78 +114,33 @@ type updateEmailPreferenceRequest struct {
 	IsDefault bool   `json:"IsDefault"`
 }
 
-// ResolveSFIDByUsername returns the Salesforce ID for the given LFID/username.
-func (c *Client) ResolveSFIDByUsername(ctx context.Context, username string) (string, error) {
-	username = strings.TrimSpace(username)
-	if username == "" {
-		return "", domain.NewValidationError("username is required")
+// GetSelf resolves the calling user's SFID and email records from their bearer token.
+func (c *Client) GetSelf(ctx context.Context, token string) (*domain.Self, error) {
+	reqURL := fmt.Sprintf("%s%s/me", c.baseURL, apiPath)
+
+	var me meResponse
+	if err := c.doJSON(ctx, token, http.MethodGet, reqURL, nil, &me); err != nil {
+		return nil, err
+	}
+	if me.ID == "" {
+		return nil, domain.NewInternalError("user-service /v1/me returned no user ID")
 	}
 
-	q := url.Values{}
-	q.Set("username", username)
-	reqURL := fmt.Sprintf("%s%s/users/search?%s", c.baseURL, apiPath, q.Encode())
-
-	var result userListResponse
-	if err := c.doJSON(ctx, http.MethodGet, reqURL, nil, &result); err != nil {
-		return "", err
+	self := &domain.Self{SFID: me.ID, Emails: make([]domain.SelfEmail, 0, len(me.Emails))}
+	for _, e := range me.Emails {
+		self.Emails = append(self.Emails, domain.SelfEmail{
+			ID:       e.ID,
+			Address:  e.EmailAddress,
+			Active:   e.Active,
+			Verified: e.IsVerified,
+		})
 	}
-
-	for _, u := range result.Data {
-		if u.ID != "" {
-			return u.ID, nil
-		}
-	}
-	return "", domain.ErrUserNotFound
-}
-
-// ResolveEmailID returns the Salesforce ID of the user's email record matching the given
-// address (case-insensitive). The email must be an active, VERIFIED record on the account —
-// meeting invites must only ever be routed to a verified address. A matching-but-unverified
-// address is a validation error; a completely unknown address yields a retryable
-// UnavailableError (verified emails sync into SFDC from auth0 asynchronously). This method
-// never creates records.
-func (c *Client) ResolveEmailID(ctx context.Context, sfid, email string) (string, error) {
-	sfid = strings.TrimSpace(sfid)
-	if sfid == "" {
-		return "", domain.NewValidationError("salesforce ID is required")
-	}
-	email = strings.TrimSpace(email)
-	if email == "" {
-		return "", domain.NewValidationError("email is required")
-	}
-
-	reqURL := fmt.Sprintf("%s%s/users/%s", c.baseURL, apiPath, url.PathEscape(sfid))
-	var user userResponse
-	if err := c.doJSON(ctx, http.MethodGet, reqURL, nil, &user); err != nil {
-		return "", err
-	}
-
-	matchedUnverified := false
-	for i := range user.Emails {
-		e := user.Emails[i]
-		if e.ID == "" || !strings.EqualFold(strings.TrimSpace(e.EmailAddress), email) {
-			continue
-		}
-		if e.Active && e.IsVerified {
-			return e.ID, nil
-		}
-		// Address belongs to the user but is not usable as an invite target.
-		matchedUnverified = true
-	}
-
-	// Redact the address in the returned error — it propagates into logs via ErrKey.
-	redactedEmail := redaction.RedactEmail(email)
-	if matchedUnverified {
-		return "", domain.NewValidationError(
-			fmt.Sprintf("email %q is not an active, verified address on this account", redactedEmail))
-	}
-	return "", domain.NewUnavailableError(
-		fmt.Sprintf("email %q not yet available in user-service; retry", redactedEmail))
+	return self, nil
 }
 
 // GetMeetingEmailPreference returns the user's Type=Meeting email preference, or nil.
-func (c *Client) GetMeetingEmailPreference(ctx context.Context, sfid string) (*domain.PreferredEmail, error) {
-	pref, err := c.getMeetingPreference(ctx, sfid)
+func (c *Client) GetMeetingEmailPreference(ctx context.Context, token, sfid string) (*domain.PreferredEmail, error) {
+	pref, err := c.getMeetingPreference(ctx, token, sfid)
 	if err != nil {
 		return nil, err
 	}
@@ -287,13 +151,13 @@ func (c *Client) GetMeetingEmailPreference(ctx context.Context, sfid string) (*d
 }
 
 // SetMeetingEmailPreference upserts the user's Type=Meeting email preference.
-func (c *Client) SetMeetingEmailPreference(ctx context.Context, sfid, emailID string) (*domain.PreferredEmail, error) {
+func (c *Client) SetMeetingEmailPreference(ctx context.Context, token, sfid, emailID string) (*domain.PreferredEmail, error) {
 	emailID = strings.TrimSpace(emailID)
 	if emailID == "" {
 		return nil, domain.NewValidationError("email_id is required to set a preference")
 	}
 
-	existing, err := c.getMeetingPreference(ctx, sfid)
+	existing, err := c.getMeetingPreference(ctx, token, sfid)
 	if err != nil {
 		return nil, err
 	}
@@ -303,18 +167,18 @@ func (c *Client) SetMeetingEmailPreference(ctx context.Context, sfid, emailID st
 	if existing != nil {
 		reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails/%s", c.baseURL, apiPath, url.PathEscape(sfid), url.PathEscape(existing.ID))
 		body := updateEmailPreferenceRequest{EmailID: emailID, IsDefault: true}
-		writeErr = c.doJSON(ctx, http.MethodPatch, reqURL, body, &result)
+		writeErr = c.doJSON(ctx, token, http.MethodPatch, reqURL, body, &result)
 	} else {
 		reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails", c.baseURL, apiPath, url.PathEscape(sfid))
 		body := createEmailPreferenceRequest{EmailID: emailID, Type: meetingPreferenceType, IsDefault: true}
-		writeErr = c.doJSON(ctx, http.MethodPost, reqURL, body, &result)
+		writeErr = c.doJSON(ctx, token, http.MethodPost, reqURL, body, &result)
 	}
 
 	if writeErr != nil {
 		// The user-service preferences write path commits the change but can return a
 		// bodyless upstream 5xx (observed on PATCH). Verify by re-reading: if the stored
 		// preference now matches the requested EmailID, treat the write as successful.
-		if pref, verifyErr := c.getMeetingPreference(ctx, sfid); verifyErr == nil && pref != nil && pref.EmailID == emailID {
+		if pref, verifyErr := c.getMeetingPreference(ctx, token, sfid); verifyErr == nil && pref != nil && pref.EmailID == emailID {
 			slog.DebugContext(ctx, "user-service write returned an error but the change was persisted; treating as success",
 				logging.ErrKey, writeErr)
 			return &domain.PreferredEmail{PreferenceID: pref.ID, EmailID: pref.EmailID, Email: pref.Email}, nil
@@ -326,8 +190,8 @@ func (c *Client) SetMeetingEmailPreference(ctx context.Context, sfid, emailID st
 }
 
 // ClearMeetingEmailPreference removes the user's Type=Meeting preference (no-op if none).
-func (c *Client) ClearMeetingEmailPreference(ctx context.Context, sfid string) error {
-	existing, err := c.getMeetingPreference(ctx, sfid)
+func (c *Client) ClearMeetingEmailPreference(ctx context.Context, token, sfid string) error {
+	existing, err := c.getMeetingPreference(ctx, token, sfid)
 	if err != nil {
 		return err
 	}
@@ -336,9 +200,9 @@ func (c *Client) ClearMeetingEmailPreference(ctx context.Context, sfid string) e
 	}
 
 	reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails/%s", c.baseURL, apiPath, url.PathEscape(sfid), url.PathEscape(existing.ID))
-	if delErr := c.doJSON(ctx, http.MethodDelete, reqURL, nil, nil); delErr != nil {
+	if delErr := c.doJSON(ctx, token, http.MethodDelete, reqURL, nil, nil); delErr != nil {
 		// As with the upsert path, verify the delete actually landed despite an upstream error.
-		if pref, verifyErr := c.getMeetingPreference(ctx, sfid); verifyErr == nil && pref == nil {
+		if pref, verifyErr := c.getMeetingPreference(ctx, token, sfid); verifyErr == nil && pref == nil {
 			slog.DebugContext(ctx, "user-service delete returned an error but the record is gone; treating as success",
 				logging.ErrKey, delErr)
 			return nil
@@ -349,7 +213,7 @@ func (c *Client) ClearMeetingEmailPreference(ctx context.Context, sfid string) e
 }
 
 // getMeetingPreference fetches the single Type=Meeting preference record, or nil if absent.
-func (c *Client) getMeetingPreference(ctx context.Context, sfid string) (*emailPreference, error) {
+func (c *Client) getMeetingPreference(ctx context.Context, token, sfid string) (*emailPreference, error) {
 	sfid = strings.TrimSpace(sfid)
 	if sfid == "" {
 		return nil, domain.NewValidationError("salesforce ID is required")
@@ -360,7 +224,7 @@ func (c *Client) getMeetingPreference(ctx context.Context, sfid string) (*emailP
 	reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails?%s", c.baseURL, apiPath, url.PathEscape(sfid), q.Encode())
 
 	var result emailPreferenceListResponse
-	if err := c.doJSON(ctx, http.MethodGet, reqURL, nil, &result); err != nil {
+	if err := c.doJSON(ctx, token, http.MethodGet, reqURL, nil, &result); err != nil {
 		return nil, err
 	}
 
@@ -373,9 +237,14 @@ func (c *Client) getMeetingPreference(ctx context.Context, sfid string) (*emailP
 	return nil, nil
 }
 
-// doJSON performs an HTTP request with an optional JSON body and decodes a JSON
-// response into out (out may be nil for no-content responses).
-func (c *Client) doJSON(ctx context.Context, method, reqURL string, body, out any) error {
+// doJSON performs an HTTP request as the user (bearer token) with an optional JSON body
+// and decodes a JSON response into out (out may be nil for no-content responses).
+func (c *Client) doJSON(ctx context.Context, token, method, reqURL string, body, out any) error {
+	token = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(token), "Bearer "))
+	if token == "" {
+		return domain.NewValidationError("user token is required")
+	}
+
 	var reader io.Reader
 	if body != nil {
 		encoded, err := json.Marshal(body)
@@ -389,13 +258,14 @@ func (c *Client) doJSON(ctx context.Context, method, reqURL string, body, out an
 	if err != nil {
 		return domain.NewInternalError("failed to create request", err)
 	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
 	if body != nil {
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
 	httpReq.Header.Set("Accept", "application/json")
 
-	// Log only the URL path (not query) and body length — the query embeds usernames/SFIDs
-	// and response bodies contain email addresses, which are PII we must keep out of logs.
+	// Log only the URL path (not query) and body length — the query embeds SFIDs and
+	// response bodies contain email addresses, which are PII we must keep out of logs.
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		slog.DebugContext(ctx, "user-service request errored", "method", method, "path", httpReq.URL.Path, logging.ErrKey, err)
@@ -449,9 +319,9 @@ func mapHTTPError(statusCode int, body []byte) error {
 	case http.StatusBadRequest:
 		return domain.NewValidationError(message)
 	case http.StatusUnauthorized, http.StatusForbidden:
-		// The M2M principal (not the RPC caller) failed to auth — a server-side/config
-		// problem, so Internal rather than Validation (which callers read as bad input).
-		return domain.NewInternalError(fmt.Sprintf("user-service authentication/authorization failed: %s", message))
+		// The user's forwarded token is missing/expired/unauthorized — a caller-supplied
+		// credential problem, so surface it as a validation error.
+		return domain.NewValidationError(fmt.Sprintf("user token rejected by user-service: %s", message))
 	case http.StatusNotFound:
 		return domain.NewNotFoundError(message)
 	case http.StatusConflict:

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -100,6 +100,15 @@ func (a *auth0TokenSource) Token() (*oauth2.Token, error) {
 func NewClient(config Config) (*Client, error) {
 	ctx := context.Background()
 
+	if config.BaseURL == "" {
+		return nil, fmt.Errorf("user-service base URL is required")
+	}
+	if config.Auth0Domain == "" {
+		return nil, fmt.Errorf("user-service Auth0 domain is required")
+	}
+	if config.Audience == "" {
+		return nil, fmt.Errorf("user-service audience is required")
+	}
 	if config.ClientID == "" {
 		return nil, fmt.Errorf("user-service client ID is required")
 	}

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -268,7 +268,7 @@ func (c *Client) ResolveEmailID(ctx context.Context, sfid, email string) (string
 	redactedEmail := redaction.RedactEmail(email)
 	if matchedUnverified {
 		return "", domain.NewValidationError(
-			fmt.Sprintf("email %q is not a verified address on this account", redactedEmail))
+			fmt.Sprintf("email %q is not an active, verified address on this account", redactedEmail))
 	}
 	return "", domain.NewUnavailableError(
 		fmt.Sprintf("email %q not yet available in user-service; retry", redactedEmail))

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -1,0 +1,460 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Package userservice provides an HTTP client for the v1 user-service preferences
+// API, used to read and write a user's preferred meeting-invite email (Phase 1
+// storage for LFXV2-2599). It mirrors the ITX proxy client's Auth0 M2M setup but
+// targets the v1 API-gateway audience.
+package userservice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/auth0/go-auth0/authentication"
+	"github.com/auth0/go-auth0/authentication/oauth"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"golang.org/x/oauth2"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
+)
+
+const (
+	tokenExpiryLeeway = 60 * time.Second
+
+	// apiPath is the user-service prefix behind the LFX API gateway.
+	apiPath = "/user-service/v1"
+
+	// meetingPreferenceType is the user-service email-preference type for meeting invites.
+	meetingPreferenceType = "Meeting"
+
+	// meetingFilter selects the Type=Meeting preference record (case-insensitive match).
+	meetingFilter = "type eq meeting"
+)
+
+// Config holds v1 user-service (API-gateway) client configuration.
+type Config struct {
+	// BaseURL is the API-gateway root, e.g. https://api-gw.dev.platform.linuxfoundation.org
+	BaseURL string
+	// ClientID is the Auth0 M2M client ID.
+	ClientID string
+	// PrivateKey is an RSA private key in PEM format for client-assertion (RS256) auth.
+	// Takes precedence over ClientSecret when both are set.
+	PrivateKey string
+	// ClientSecret is the Auth0 M2M client secret, used when PrivateKey is empty.
+	ClientSecret string
+	// Auth0Domain is the Auth0 tenant domain.
+	Auth0Domain string
+	// Audience is the OAuth2 audience for the API gateway.
+	Audience string
+	// Timeout bounds each HTTP request.
+	Timeout time.Duration
+}
+
+// Client implements domain.UserServiceClient against the v1 user-service API.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// auth0TokenSource implements oauth2.TokenSource using the Auth0 SDK.
+type auth0TokenSource struct {
+	ctx        context.Context
+	authConfig *authentication.Authentication
+	audience   string
+}
+
+// Token implements the oauth2.TokenSource interface.
+func (a *auth0TokenSource) Token() (*oauth2.Token, error) {
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	tokenSet, err := a.authConfig.OAuth.LoginWithClientCredentials(ctx, oauth.LoginWithClientCredentialsRequest{
+		Audience: a.audience,
+	}, oauth.IDTokenValidationOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token from Auth0: %w", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken:  tokenSet.AccessToken,
+		TokenType:    tokenSet.TokenType,
+		RefreshToken: tokenSet.RefreshToken,
+		Expiry:       time.Now().Add(time.Duration(tokenSet.ExpiresIn)*time.Second - tokenExpiryLeeway),
+	}, nil
+}
+
+// NewClient creates a new user-service client with OAuth2 M2M authentication.
+// It uses private-key client-assertion when PrivateKey is set, otherwise a client secret.
+func NewClient(config Config) (*Client, error) {
+	ctx := context.Background()
+
+	if config.ClientID == "" {
+		return nil, fmt.Errorf("user-service client ID is required")
+	}
+	if config.PrivateKey == "" && config.ClientSecret == "" {
+		return nil, fmt.Errorf("user-service requires either a private key or a client secret")
+	}
+
+	// otel-instrumented HTTP client for the Auth0 token requests.
+	otelClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Timeout:   config.Timeout,
+	}
+
+	authOpts := []authentication.Option{
+		authentication.WithClientID(config.ClientID),
+		authentication.WithClient(otelClient),
+	}
+	if config.PrivateKey != "" {
+		authOpts = append(authOpts, authentication.WithClientAssertion(config.PrivateKey, "RS256"))
+	} else {
+		authOpts = append(authOpts, authentication.WithClientSecret(config.ClientSecret))
+	}
+
+	authConfig, err := authentication.New(ctx, config.Auth0Domain, authOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Auth0 client: %w", err)
+	}
+
+	tokenSource := &auth0TokenSource{ctx: ctx, authConfig: authConfig, audience: config.Audience}
+	reuseTokenSource := oauth2.ReuseTokenSource(nil, tokenSource)
+
+	// HTTP client that auto-manages tokens; wrap the transport with otelhttp so API
+	// calls appear in traces.
+	httpClient := oauth2.NewClient(ctx, reuseTokenSource)
+	httpClient.Transport = otelhttp.NewTransport(httpClient.Transport)
+	httpClient.Timeout = config.Timeout
+
+	return newClient(httpClient, config.BaseURL), nil
+}
+
+// newClient builds a Client from a ready HTTP client and base URL. It is the shared
+// constructor used by NewClient and tests (which inject an unauthenticated client).
+func newClient(httpClient *http.Client, baseURL string) *Client {
+	return &Client{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+	}
+}
+
+// --- user-service DTOs (subset of the swagger schema) ---
+
+type userListResponse struct {
+	Data []struct {
+		ID string `json:"ID"`
+	} `json:"Data"`
+}
+
+// userResponse is the subset of GET /v1/users/{sfid} we need: the user's email records.
+type userResponse struct {
+	Emails []userEmail `json:"Emails"`
+}
+
+type userEmail struct {
+	ID           string `json:"ID"`
+	EmailAddress string `json:"EmailAddress"`
+	Active       bool   `json:"Active"`
+	IsVerified   bool   `json:"IsVerified"`
+}
+
+type emailPreference struct {
+	ID      string `json:"ID"`
+	EmailID string `json:"EmailID"`
+	Email   string `json:"Email"`
+	Type    string `json:"Type"`
+}
+
+type emailPreferenceListResponse struct {
+	Data []emailPreference `json:"Data"`
+}
+
+type createEmailPreferenceRequest struct {
+	EmailID   string `json:"EmailID"`
+	Type      string `json:"Type"`
+	IsDefault bool   `json:"IsDefault"`
+}
+
+// updateEmailPreferenceRequest is the PATCH body for an existing preference. It omits
+// Type on purpose: the record's Type is already set, and sending Type on the update path
+// makes the upstream user-service return an empty-body 502 (the write still lands). This
+// mirrors the myprofile client, which sends Type only on create.
+type updateEmailPreferenceRequest struct {
+	EmailID   string `json:"EmailID"`
+	IsDefault bool   `json:"IsDefault"`
+}
+
+// ResolveSFIDByUsername returns the Salesforce ID for the given LFID/username.
+func (c *Client) ResolveSFIDByUsername(ctx context.Context, username string) (string, error) {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return "", domain.NewValidationError("username is required")
+	}
+
+	q := url.Values{}
+	q.Set("username", username)
+	reqURL := fmt.Sprintf("%s%s/users/search?%s", c.baseURL, apiPath, q.Encode())
+
+	var result userListResponse
+	if err := c.doJSON(ctx, http.MethodGet, reqURL, nil, &result); err != nil {
+		return "", err
+	}
+
+	for _, u := range result.Data {
+		if u.ID != "" {
+			return u.ID, nil
+		}
+	}
+	return "", domain.ErrUserNotFound
+}
+
+// ResolveEmailID returns the Salesforce ID of the user's email record matching the given
+// address (case-insensitive). The email must be an active, VERIFIED record on the account —
+// meeting invites must only ever be routed to a verified address. A matching-but-unverified
+// address is a validation error; a completely unknown address yields a retryable
+// UnavailableError (verified emails sync into SFDC from auth0 asynchronously). This method
+// never creates records.
+func (c *Client) ResolveEmailID(ctx context.Context, sfid, email string) (string, error) {
+	sfid = strings.TrimSpace(sfid)
+	if sfid == "" {
+		return "", domain.NewValidationError("salesforce ID is required")
+	}
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return "", domain.NewValidationError("email is required")
+	}
+
+	reqURL := fmt.Sprintf("%s%s/users/%s", c.baseURL, apiPath, url.PathEscape(sfid))
+	var user userResponse
+	if err := c.doJSON(ctx, http.MethodGet, reqURL, nil, &user); err != nil {
+		return "", err
+	}
+
+	matchedUnverified := false
+	for i := range user.Emails {
+		e := user.Emails[i]
+		if e.ID == "" || !strings.EqualFold(strings.TrimSpace(e.EmailAddress), email) {
+			continue
+		}
+		if e.Active && e.IsVerified {
+			return e.ID, nil
+		}
+		// Address belongs to the user but is not usable as an invite target.
+		matchedUnverified = true
+	}
+
+	if matchedUnverified {
+		return "", domain.NewValidationError(
+			fmt.Sprintf("email %q is not a verified address on this account", email))
+	}
+	return "", domain.NewUnavailableError(
+		fmt.Sprintf("email %q not yet available in user-service; retry", email))
+}
+
+// GetMeetingEmailPreference returns the user's Type=Meeting email preference, or nil.
+func (c *Client) GetMeetingEmailPreference(ctx context.Context, sfid string) (*domain.PreferredEmail, error) {
+	pref, err := c.getMeetingPreference(ctx, sfid)
+	if err != nil {
+		return nil, err
+	}
+	if pref == nil {
+		return nil, nil
+	}
+	return &domain.PreferredEmail{PreferenceID: pref.ID, EmailID: pref.EmailID, Email: pref.Email}, nil
+}
+
+// SetMeetingEmailPreference upserts the user's Type=Meeting email preference.
+func (c *Client) SetMeetingEmailPreference(ctx context.Context, sfid, emailID string) (*domain.PreferredEmail, error) {
+	emailID = strings.TrimSpace(emailID)
+	if emailID == "" {
+		return nil, domain.NewValidationError("email_id is required to set a preference")
+	}
+
+	existing, err := c.getMeetingPreference(ctx, sfid)
+	if err != nil {
+		return nil, err
+	}
+
+	var result emailPreference
+	var writeErr error
+	if existing != nil {
+		reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails/%s", c.baseURL, apiPath, url.PathEscape(sfid), url.PathEscape(existing.ID))
+		body := updateEmailPreferenceRequest{EmailID: emailID, IsDefault: true}
+		writeErr = c.doJSON(ctx, http.MethodPatch, reqURL, body, &result)
+	} else {
+		reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails", c.baseURL, apiPath, url.PathEscape(sfid))
+		body := createEmailPreferenceRequest{EmailID: emailID, Type: meetingPreferenceType, IsDefault: true}
+		writeErr = c.doJSON(ctx, http.MethodPost, reqURL, body, &result)
+	}
+
+	if writeErr != nil {
+		// The user-service preferences write path commits the change but can return a
+		// bodyless upstream 5xx (observed on PATCH). Verify by re-reading: if the stored
+		// preference now matches the requested EmailID, treat the write as successful.
+		if pref, verifyErr := c.getMeetingPreference(ctx, sfid); verifyErr == nil && pref != nil && pref.EmailID == emailID {
+			slog.DebugContext(ctx, "user-service write returned an error but the change was persisted; treating as success",
+				logging.ErrKey, writeErr)
+			return &domain.PreferredEmail{PreferenceID: pref.ID, EmailID: pref.EmailID, Email: pref.Email}, nil
+		}
+		return nil, writeErr
+	}
+
+	return &domain.PreferredEmail{PreferenceID: result.ID, EmailID: result.EmailID, Email: result.Email}, nil
+}
+
+// ClearMeetingEmailPreference removes the user's Type=Meeting preference (no-op if none).
+func (c *Client) ClearMeetingEmailPreference(ctx context.Context, sfid string) error {
+	existing, err := c.getMeetingPreference(ctx, sfid)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return nil
+	}
+
+	reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails/%s", c.baseURL, apiPath, url.PathEscape(sfid), url.PathEscape(existing.ID))
+	if delErr := c.doJSON(ctx, http.MethodDelete, reqURL, nil, nil); delErr != nil {
+		// As with the upsert path, verify the delete actually landed despite an upstream error.
+		if pref, verifyErr := c.getMeetingPreference(ctx, sfid); verifyErr == nil && pref == nil {
+			slog.DebugContext(ctx, "user-service delete returned an error but the record is gone; treating as success",
+				logging.ErrKey, delErr)
+			return nil
+		}
+		return delErr
+	}
+	return nil
+}
+
+// getMeetingPreference fetches the single Type=Meeting preference record, or nil if absent.
+func (c *Client) getMeetingPreference(ctx context.Context, sfid string) (*emailPreference, error) {
+	sfid = strings.TrimSpace(sfid)
+	if sfid == "" {
+		return nil, domain.NewValidationError("salesforce ID is required")
+	}
+
+	q := url.Values{}
+	q.Set("$filter", meetingFilter)
+	reqURL := fmt.Sprintf("%s%s/users/%s/preferences/emails?%s", c.baseURL, apiPath, url.PathEscape(sfid), q.Encode())
+
+	var result emailPreferenceListResponse
+	if err := c.doJSON(ctx, http.MethodGet, reqURL, nil, &result); err != nil {
+		return nil, err
+	}
+
+	// The gateway filter is best-effort; guard by Type in case it returns extra rows.
+	for i := range result.Data {
+		if strings.EqualFold(result.Data[i].Type, meetingPreferenceType) {
+			return &result.Data[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// doJSON performs an HTTP request with an optional JSON body and decodes a JSON
+// response into out (out may be nil for no-content responses).
+func (c *Client) doJSON(ctx context.Context, method, reqURL string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return domain.NewInternalError("failed to marshal request", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, reqURL, reader)
+	if err != nil {
+		return domain.NewInternalError("failed to create request", err)
+	}
+	if body != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		slog.DebugContext(ctx, "user-service request errored", "method", method, "url", reqURL, logging.ErrKey, err)
+		return domain.NewUnavailableError("user-service request failed", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return domain.NewInternalError("failed to read response", err)
+	}
+
+	slog.DebugContext(ctx, "user-service response",
+		"method", method, "url", reqURL, "status", resp.StatusCode, "body", truncate(string(respBody), 512))
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return mapHTTPError(resp.StatusCode, respBody)
+	}
+
+	if out == nil || len(respBody) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return domain.NewInternalError("failed to parse response", err)
+	}
+	return nil
+}
+
+// mapHTTPError maps HTTP status codes to domain errors.
+func mapHTTPError(statusCode int, body []byte) error {
+	var errMsg struct {
+		Message string `json:"Message"`
+		Error   string `json:"error"`
+	}
+	_ = json.Unmarshal(body, &errMsg)
+
+	message := errMsg.Message
+	if message == "" {
+		message = errMsg.Error
+	}
+	if message == "" {
+		// No structured error (e.g. a gateway 5xx with an HTML/empty body); include a
+		// truncated raw body so the failure is diagnosable from the error alone.
+		message = fmt.Sprintf("HTTP %d error", statusCode)
+		if snippet := truncate(strings.TrimSpace(string(body)), 256); snippet != "" {
+			message = fmt.Sprintf("%s: %s", message, snippet)
+		}
+	}
+
+	switch statusCode {
+	case http.StatusBadRequest:
+		return domain.NewValidationError(message)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return domain.NewValidationError(fmt.Sprintf("authentication/authorization failed: %s", message))
+	case http.StatusNotFound:
+		return domain.NewNotFoundError(message)
+	case http.StatusConflict:
+		return domain.NewConflictError(message)
+	case http.StatusServiceUnavailable:
+		return domain.NewUnavailableError(message)
+	default:
+		return domain.NewInternalError(message)
+	}
+}
+
+// truncate shortens s to at most n runes, appending an ellipsis when truncated.
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
+// Ensure Client implements domain.UserServiceClient.
+var _ domain.UserServiceClient = (*Client)(nil)

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 )
 
 const (
@@ -263,12 +264,14 @@ func (c *Client) ResolveEmailID(ctx context.Context, sfid, email string) (string
 		matchedUnverified = true
 	}
 
+	// Redact the address in the returned error — it propagates into logs via ErrKey.
+	redactedEmail := redaction.RedactEmail(email)
 	if matchedUnverified {
 		return "", domain.NewValidationError(
-			fmt.Sprintf("email %q is not a verified address on this account", email))
+			fmt.Sprintf("email %q is not a verified address on this account", redactedEmail))
 	}
 	return "", domain.NewUnavailableError(
-		fmt.Sprintf("email %q not yet available in user-service; retry", email))
+		fmt.Sprintf("email %q not yet available in user-service; retry", redactedEmail))
 }
 
 // GetMeetingEmailPreference returns the user's Type=Meeting email preference, or nil.

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -264,12 +265,19 @@ func (c *Client) doJSON(ctx context.Context, token, method, reqURL string, body,
 	}
 	httpReq.Header.Set("Accept", "application/json")
 
-	// Log only the URL path (not query) and body length — the query embeds SFIDs and
-	// response bodies contain email addresses, which are PII we must keep out of logs.
+	// Log only method/status/length — the URL path embeds the SFID and response bodies
+	// contain email addresses, both of which are identifiers we keep out of logs.
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		slog.DebugContext(ctx, "user-service request errored", "method", method, "path", httpReq.URL.Path, logging.ErrKey, err)
-		return domain.NewUnavailableError("user-service request failed", err)
+		// *url.Error embeds the full request URL (SFID in the path); unwrap it so the
+		// SFID isn't logged here or carried into the returned/replied error.
+		cause := err
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) && urlErr.Err != nil {
+			cause = urlErr.Err
+		}
+		slog.DebugContext(ctx, "user-service request errored", "method", method, logging.ErrKey, cause)
+		return domain.NewUnavailableError("user-service request failed", cause)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -279,7 +287,7 @@ func (c *Client) doJSON(ctx context.Context, token, method, reqURL string, body,
 	}
 
 	slog.DebugContext(ctx, "user-service response",
-		"method", method, "path", httpReq.URL.Path, "status", resp.StatusCode, "body_len", len(respBody))
+		"method", method, "status", resp.StatusCode, "body_len", len(respBody))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return mapHTTPError(resp.StatusCode, respBody)

--- a/internal/infrastructure/userservice/client_test.go
+++ b/internal/infrastructure/userservice/client_test.go
@@ -251,7 +251,8 @@ func TestSetMeetingEmailPreference_WriteErrorNotPersisted(t *testing.T) {
 
 	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
 	require.Error(t, err)
-	assert.Equal(t, domain.ErrorTypeInternal, domain.GetErrorType(err))
+	// A 502 that did not persist maps to a retryable Unavailable error.
+	assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
 }
 
 func TestClearMeetingEmailPreference_DeleteErrorButGone(t *testing.T) {
@@ -328,11 +329,14 @@ func TestMapHTTPError(t *testing.T) {
 		want   domain.ErrorType
 	}{
 		{http.StatusBadRequest, domain.ErrorTypeValidation},
-		{http.StatusUnauthorized, domain.ErrorTypeValidation},
-		{http.StatusForbidden, domain.ErrorTypeValidation},
+		{http.StatusUnauthorized, domain.ErrorTypeInternal},
+		{http.StatusForbidden, domain.ErrorTypeInternal},
 		{http.StatusNotFound, domain.ErrorTypeNotFound},
 		{http.StatusConflict, domain.ErrorTypeConflict},
+		{http.StatusTooManyRequests, domain.ErrorTypeUnavailable},
+		{http.StatusBadGateway, domain.ErrorTypeUnavailable},
 		{http.StatusServiceUnavailable, domain.ErrorTypeUnavailable},
+		{http.StatusGatewayTimeout, domain.ErrorTypeUnavailable},
 		{http.StatusTeapot, domain.ErrorTypeInternal},
 	}
 	for _, tt := range tests {

--- a/internal/infrastructure/userservice/client_test.go
+++ b/internal/infrastructure/userservice/client_test.go
@@ -17,100 +17,66 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 )
 
-// testClient returns a Client pointed at the given test server with no auth transport.
+const testToken = "test-user-token"
+
+// testClient returns a Client pointed at the given test server.
 func testClient(server *httptest.Server) *Client {
 	return newClient(server.Client(), server.URL)
 }
 
-func TestResolveSFIDByUsername(t *testing.T) {
-	t.Run("returns SFID from first result", func(t *testing.T) {
+func TestGetSelf(t *testing.T) {
+	t.Run("returns SFID and emails, forwarding the bearer token", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "/user-service/v1/users/search", r.URL.Path)
-			assert.Equal(t, "alice", r.URL.Query().Get("username"))
-			_ = json.NewEncoder(w).Encode(userListResponse{Data: []struct {
-				ID string `json:"ID"`
-			}{{ID: "00Q4100000XcQnBEAV"}}})
+			assert.Equal(t, "/user-service/v1/me", r.URL.Path)
+			assert.Equal(t, "Bearer "+testToken, r.Header.Get("Authorization"))
+			_ = json.NewEncoder(w).Encode(meResponse{
+				ID: "SFID1",
+				Emails: []userEmail{
+					{ID: "e-1", EmailAddress: "alice@work.com", Active: true, IsVerified: true},
+					{ID: "e-2", EmailAddress: "old@work.com", Active: false, IsVerified: true},
+				},
+			})
 		}))
 		defer server.Close()
 
-		sfid, err := testClient(server).ResolveSFIDByUsername(context.Background(), "alice")
+		self, err := testClient(server).GetSelf(context.Background(), testToken)
 		require.NoError(t, err)
-		assert.Equal(t, "00Q4100000XcQnBEAV", sfid)
+		assert.Equal(t, "SFID1", self.SFID)
+		require.Len(t, self.Emails, 2)
+		assert.Equal(t, "alice@work.com", self.Emails[0].Address)
+		assert.True(t, self.Emails[0].Verified)
 	})
 
-	t.Run("empty result returns ErrUserNotFound", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(userListResponse{})
+	t.Run("strips a Bearer prefix from the provided token", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer "+testToken, r.Header.Get("Authorization"))
+			_ = json.NewEncoder(w).Encode(meResponse{ID: "SFID1"})
 		}))
 		defer server.Close()
 
-		_, err := testClient(server).ResolveSFIDByUsername(context.Background(), "ghost")
-		assert.ErrorIs(t, err, domain.ErrUserNotFound)
+		_, err := testClient(server).GetSelf(context.Background(), "Bearer "+testToken)
+		require.NoError(t, err)
 	})
 
-	t.Run("blank username is a validation error", func(t *testing.T) {
+	t.Run("blank token is a validation error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
-			t.Fatal("should not call the server for a blank username")
+			t.Fatal("should not call the server for a blank token")
 		}))
 		defer server.Close()
 
-		_, err := testClient(server).ResolveSFIDByUsername(context.Background(), "  ")
-		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
-	})
-}
-
-func TestResolveEmailID(t *testing.T) {
-	t.Run("matches a verified, active address case-insensitively", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, http.MethodGet, r.Method)
-			assert.Equal(t, "/user-service/v1/users/SFID1", r.URL.Path)
-			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
-				{ID: "e-inactive", EmailAddress: "old@work.com", Active: false, IsVerified: true},
-				{ID: "e-1", EmailAddress: "Alice@Work.com", Active: true, IsVerified: true},
-			}})
-		}))
-		defer server.Close()
-
-		id, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "alice@work.com")
-		require.NoError(t, err)
-		assert.Equal(t, "e-1", id)
-	})
-
-	t.Run("unverified match is a validation error (never routes invites to it)", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
-				{ID: "e-1", EmailAddress: "alice@work.com", Active: true, IsVerified: false},
-			}})
-		}))
-		defer server.Close()
-
-		_, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "alice@work.com")
+		_, err := testClient(server).GetSelf(context.Background(), "  ")
 		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
 	})
 
-	t.Run("not-yet-synced address returns retryable unavailable error", func(t *testing.T) {
+	t.Run("empty ID is an internal error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
-				{ID: "e-1", EmailAddress: "other@work.com", Active: true, IsVerified: true},
-			}})
+			_ = json.NewEncoder(w).Encode(meResponse{})
 		}))
 		defer server.Close()
 
-		_, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "new@work.com")
-		assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
-	})
-
-	t.Run("inactive (even if verified) match is not used", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
-				{ID: "e-1", EmailAddress: "alice@work.com", Active: false, IsVerified: true},
-			}})
-		}))
-		defer server.Close()
-
-		_, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "alice@work.com")
-		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+		_, err := testClient(server).GetSelf(context.Background(), testToken)
+		assert.Equal(t, domain.ErrorTypeInternal, domain.GetErrorType(err))
 	})
 }
 
@@ -120,18 +86,18 @@ func TestGetMeetingEmailPreference(t *testing.T) {
 			assert.Equal(t, http.MethodGet, r.Method)
 			assert.Equal(t, "/user-service/v1/users/SFID1/preferences/emails", r.URL.Path)
 			assert.Equal(t, "type eq meeting", r.URL.Query().Get("$filter"))
+			assert.Equal(t, "Bearer "+testToken, r.Header.Get("Authorization"))
 			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
 				{ID: "pref-1", EmailID: "email-sfid", Email: "alice@work.com", Type: "Meeting"},
 			}})
 		}))
 		defer server.Close()
 
-		pref, err := testClient(server).GetMeetingEmailPreference(context.Background(), "SFID1")
+		pref, err := testClient(server).GetMeetingEmailPreference(context.Background(), testToken, "SFID1")
 		require.NoError(t, err)
 		require.NotNil(t, pref)
 		assert.Equal(t, "pref-1", pref.PreferenceID)
 		assert.Equal(t, "email-sfid", pref.EmailID)
-		assert.Equal(t, "alice@work.com", pref.Email)
 	})
 
 	t.Run("returns nil when no preference set", func(t *testing.T) {
@@ -140,7 +106,7 @@ func TestGetMeetingEmailPreference(t *testing.T) {
 		}))
 		defer server.Close()
 
-		pref, err := testClient(server).GetMeetingEmailPreference(context.Background(), "SFID1")
+		pref, err := testClient(server).GetMeetingEmailPreference(context.Background(), testToken, "SFID1")
 		require.NoError(t, err)
 		assert.Nil(t, pref)
 	})
@@ -166,7 +132,7 @@ func TestSetMeetingEmailPreference_CreateWhenAbsent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "email-sfid")
+	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), testToken, "SFID1", "email-sfid")
 	require.NoError(t, err)
 	assert.True(t, posted, "expected POST when no preference exists")
 	assert.Equal(t, "email-sfid", postBody.EmailID)
@@ -202,11 +168,10 @@ func TestSetMeetingEmailPreference_PatchWhenPresent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
+	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), testToken, "SFID1", "new")
 	require.NoError(t, err)
 	assert.True(t, patched, "expected PATCH when a preference already exists")
 	assert.Equal(t, "new", pref.EmailID)
-	assert.Equal(t, "new@work.com", pref.Email)
 }
 
 func TestSetMeetingEmailPreference_WriteErrorButPersisted(t *testing.T) {
@@ -216,10 +181,9 @@ func TestSetMeetingEmailPreference_WriteErrorButPersisted(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
 			patched = true
-			w.WriteHeader(http.StatusBadGateway) // 502, empty body
+			w.WriteHeader(http.StatusBadGateway)
 			return
 		}
-		// GET preference: before the write returns "old"; after the write returns "new".
 		emailID := "old"
 		if patched {
 			emailID = "new"
@@ -230,14 +194,13 @@ func TestSetMeetingEmailPreference_WriteErrorButPersisted(t *testing.T) {
 	}))
 	defer server.Close()
 
-	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
+	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), testToken, "SFID1", "new")
 	require.NoError(t, err)
 	require.NotNil(t, pref)
 	assert.Equal(t, "new", pref.EmailID)
 }
 
 func TestSetMeetingEmailPreference_WriteErrorNotPersisted(t *testing.T) {
-	// The PATCH errors and the change did NOT land (GET still shows the old value). Expect the error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPatch {
 			w.WriteHeader(http.StatusBadGateway)
@@ -249,14 +212,13 @@ func TestSetMeetingEmailPreference_WriteErrorNotPersisted(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
+	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), testToken, "SFID1", "new")
 	require.Error(t, err)
 	// A 502 that did not persist maps to a retryable Unavailable error.
 	assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
 }
 
 func TestClearMeetingEmailPreference_DeleteErrorButGone(t *testing.T) {
-	// DELETE returns a bodyless 502 but the record is actually removed. Expect success.
 	deleted := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {
@@ -274,7 +236,7 @@ func TestClearMeetingEmailPreference_DeleteErrorButGone(t *testing.T) {
 	}))
 	defer server.Close()
 
-	require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), "SFID1"))
+	require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), testToken, "SFID1"))
 }
 
 func TestSetMeetingEmailPreference_BlankEmailID(t *testing.T) {
@@ -283,7 +245,7 @@ func TestSetMeetingEmailPreference_BlankEmailID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "  ")
+	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), testToken, "SFID1", "  ")
 	assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
 }
 
@@ -306,7 +268,7 @@ func TestClearMeetingEmailPreference(t *testing.T) {
 		}))
 		defer server.Close()
 
-		require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), "SFID1"))
+		require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), testToken, "SFID1"))
 		assert.True(t, deleted, "expected DELETE for existing preference")
 	})
 
@@ -319,7 +281,7 @@ func TestClearMeetingEmailPreference(t *testing.T) {
 		}))
 		defer server.Close()
 
-		require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), "SFID1"))
+		require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), testToken, "SFID1"))
 	})
 }
 
@@ -329,8 +291,8 @@ func TestMapHTTPError(t *testing.T) {
 		want   domain.ErrorType
 	}{
 		{http.StatusBadRequest, domain.ErrorTypeValidation},
-		{http.StatusUnauthorized, domain.ErrorTypeInternal},
-		{http.StatusForbidden, domain.ErrorTypeInternal},
+		{http.StatusUnauthorized, domain.ErrorTypeValidation},
+		{http.StatusForbidden, domain.ErrorTypeValidation},
 		{http.StatusNotFound, domain.ErrorTypeNotFound},
 		{http.StatusConflict, domain.ErrorTypeConflict},
 		{http.StatusTooManyRequests, domain.ErrorTypeUnavailable},

--- a/internal/infrastructure/userservice/client_test.go
+++ b/internal/infrastructure/userservice/client_test.go
@@ -1,0 +1,342 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package userservice
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+// testClient returns a Client pointed at the given test server with no auth transport.
+func testClient(server *httptest.Server) *Client {
+	return newClient(server.Client(), server.URL)
+}
+
+func TestResolveSFIDByUsername(t *testing.T) {
+	t.Run("returns SFID from first result", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/user-service/v1/users/search", r.URL.Path)
+			assert.Equal(t, "alice", r.URL.Query().Get("username"))
+			_ = json.NewEncoder(w).Encode(userListResponse{Data: []struct {
+				ID string `json:"ID"`
+			}{{ID: "00Q4100000XcQnBEAV"}}})
+		}))
+		defer server.Close()
+
+		sfid, err := testClient(server).ResolveSFIDByUsername(context.Background(), "alice")
+		require.NoError(t, err)
+		assert.Equal(t, "00Q4100000XcQnBEAV", sfid)
+	})
+
+	t.Run("empty result returns ErrUserNotFound", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(userListResponse{})
+		}))
+		defer server.Close()
+
+		_, err := testClient(server).ResolveSFIDByUsername(context.Background(), "ghost")
+		assert.ErrorIs(t, err, domain.ErrUserNotFound)
+	})
+
+	t.Run("blank username is a validation error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Fatal("should not call the server for a blank username")
+		}))
+		defer server.Close()
+
+		_, err := testClient(server).ResolveSFIDByUsername(context.Background(), "  ")
+		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+	})
+}
+
+func TestResolveEmailID(t *testing.T) {
+	t.Run("matches a verified, active address case-insensitively", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/user-service/v1/users/SFID1", r.URL.Path)
+			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
+				{ID: "e-inactive", EmailAddress: "old@work.com", Active: false, IsVerified: true},
+				{ID: "e-1", EmailAddress: "Alice@Work.com", Active: true, IsVerified: true},
+			}})
+		}))
+		defer server.Close()
+
+		id, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "alice@work.com")
+		require.NoError(t, err)
+		assert.Equal(t, "e-1", id)
+	})
+
+	t.Run("unverified match is a validation error (never routes invites to it)", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
+				{ID: "e-1", EmailAddress: "alice@work.com", Active: true, IsVerified: false},
+			}})
+		}))
+		defer server.Close()
+
+		_, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "alice@work.com")
+		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+	})
+
+	t.Run("not-yet-synced address returns retryable unavailable error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
+				{ID: "e-1", EmailAddress: "other@work.com", Active: true, IsVerified: true},
+			}})
+		}))
+		defer server.Close()
+
+		_, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "new@work.com")
+		assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
+	})
+
+	t.Run("inactive (even if verified) match is not used", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(userResponse{Emails: []userEmail{
+				{ID: "e-1", EmailAddress: "alice@work.com", Active: false, IsVerified: true},
+			}})
+		}))
+		defer server.Close()
+
+		_, err := testClient(server).ResolveEmailID(context.Background(), "SFID1", "alice@work.com")
+		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+	})
+}
+
+func TestGetMeetingEmailPreference(t *testing.T) {
+	t.Run("returns preference when present", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/user-service/v1/users/SFID1/preferences/emails", r.URL.Path)
+			assert.Equal(t, "type eq meeting", r.URL.Query().Get("$filter"))
+			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
+				{ID: "pref-1", EmailID: "email-sfid", Email: "alice@work.com", Type: "Meeting"},
+			}})
+		}))
+		defer server.Close()
+
+		pref, err := testClient(server).GetMeetingEmailPreference(context.Background(), "SFID1")
+		require.NoError(t, err)
+		require.NotNil(t, pref)
+		assert.Equal(t, "pref-1", pref.PreferenceID)
+		assert.Equal(t, "email-sfid", pref.EmailID)
+		assert.Equal(t, "alice@work.com", pref.Email)
+	})
+
+	t.Run("returns nil when no preference set", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{})
+		}))
+		defer server.Close()
+
+		pref, err := testClient(server).GetMeetingEmailPreference(context.Background(), "SFID1")
+		require.NoError(t, err)
+		assert.Nil(t, pref)
+	})
+}
+
+func TestSetMeetingEmailPreference_CreateWhenAbsent(t *testing.T) {
+	var postBody createEmailPreferenceRequest
+	posted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{})
+		case http.MethodPost:
+			posted = true
+			assert.Equal(t, "/user-service/v1/users/SFID1/preferences/emails", r.URL.Path)
+			body, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(body, &postBody))
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(emailPreference{ID: "pref-new", EmailID: "email-sfid", Email: "alice@work.com", Type: "Meeting"})
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "email-sfid")
+	require.NoError(t, err)
+	assert.True(t, posted, "expected POST when no preference exists")
+	assert.Equal(t, "email-sfid", postBody.EmailID)
+	assert.Equal(t, "Meeting", postBody.Type)
+	assert.True(t, postBody.IsDefault)
+	assert.Equal(t, "pref-new", pref.PreferenceID)
+}
+
+func TestSetMeetingEmailPreference_PatchWhenPresent(t *testing.T) {
+	patched := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
+				{ID: "pref-1", EmailID: "old", Email: "old@work.com", Type: "Meeting"},
+			}})
+		case http.MethodPatch:
+			patched = true
+			assert.Equal(t, "/user-service/v1/users/SFID1/preferences/emails/pref-1", r.URL.Path)
+			// The PATCH body must NOT include Type — sending it on the update path makes the
+			// upstream user-service return an empty-body 502 (the write still lands).
+			var raw map[string]any
+			body, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(body, &raw))
+			_, hasType := raw["Type"]
+			assert.False(t, hasType, "PATCH body must not include Type")
+			assert.Equal(t, "new", raw["EmailID"])
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(emailPreference{ID: "pref-1", EmailID: "new", Email: "new@work.com", Type: "Meeting"})
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
+	require.NoError(t, err)
+	assert.True(t, patched, "expected PATCH when a preference already exists")
+	assert.Equal(t, "new", pref.EmailID)
+	assert.Equal(t, "new@work.com", pref.Email)
+}
+
+func TestSetMeetingEmailPreference_WriteErrorButPersisted(t *testing.T) {
+	// The PATCH returns a bodyless 502 (as observed against dev), but the change is
+	// persisted — the follow-up GET reflects the new EmailID. Expect success.
+	patched := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patched = true
+			w.WriteHeader(http.StatusBadGateway) // 502, empty body
+			return
+		}
+		// GET preference: before the write returns "old"; after the write returns "new".
+		emailID := "old"
+		if patched {
+			emailID = "new"
+		}
+		_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
+			{ID: "pref-1", EmailID: emailID, Email: "x@work.com", Type: "Meeting"},
+		}})
+	}))
+	defer server.Close()
+
+	pref, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
+	require.NoError(t, err)
+	require.NotNil(t, pref)
+	assert.Equal(t, "new", pref.EmailID)
+}
+
+func TestSetMeetingEmailPreference_WriteErrorNotPersisted(t *testing.T) {
+	// The PATCH errors and the change did NOT land (GET still shows the old value). Expect the error.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
+			{ID: "pref-1", EmailID: "old", Email: "x@work.com", Type: "Meeting"},
+		}})
+	}))
+	defer server.Close()
+
+	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "new")
+	require.Error(t, err)
+	assert.Equal(t, domain.ErrorTypeInternal, domain.GetErrorType(err))
+}
+
+func TestClearMeetingEmailPreference_DeleteErrorButGone(t *testing.T) {
+	// DELETE returns a bodyless 502 but the record is actually removed. Expect success.
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = true
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if deleted {
+			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
+			{ID: "pref-1", EmailID: "e", Email: "e@work.com", Type: "Meeting"},
+		}})
+	}))
+	defer server.Close()
+
+	require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), "SFID1"))
+}
+
+func TestSetMeetingEmailPreference_BlankEmailID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("should not call the server for a blank email_id")
+	}))
+	defer server.Close()
+
+	_, err := testClient(server).SetMeetingEmailPreference(context.Background(), "SFID1", "  ")
+	assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+}
+
+func TestClearMeetingEmailPreference(t *testing.T) {
+	t.Run("deletes existing preference", func(t *testing.T) {
+		deleted := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet:
+				_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{Data: []emailPreference{
+					{ID: "pref-1", EmailID: "e", Email: "e@work.com", Type: "Meeting"},
+				}})
+			case http.MethodDelete:
+				deleted = true
+				assert.Equal(t, "/user-service/v1/users/SFID1/preferences/emails/pref-1", r.URL.Path)
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Fatalf("unexpected method %s", r.Method)
+			}
+		}))
+		defer server.Close()
+
+		require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), "SFID1"))
+		assert.True(t, deleted, "expected DELETE for existing preference")
+	})
+
+	t.Run("no-op when no preference exists", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				t.Fatal("should not DELETE when no preference exists")
+			}
+			_ = json.NewEncoder(w).Encode(emailPreferenceListResponse{})
+		}))
+		defer server.Close()
+
+		require.NoError(t, testClient(server).ClearMeetingEmailPreference(context.Background(), "SFID1"))
+	})
+}
+
+func TestMapHTTPError(t *testing.T) {
+	tests := []struct {
+		status int
+		want   domain.ErrorType
+	}{
+		{http.StatusBadRequest, domain.ErrorTypeValidation},
+		{http.StatusUnauthorized, domain.ErrorTypeValidation},
+		{http.StatusForbidden, domain.ErrorTypeValidation},
+		{http.StatusNotFound, domain.ErrorTypeNotFound},
+		{http.StatusConflict, domain.ErrorTypeConflict},
+		{http.StatusServiceUnavailable, domain.ErrorTypeUnavailable},
+		{http.StatusTeapot, domain.ErrorTypeInternal},
+	}
+	for _, tt := range tests {
+		err := mapHTTPError(tt.status, []byte(`{"Message":"boom"}`))
+		assert.Equal(t, tt.want, domain.GetErrorType(err))
+	}
+}

--- a/internal/service/preferred_email_service.go
+++ b/internal/service/preferred_email_service.go
@@ -1,0 +1,83 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+// primaryEmailSentinel is the special email_id value that clears the override so the
+// user's primary email is used (mirrors the myprofile "use primary" behavior).
+const primaryEmailSentinel = "primary"
+
+// PreferredEmailService orchestrates reading and writing a user's preferred
+// meeting-invite email: it resolves the LFID/username to a Salesforce ID and then
+// delegates storage to the v1 user-service (Phase 1).
+type PreferredEmailService struct {
+	userClient domain.UserServiceClient
+	logger     *slog.Logger
+}
+
+// NewPreferredEmailService creates a new PreferredEmailService.
+func NewPreferredEmailService(userClient domain.UserServiceClient, logger *slog.Logger) *PreferredEmailService {
+	return &PreferredEmailService{userClient: userClient, logger: logger}
+}
+
+// GetPreferredEmail returns the user's preferred meeting-invite email, or nil when
+// no override is set (use primary).
+func (s *PreferredEmailService) GetPreferredEmail(ctx context.Context, username string) (*domain.PreferredEmail, error) {
+	sfid, err := s.resolveSFID(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	return s.userClient.GetMeetingEmailPreference(ctx, sfid)
+}
+
+// SetPreferredEmail sets the user's preferred meeting-invite email.
+//
+// The selection may be given as a verified email address (email) or as an SFDC email
+// record ID (emailID); email takes precedence when non-empty. An empty selection, or the
+// "primary" sentinel, clears the override, in which case a nil PreferredEmail is returned.
+// When an address is given it is resolved to its (auth0→SFDC synced) email-record ID; a
+// not-yet-synced address surfaces the client's retryable error.
+func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username, email, emailID string) (*domain.PreferredEmail, error) {
+	sfid, err := s.resolveSFID(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+
+	email = strings.TrimSpace(email)
+	emailID = strings.TrimSpace(emailID)
+
+	// An address takes precedence and is resolved to its SFDC email-record ID.
+	if email != "" && !strings.EqualFold(email, primaryEmailSentinel) {
+		resolvedID, err := s.userClient.ResolveEmailID(ctx, sfid, email)
+		if err != nil {
+			return nil, err
+		}
+		emailID = resolvedID
+	}
+
+	if emailID == "" || strings.EqualFold(emailID, primaryEmailSentinel) {
+		if err := s.userClient.ClearMeetingEmailPreference(ctx, sfid); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	return s.userClient.SetMeetingEmailPreference(ctx, sfid, emailID)
+}
+
+// resolveSFID resolves an LFID/username to a Salesforce ID.
+func (s *PreferredEmailService) resolveSFID(ctx context.Context, username string) (string, error) {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return "", domain.NewValidationError("user is required")
+	}
+	return s.userClient.ResolveSFIDByUsername(ctx, username)
+}

--- a/internal/service/preferred_email_service.go
+++ b/internal/service/preferred_email_service.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 )
 
 // primaryEmailSentinel is the special email_id value that clears the override so the
@@ -35,7 +37,13 @@ func (s *PreferredEmailService) GetPreferredEmail(ctx context.Context, username 
 	if err != nil {
 		return nil, err
 	}
-	return s.userClient.GetMeetingEmailPreference(ctx, sfid)
+	pref, err := s.userClient.GetMeetingEmailPreference(ctx, sfid)
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to get preferred meeting email",
+			"user", redaction.Redact(username), logging.ErrKey, err)
+		return nil, err
+	}
+	return pref, nil
 }
 
 // SetPreferredEmail sets the user's preferred meeting-invite email.
@@ -58,6 +66,8 @@ func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username,
 	if email != "" && !strings.EqualFold(email, primaryEmailSentinel) {
 		resolvedID, err := s.userClient.ResolveEmailID(ctx, sfid, email)
 		if err != nil {
+			s.logger.WarnContext(ctx, "failed to resolve email address to a verified record",
+				"user", redaction.Redact(username), logging.ErrKey, err)
 			return nil, err
 		}
 		emailID = resolvedID
@@ -65,12 +75,22 @@ func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username,
 
 	if emailID == "" || strings.EqualFold(emailID, primaryEmailSentinel) {
 		if err := s.userClient.ClearMeetingEmailPreference(ctx, sfid); err != nil {
+			s.logger.WarnContext(ctx, "failed to clear preferred meeting email",
+				"user", redaction.Redact(username), logging.ErrKey, err)
 			return nil, err
 		}
+		s.logger.InfoContext(ctx, "cleared preferred meeting email override", "user", redaction.Redact(username))
 		return nil, nil
 	}
 
-	return s.userClient.SetMeetingEmailPreference(ctx, sfid, emailID)
+	pref, err := s.userClient.SetMeetingEmailPreference(ctx, sfid, emailID)
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to set preferred meeting email",
+			"user", redaction.Redact(username), logging.ErrKey, err)
+		return nil, err
+	}
+	s.logger.InfoContext(ctx, "set preferred meeting email", "user", redaction.Redact(username))
+	return pref, nil
 }
 
 // resolveSFID resolves an LFID/username to a Salesforce ID.
@@ -79,5 +99,11 @@ func (s *PreferredEmailService) resolveSFID(ctx context.Context, username string
 	if username == "" {
 		return "", domain.NewValidationError("user is required")
 	}
-	return s.userClient.ResolveSFIDByUsername(ctx, username)
+	sfid, err := s.userClient.ResolveSFIDByUsername(ctx, username)
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to resolve user to a Salesforce ID",
+			"user", redaction.Redact(username), logging.ErrKey, err)
+		return "", err
+	}
+	return sfid, nil
 }

--- a/internal/service/preferred_email_service.go
+++ b/internal/service/preferred_email_service.go
@@ -62,15 +62,20 @@ func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username,
 	email = strings.TrimSpace(email)
 	emailID = strings.TrimSpace(emailID)
 
-	// An address takes precedence and is resolved to its SFDC email-record ID.
-	if email != "" && !strings.EqualFold(email, primaryEmailSentinel) {
-		resolvedID, err := s.userClient.ResolveEmailID(ctx, sfid, email)
-		if err != nil {
-			s.logger.WarnContext(ctx, "failed to resolve email address to a verified record",
-				"user", redaction.Redact(username), logging.ErrKey, err)
-			return nil, err
+	// A provided address fully determines the selection (takes precedence over email_id):
+	// "primary" clears the override, any other address resolves to its SFDC email-record ID.
+	if email != "" {
+		if strings.EqualFold(email, primaryEmailSentinel) {
+			emailID = ""
+		} else {
+			resolvedID, err := s.userClient.ResolveEmailID(ctx, sfid, email)
+			if err != nil {
+				s.logger.WarnContext(ctx, "failed to resolve email address to a verified record",
+					"user", redaction.Redact(username), logging.ErrKey, err)
+				return nil, err
+			}
+			emailID = resolvedID
 		}
-		emailID = resolvedID
 	}
 
 	if emailID == "" || strings.EqualFold(emailID, primaryEmailSentinel) {

--- a/internal/service/preferred_email_service.go
+++ b/internal/service/preferred_email_service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -13,13 +14,14 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 )
 
-// primaryEmailSentinel is the special email_id value that clears the override so the
+// primaryEmailSentinel is the special email/email_id value that clears the override so the
 // user's primary email is used (mirrors the myprofile "use primary" behavior).
 const primaryEmailSentinel = "primary"
 
 // PreferredEmailService orchestrates reading and writing a user's preferred
-// meeting-invite email: it resolves the LFID/username to a Salesforce ID and then
-// delegates storage to the v1 user-service (Phase 1).
+// meeting-invite email. It acts AS the user via their bearer token (forwarded by
+// self-serve): it resolves the user from the token and delegates storage to the v1
+// user-service (Phase 1).
 type PreferredEmailService struct {
 	userClient domain.UserServiceClient
 	logger     *slog.Logger
@@ -32,29 +34,27 @@ func NewPreferredEmailService(userClient domain.UserServiceClient, logger *slog.
 
 // GetPreferredEmail returns the user's preferred meeting-invite email, or nil when
 // no override is set (use primary).
-func (s *PreferredEmailService) GetPreferredEmail(ctx context.Context, username string) (*domain.PreferredEmail, error) {
-	sfid, err := s.resolveSFID(ctx, username)
+func (s *PreferredEmailService) GetPreferredEmail(ctx context.Context, token string) (*domain.PreferredEmail, error) {
+	self, err := s.getSelf(ctx, token)
 	if err != nil {
 		return nil, err
 	}
-	pref, err := s.userClient.GetMeetingEmailPreference(ctx, sfid)
+	pref, err := s.userClient.GetMeetingEmailPreference(ctx, token, self.SFID)
 	if err != nil {
 		s.logger.WarnContext(ctx, "failed to get preferred meeting email",
-			"user", redaction.Redact(username), logging.ErrKey, err)
+			"user", redaction.Redact(self.SFID), logging.ErrKey, err)
 		return nil, err
 	}
 	return pref, nil
 }
 
-// SetPreferredEmail sets the user's preferred meeting-invite email.
-//
-// The selection may be given as a verified email address (email) or as an SFDC email
-// record ID (emailID); email takes precedence when non-empty. An empty selection, or the
-// "primary" sentinel, clears the override, in which case a nil PreferredEmail is returned.
-// When an address is given it is resolved to its (auth0→SFDC synced) email-record ID; a
-// not-yet-synced address surfaces the client's retryable error.
-func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username, email, emailID string) (*domain.PreferredEmail, error) {
-	sfid, err := s.resolveSFID(ctx, username)
+// SetPreferredEmail sets the user's preferred meeting-invite email. The selection may be
+// given as a verified email address (email) or an SFDC email-record ID (emailID); email
+// takes precedence when non-empty. An empty selection, or the "primary" sentinel, clears
+// the override, in which case a nil PreferredEmail is returned. An address is resolved to
+// its (auth0→SFDC synced) email-record ID and must be an active, verified email.
+func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, token, email, emailID string) (*domain.PreferredEmail, error) {
+	self, err := s.getSelf(ctx, token)
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +68,10 @@ func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username,
 		if strings.EqualFold(email, primaryEmailSentinel) {
 			emailID = ""
 		} else {
-			resolvedID, err := s.userClient.ResolveEmailID(ctx, sfid, email)
+			resolvedID, err := resolveVerifiedEmailID(self, email)
 			if err != nil {
 				s.logger.WarnContext(ctx, "failed to resolve email address to a verified record",
-					"user", redaction.Redact(username), logging.ErrKey, err)
+					"user", redaction.Redact(self.SFID), logging.ErrKey, err)
 				return nil, err
 			}
 			emailID = resolvedID
@@ -79,36 +79,57 @@ func (s *PreferredEmailService) SetPreferredEmail(ctx context.Context, username,
 	}
 
 	if emailID == "" || strings.EqualFold(emailID, primaryEmailSentinel) {
-		if err := s.userClient.ClearMeetingEmailPreference(ctx, sfid); err != nil {
+		if err := s.userClient.ClearMeetingEmailPreference(ctx, token, self.SFID); err != nil {
 			s.logger.WarnContext(ctx, "failed to clear preferred meeting email",
-				"user", redaction.Redact(username), logging.ErrKey, err)
+				"user", redaction.Redact(self.SFID), logging.ErrKey, err)
 			return nil, err
 		}
-		s.logger.InfoContext(ctx, "cleared preferred meeting email override", "user", redaction.Redact(username))
+		s.logger.InfoContext(ctx, "cleared preferred meeting email override", "user", redaction.Redact(self.SFID))
 		return nil, nil
 	}
 
-	pref, err := s.userClient.SetMeetingEmailPreference(ctx, sfid, emailID)
+	pref, err := s.userClient.SetMeetingEmailPreference(ctx, token, self.SFID, emailID)
 	if err != nil {
 		s.logger.WarnContext(ctx, "failed to set preferred meeting email",
-			"user", redaction.Redact(username), logging.ErrKey, err)
+			"user", redaction.Redact(self.SFID), logging.ErrKey, err)
 		return nil, err
 	}
-	s.logger.InfoContext(ctx, "set preferred meeting email", "user", redaction.Redact(username))
+	s.logger.InfoContext(ctx, "set preferred meeting email", "user", redaction.Redact(self.SFID))
 	return pref, nil
 }
 
-// resolveSFID resolves an LFID/username to a Salesforce ID.
-func (s *PreferredEmailService) resolveSFID(ctx context.Context, username string) (string, error) {
-	username = strings.TrimSpace(username)
-	if username == "" {
-		return "", domain.NewValidationError("user is required")
+// getSelf resolves the calling user from their bearer token.
+func (s *PreferredEmailService) getSelf(ctx context.Context, token string) (*domain.Self, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, domain.NewValidationError("user token is required")
 	}
-	sfid, err := s.userClient.ResolveSFIDByUsername(ctx, username)
-	if err != nil {
-		s.logger.WarnContext(ctx, "failed to resolve user to a Salesforce ID",
-			"user", redaction.Redact(username), logging.ErrKey, err)
-		return "", err
+	return s.userClient.GetSelf(ctx, token)
+}
+
+// resolveVerifiedEmailID finds the SFDC email-record ID for the given address among the
+// user's emails. The address must be an active, verified record (invites must only route to
+// a verified address): a matching-but-unusable address is a ValidationError, while an
+// unknown address returns a retryable UnavailableError (SFDC emails sync from auth0
+// asynchronously).
+func resolveVerifiedEmailID(self *domain.Self, email string) (string, error) {
+	email = strings.TrimSpace(email)
+	matchedUnusable := false
+	for _, e := range self.Emails {
+		if e.ID == "" || !strings.EqualFold(strings.TrimSpace(e.Address), email) {
+			continue
+		}
+		if e.Active && e.Verified {
+			return e.ID, nil
+		}
+		matchedUnusable = true
 	}
-	return sfid, nil
+
+	// Redact the address in the returned error — it propagates into logs via ErrKey.
+	redactedEmail := redaction.RedactEmail(email)
+	if matchedUnusable {
+		return "", domain.NewValidationError(
+			fmt.Sprintf("email %q is not an active, verified address on this account", redactedEmail))
+	}
+	return "", domain.NewUnavailableError(
+		fmt.Sprintf("email %q not yet available in user-service; retry", redactedEmail))
 }

--- a/internal/service/preferred_email_service_test.go
+++ b/internal/service/preferred_email_service_test.go
@@ -1,0 +1,146 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+// mockUserServiceClient is a testify mock for domain.UserServiceClient.
+type mockUserServiceClient struct{ mock.Mock }
+
+func (m *mockUserServiceClient) ResolveSFIDByUsername(ctx context.Context, username string) (string, error) {
+	args := m.Called(ctx, username)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockUserServiceClient) ResolveEmailID(ctx context.Context, sfid, email string) (string, error) {
+	args := m.Called(ctx, sfid, email)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockUserServiceClient) GetMeetingEmailPreference(ctx context.Context, sfid string) (*domain.PreferredEmail, error) {
+	args := m.Called(ctx, sfid)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.PreferredEmail), args.Error(1)
+}
+
+func (m *mockUserServiceClient) SetMeetingEmailPreference(ctx context.Context, sfid, emailID string) (*domain.PreferredEmail, error) {
+	args := m.Called(ctx, sfid, emailID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.PreferredEmail), args.Error(1)
+}
+
+func (m *mockUserServiceClient) ClearMeetingEmailPreference(ctx context.Context, sfid string) error {
+	return m.Called(ctx, sfid).Error(0)
+}
+
+var _ domain.UserServiceClient = (*mockUserServiceClient)(nil)
+
+func TestGetPreferredEmail(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("resolves SFID then returns preference", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		want := &domain.PreferredEmail{PreferenceID: "p1", EmailID: "e1", Email: "alice@work.com"}
+		client.On("GetMeetingEmailPreference", ctx, "SFID1").Return(want, nil)
+
+		got, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, "alice")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		client.AssertExpectations(t)
+	})
+
+	t.Run("propagates user-not-found", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "ghost").Return("", domain.ErrUserNotFound)
+
+		_, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, "ghost")
+		assert.ErrorIs(t, err, domain.ErrUserNotFound)
+		client.AssertNotCalled(t, "GetMeetingEmailPreference", mock.Anything, mock.Anything)
+	})
+
+	t.Run("blank user is a validation error", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		_, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, "   ")
+		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+		client.AssertNotCalled(t, "ResolveSFIDByUsername", mock.Anything, mock.Anything)
+	})
+}
+
+func TestSetPreferredEmail(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sets preference for a concrete email_id", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		want := &domain.PreferredEmail{PreferenceID: "p1", EmailID: "e1", Email: "alice@work.com"}
+		client.On("SetMeetingEmailPreference", ctx, "SFID1", "e1").Return(want, nil)
+
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "", "e1")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		client.AssertExpectations(t)
+	})
+
+	t.Run("resolves an address to its email_id (email wins over email_id)", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("ResolveEmailID", ctx, "SFID1", "alice@work.com").Return("e1", nil)
+		want := &domain.PreferredEmail{PreferenceID: "p1", EmailID: "e1", Email: "alice@work.com"}
+		client.On("SetMeetingEmailPreference", ctx, "SFID1", "e1").Return(want, nil)
+
+		// email_id is also provided but must be ignored in favor of the resolved address.
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "alice@work.com", "ignored")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		client.AssertExpectations(t)
+	})
+
+	t.Run("propagates retryable error for a not-yet-synced address", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("ResolveEmailID", ctx, "SFID1", "new@work.com").
+			Return("", domain.NewUnavailableError("not yet available"))
+
+		_, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "new@work.com", "")
+		assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
+		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("empty selection clears the override", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("ClearMeetingEmailPreference", ctx, "SFID1").Return(nil)
+
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "", "")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("primary sentinel clears the override", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("ClearMeetingEmailPreference", ctx, "SFID1").Return(nil)
+
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "", "PRIMARY")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		client.AssertExpectations(t)
+	})
+}

--- a/internal/service/preferred_email_service_test.go
+++ b/internal/service/preferred_email_service_test.go
@@ -143,4 +143,17 @@ func TestSetPreferredEmail(t *testing.T) {
 		assert.Nil(t, got)
 		client.AssertExpectations(t)
 	})
+
+	t.Run("email=primary clears even when email_id is set (email wins)", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("ClearMeetingEmailPreference", ctx, "SFID1").Return(nil)
+
+		// email takes precedence: "primary" must clear, ignoring the provided email_id.
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "primary", "e1")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		client.AssertNotCalled(t, "ResolveEmailID", mock.Anything, mock.Anything, mock.Anything)
+		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
+	})
 }

--- a/internal/service/preferred_email_service_test.go
+++ b/internal/service/preferred_email_service_test.go
@@ -15,70 +15,80 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 )
 
+const testToken = "test-user-token"
+
 // mockUserServiceClient is a testify mock for domain.UserServiceClient.
 type mockUserServiceClient struct{ mock.Mock }
 
-func (m *mockUserServiceClient) ResolveSFIDByUsername(ctx context.Context, username string) (string, error) {
-	args := m.Called(ctx, username)
-	return args.String(0), args.Error(1)
+func (m *mockUserServiceClient) GetSelf(ctx context.Context, token string) (*domain.Self, error) {
+	args := m.Called(ctx, token)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Self), args.Error(1)
 }
 
-func (m *mockUserServiceClient) ResolveEmailID(ctx context.Context, sfid, email string) (string, error) {
-	args := m.Called(ctx, sfid, email)
-	return args.String(0), args.Error(1)
-}
-
-func (m *mockUserServiceClient) GetMeetingEmailPreference(ctx context.Context, sfid string) (*domain.PreferredEmail, error) {
-	args := m.Called(ctx, sfid)
+func (m *mockUserServiceClient) GetMeetingEmailPreference(ctx context.Context, token, sfid string) (*domain.PreferredEmail, error) {
+	args := m.Called(ctx, token, sfid)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*domain.PreferredEmail), args.Error(1)
 }
 
-func (m *mockUserServiceClient) SetMeetingEmailPreference(ctx context.Context, sfid, emailID string) (*domain.PreferredEmail, error) {
-	args := m.Called(ctx, sfid, emailID)
+func (m *mockUserServiceClient) SetMeetingEmailPreference(ctx context.Context, token, sfid, emailID string) (*domain.PreferredEmail, error) {
+	args := m.Called(ctx, token, sfid, emailID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*domain.PreferredEmail), args.Error(1)
 }
 
-func (m *mockUserServiceClient) ClearMeetingEmailPreference(ctx context.Context, sfid string) error {
-	return m.Called(ctx, sfid).Error(0)
+func (m *mockUserServiceClient) ClearMeetingEmailPreference(ctx context.Context, token, sfid string) error {
+	return m.Called(ctx, token, sfid).Error(0)
 }
 
 var _ domain.UserServiceClient = (*mockUserServiceClient)(nil)
 
+func selfWithEmail() *domain.Self {
+	return &domain.Self{
+		SFID: "SFID1",
+		Emails: []domain.SelfEmail{
+			{ID: "e1", Address: "alice@work.com", Active: true, Verified: true},
+			{ID: "e-unverified", Address: "new@work.com", Active: true, Verified: false},
+		},
+	}
+}
+
 func TestGetPreferredEmail(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("resolves SFID then returns preference", func(t *testing.T) {
+	t.Run("resolves self from token then returns preference", func(t *testing.T) {
 		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
 		want := &domain.PreferredEmail{PreferenceID: "p1", EmailID: "e1", Email: "alice@work.com"}
-		client.On("GetMeetingEmailPreference", ctx, "SFID1").Return(want, nil)
+		client.On("GetMeetingEmailPreference", ctx, testToken, "SFID1").Return(want, nil)
 
-		got, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, "alice")
+		got, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, testToken)
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 		client.AssertExpectations(t)
 	})
 
-	t.Run("propagates user-not-found", func(t *testing.T) {
-		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "ghost").Return("", domain.ErrUserNotFound)
-
-		_, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, "ghost")
-		assert.ErrorIs(t, err, domain.ErrUserNotFound)
-		client.AssertNotCalled(t, "GetMeetingEmailPreference", mock.Anything, mock.Anything)
-	})
-
-	t.Run("blank user is a validation error", func(t *testing.T) {
+	t.Run("blank token is a validation error", func(t *testing.T) {
 		client := &mockUserServiceClient{}
 		_, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, "   ")
 		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
-		client.AssertNotCalled(t, "ResolveSFIDByUsername", mock.Anything, mock.Anything)
+		client.AssertNotCalled(t, "GetSelf", mock.Anything, mock.Anything)
+	})
+
+	t.Run("propagates GetSelf error (e.g. rejected token)", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("GetSelf", ctx, testToken).Return(nil, domain.NewValidationError("user token rejected"))
+
+		_, err := NewPreferredEmailService(client, slog.Default()).GetPreferredEmail(ctx, testToken)
+		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+		client.AssertNotCalled(t, "GetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
 	})
 }
 
@@ -87,73 +97,64 @@ func TestSetPreferredEmail(t *testing.T) {
 
 	t.Run("sets preference for a concrete email_id", func(t *testing.T) {
 		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
 		want := &domain.PreferredEmail{PreferenceID: "p1", EmailID: "e1", Email: "alice@work.com"}
-		client.On("SetMeetingEmailPreference", ctx, "SFID1", "e1").Return(want, nil)
+		client.On("SetMeetingEmailPreference", ctx, testToken, "SFID1", "e1").Return(want, nil)
 
-		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "", "e1")
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, testToken, "", "e1")
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 		client.AssertExpectations(t)
 	})
 
-	t.Run("resolves an address to its email_id (email wins over email_id)", func(t *testing.T) {
+	t.Run("resolves a verified address to its email_id (email wins over email_id)", func(t *testing.T) {
 		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
-		client.On("ResolveEmailID", ctx, "SFID1", "alice@work.com").Return("e1", nil)
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
 		want := &domain.PreferredEmail{PreferenceID: "p1", EmailID: "e1", Email: "alice@work.com"}
-		client.On("SetMeetingEmailPreference", ctx, "SFID1", "e1").Return(want, nil)
+		client.On("SetMeetingEmailPreference", ctx, testToken, "SFID1", "e1").Return(want, nil)
 
-		// email_id is also provided but must be ignored in favor of the resolved address.
-		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "alice@work.com", "ignored")
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, testToken, "alice@work.com", "ignored")
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 		client.AssertExpectations(t)
 	})
 
-	t.Run("propagates retryable error for a not-yet-synced address", func(t *testing.T) {
+	t.Run("unverified address is a validation error", func(t *testing.T) {
 		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
-		client.On("ResolveEmailID", ctx, "SFID1", "new@work.com").
-			Return("", domain.NewUnavailableError("not yet available"))
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
 
-		_, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "new@work.com", "")
+		_, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, testToken, "new@work.com", "")
+		assert.Equal(t, domain.ErrorTypeValidation, domain.GetErrorType(err))
+		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("unknown address returns retryable unavailable error", func(t *testing.T) {
+		client := &mockUserServiceClient{}
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
+
+		_, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, testToken, "ghost@work.com", "")
 		assert.Equal(t, domain.ErrorTypeUnavailable, domain.GetErrorType(err))
-		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("empty selection clears the override", func(t *testing.T) {
 		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
-		client.On("ClearMeetingEmailPreference", ctx, "SFID1").Return(nil)
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
+		client.On("ClearMeetingEmailPreference", ctx, testToken, "SFID1").Return(nil)
 
-		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "", "")
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, testToken, "", "")
 		require.NoError(t, err)
 		assert.Nil(t, got)
-		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
-	})
-
-	t.Run("primary sentinel clears the override", func(t *testing.T) {
-		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
-		client.On("ClearMeetingEmailPreference", ctx, "SFID1").Return(nil)
-
-		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "", "PRIMARY")
-		require.NoError(t, err)
-		assert.Nil(t, got)
-		client.AssertExpectations(t)
+		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("email=primary clears even when email_id is set (email wins)", func(t *testing.T) {
 		client := &mockUserServiceClient{}
-		client.On("ResolveSFIDByUsername", ctx, "alice").Return("SFID1", nil)
-		client.On("ClearMeetingEmailPreference", ctx, "SFID1").Return(nil)
+		client.On("GetSelf", ctx, testToken).Return(selfWithEmail(), nil)
+		client.On("ClearMeetingEmailPreference", ctx, testToken, "SFID1").Return(nil)
 
-		// email takes precedence: "primary" must clear, ignoring the provided email_id.
-		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, "alice", "primary", "e1")
+		got, err := NewPreferredEmailService(client, slog.Default()).SetPreferredEmail(ctx, testToken, "primary", "e1")
 		require.NoError(t, err)
 		assert.Nil(t, got)
-		client.AssertNotCalled(t, "ResolveEmailID", mock.Anything, mock.Anything, mock.Anything)
-		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything)
+		client.AssertNotCalled(t, "SetMeetingEmailPreference", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 }

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -7,11 +7,12 @@ package constants
 const AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"
 
 // PreferredEmailGetSubject is the NATS RPC subject for reading a user's preferred
-// meeting-invite email. Request: {"user":"<lfid|username>"}. Reply: {"email_id","email"}.
+// meeting-invite email. Request: {"token":"<user bearer token>"}. The user is resolved from
+// the token (the RPC calls user-service as the user). Reply: {"email_id","email"}.
 const PreferredEmailGetSubject = "lfx.meeting-service.preferred_email.get"
 
 // PreferredEmailSetSubject is the NATS RPC subject for setting a user's preferred
-// meeting-invite email. Request: {"user":"<lfid|username>","email":<string|null>,"email_id":<string|null>}.
+// meeting-invite email. Request: {"token":"<user bearer token>","email":<string|null>,"email_id":<string|null>}.
 // "email" (a verified address, resolved to its SFDC email-record ID) takes precedence over
 // "email_id" when both are set; a null/empty selection or "primary" clears the override.
 // Reply: {"email_id","email"}.

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -11,8 +11,10 @@ const AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"
 const PreferredEmailGetSubject = "lfx.meeting-service.preferred_email.get"
 
 // PreferredEmailSetSubject is the NATS RPC subject for setting a user's preferred
-// meeting-invite email. Request: {"user":"<lfid|username>","email_id":<string|null>}.
-// email_id null or "primary" clears the override. Reply: {"email_id","email"}.
+// meeting-invite email. Request: {"user":"<lfid|username>","email":<string|null>,"email_id":<string|null>}.
+// "email" (a verified address, resolved to its SFDC email-record ID) takes precedence over
+// "email_id" when both are set; a null/empty selection or "primary" clears the override.
+// Reply: {"email_id","email"}.
 const PreferredEmailSetSubject = "lfx.meeting-service.preferred_email.set"
 
 // PreferredEmailQueueGroup is the NATS queue group for the preferred-email responder,

--- a/pkg/constants/nats.go
+++ b/pkg/constants/nats.go
@@ -5,3 +5,16 @@ package constants
 
 // AuthEmailToUsernameSubject resolves a primary email address to an LFX username via the auth service.
 const AuthEmailToUsernameSubject = "lfx.auth-service.email_to_username"
+
+// PreferredEmailGetSubject is the NATS RPC subject for reading a user's preferred
+// meeting-invite email. Request: {"user":"<lfid|username>"}. Reply: {"email_id","email"}.
+const PreferredEmailGetSubject = "lfx.meeting-service.preferred_email.get"
+
+// PreferredEmailSetSubject is the NATS RPC subject for setting a user's preferred
+// meeting-invite email. Request: {"user":"<lfid|username>","email_id":<string|null>}.
+// email_id null or "primary" clears the override. Reply: {"email_id","email"}.
+const PreferredEmailSetSubject = "lfx.meeting-service.preferred_email.set"
+
+// PreferredEmailQueueGroup is the NATS queue group for the preferred-email responder,
+// so multiple service replicas load-balance RPC requests.
+const PreferredEmailQueueGroup = "meeting-service-preferred-email"


### PR DESCRIPTION
## Summary

Part of the myprofile → LFX Self-Serve cutover (epic LFXV2-1948). Adds a NATS RPC so
self-serve can read/set a user's preferred meeting-invite email. This is **Part A
(meeting-service) only**; the self-serve UI/wiring (Part B) ships separately.

- New NATS RPCs (`lfx.meeting-service.preferred_email.get` / `.set`) served by a responder
  wired into `main.go`, gated on `NATS_URL`.
- The RPC calls the v1 user-service preferences API **as the user**: self-serve forwards the
  user's bearer token in the request (`{"token": "..."}`), meeting-service resolves the user
  via `GET /v1/me` (SFID + verified emails) and manages the `Type=Meeting` preference
  (get / upsert / clear). No service credentials — only `USER_SERVICE_BASE_URL`.
- **Phase 1 storage** — identical to myprofile, so `itx-service-zoom` keeps reading the
  preference unchanged through cutover.
- `set` accepts a verified email **address** (resolved to an active, verified SFDC email
  record — unverified/unknown rejected) or an `email_id`; `null`/`"primary"` clears.
- `verify-after-write` tolerates an upstream user-service **502** that commits the write but
  errors on the response (see note).
- New `USER_SERVICE_BASE_URL` env, chart values, `.env.example`, and CLAUDE.md docs; unit tests.

### Caller (Part B / self-serve)
self-serve forwards the logged-in user's bearer token in the RPC payload; meeting-service acts
as that user. Adding/verifying a new email stays in the self-serve email-management flow.

### Known upstream issue (not this repo)
On `set`, the user-service preferences **PATCH** commits the write but returns a bodyless
**502**. It reproduces regardless of caller identity (M2M or user token) — an upstream bug in
user-service's preferences update path. `verify-after-write` makes this RPC correct despite it;
the fix belongs in the `user-service` repo.

Refs LFXV2-2599

🤖 Generated with Claude Code
