### PR TITLE
fix(indexer): include combined full name in registrant/participant name_and_aliases

### DIFF
--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -272,7 +272,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Field | Value |
 |---|---|
 | `sort_name` | `email` (trimmed) |
-| `name_and_aliases` | `[username, email]` (deduplicated, omits empty values) |
+| `name_and_aliases` | `[username, email, first_name, last_name, "first_name last_name"]` (deduplicated, omits empty values) |
 | `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References
@@ -518,7 +518,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | Field | Value |
 |---|---|
 | `sort_name` | `email` (trimmed) |
-| `name_and_aliases` | `[first_name, last_name, username]` (deduplicated, omits empty values) |
+| `name_and_aliases` | `[first_name, last_name, username, "first_name last_name"]` (deduplicated, omits empty values) |
 | `fulltext` | `sort_name` + `name_and_aliases` (space-joined, deduplicated) |
 
 ### Parent References

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -553,7 +553,13 @@ func (r *RegistrantEventData) SortName() string {
 func (r *RegistrantEventData) NameAndAliases() []string {
 	seen := make(map[string]bool)
 	var result []string
-	for _, v := range []string{r.Username, r.Email} {
+	first := strings.TrimSpace(r.FirstName)
+	last := strings.TrimSpace(r.LastName)
+	values := []string{r.Username, r.Email, first, last}
+	if first != "" && last != "" {
+		values = append(values, first+" "+last)
+	}
+	for _, v := range values {
 		v = strings.TrimSpace(v)
 		if v != "" && !seen[v] {
 			result = append(result, v)
@@ -870,7 +876,13 @@ func (p *PastMeetingParticipantEventData) SortName() string {
 func (p *PastMeetingParticipantEventData) NameAndAliases() []string {
 	seen := make(map[string]bool)
 	var result []string
-	for _, v := range []string{p.FirstName, p.LastName, p.Username} {
+	first := strings.TrimSpace(p.FirstName)
+	last := strings.TrimSpace(p.LastName)
+	values := []string{p.FirstName, p.LastName, p.Username}
+	if first != "" && last != "" {
+		values = append(values, first+" "+last)
+	}
+	for _, v := range values {
 		v = strings.TrimSpace(v)
 		if v != "" && !seen[v] {
 			result = append(result, v)

--- a/internal/domain/models/event_models_test.go
+++ b/internal/domain/models/event_models_test.go
@@ -18,20 +18,20 @@ func TestRegistrantEventData_NameAndAliases(t *testing.T) {
 		{
 			name: "includes combined full name alongside individual tokens",
 			data: RegistrantEventData{
-				FirstName: "Paul",
-				LastName:  "Hinz",
-				Username:  "phinz",
-				Email:     "phinz@example.com",
+				FirstName: "Jane",
+				LastName:  "Smith",
+				Username:  "jsmith",
+				Email:     "jsmith@example.com",
 			},
-			expected: []string{"phinz", "phinz@example.com", "Paul", "Hinz", "Paul Hinz"},
+			expected: []string{"jsmith", "jsmith@example.com", "Jane", "Smith", "Jane Smith"},
 		},
 		{
 			name: "omits combined name when first or last name is missing",
 			data: RegistrantEventData{
-				FirstName: "Paul",
-				Username:  "phinz",
+				FirstName: "Jane",
+				Username:  "jsmith",
 			},
-			expected: []string{"phinz", "Paul"},
+			expected: []string{"jsmith", "Jane"},
 		},
 		{
 			name:     "empty when no fields set",
@@ -56,19 +56,19 @@ func TestPastMeetingParticipantEventData_NameAndAliases(t *testing.T) {
 		{
 			name: "includes combined full name alongside individual tokens",
 			data: PastMeetingParticipantEventData{
-				FirstName: "Paul",
-				LastName:  "Hinz",
-				Username:  "phinz",
+				FirstName: "Jane",
+				LastName:  "Smith",
+				Username:  "jsmith",
 			},
-			expected: []string{"Paul", "Hinz", "phinz", "Paul Hinz"},
+			expected: []string{"Jane", "Smith", "jsmith", "Jane Smith"},
 		},
 		{
 			name: "omits combined name when last name is missing",
 			data: PastMeetingParticipantEventData{
-				FirstName: "Paul",
-				Username:  "phinz",
+				FirstName: "Jane",
+				Username:  "jsmith",
 			},
-			expected: []string{"Paul", "phinz"},
+			expected: []string{"Jane", "jsmith"},
 		},
 		{
 			name:     "empty when no fields set",

--- a/internal/domain/models/event_models_test.go
+++ b/internal/domain/models/event_models_test.go
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistrantEventData_NameAndAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     RegistrantEventData
+		expected []string
+	}{
+		{
+			name: "includes combined full name alongside individual tokens",
+			data: RegistrantEventData{
+				FirstName: "Paul",
+				LastName:  "Hinz",
+				Username:  "phinz",
+				Email:     "phinz@example.com",
+			},
+			expected: []string{"phinz", "phinz@example.com", "Paul", "Hinz", "Paul Hinz"},
+		},
+		{
+			name: "omits combined name when first or last name is missing",
+			data: RegistrantEventData{
+				FirstName: "Paul",
+				Username:  "phinz",
+			},
+			expected: []string{"phinz", "Paul"},
+		},
+		{
+			name:     "empty when no fields set",
+			data:     RegistrantEventData{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.data.NameAndAliases())
+		})
+	}
+}
+
+func TestPastMeetingParticipantEventData_NameAndAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     PastMeetingParticipantEventData
+		expected []string
+	}{
+		{
+			name: "includes combined full name alongside individual tokens",
+			data: PastMeetingParticipantEventData{
+				FirstName: "Paul",
+				LastName:  "Hinz",
+				Username:  "phinz",
+			},
+			expected: []string{"Paul", "Hinz", "phinz", "Paul Hinz"},
+		},
+		{
+			name: "omits combined name when last name is missing",
+			data: PastMeetingParticipantEventData{
+				FirstName: "Paul",
+				Username:  "phinz",
+			},
+			expected: []string{"Paul", "phinz"},
+		},
+		{
+			name:     "empty when no fields set",
+			data:     PastMeetingParticipantEventData{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.data.NameAndAliases())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `name_and_aliases` for meeting registrants and past-meeting participants stored `first_name` and `last_name` as separate array elements, so the query service's `bool_prefix` `multi_match` against `name_and_aliases`/`_2gram`/`_3gram` never produced a shingle spanning both tokens.
- Multi-word queries like "Paul Hinz" returned zero results even though "Hinz" alone matched.
- `RegistrantEventData.NameAndAliases()` also previously omitted `first_name`/`last_name` entirely (only `username`/`email` were indexed) — a related gap now fixed alongside the main issue.
- Appends the combined `"first_name last_name"` value in both `RegistrantEventData` and `PastMeetingParticipantEventData`.

## Related
- [LFXV2-2614](https://linuxfoundation.atlassian.net/browse/LFXV2-2614)
- Companion fix in `lfx-v2-committee-service` (committee members) — same root cause.

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./...` passes
- [x] New `internal/domain/models/event_models_test.go` covers both methods: full-name inclusion, missing first/last name, and empty data
- [x] `docs/indexer-contract.md` updated to document the new alias for both resource types

[LFXV2-2614]: https://linuxfoundation.atlassian.net/browse/LFXV2-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ