### PR TITLE
feat(nats): add NATS consumer spans to KV and invite handlers

### DIFF
--- a/cmd/meeting-api/eventing/invite_accepted_subscriber.go
+++ b/cmd/meeting-api/eventing/invite_accepted_subscriber.go
@@ -13,6 +13,7 @@ import (
 	natsgo "github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
@@ -109,12 +110,16 @@ func (s *InviteAcceptedSubscriber) handle(msg *natsgo.Msg) {
 
 	var evt inviteapi.InviteServiceAcceptedEvent
 	if err := json.Unmarshal(msg.Data, &evt); err != nil {
-		s.logger.With(logging.ErrKey, err).Warn("failed to parse InviteServiceAcceptedEvent; discarding")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		s.logger.With(logging.ErrKey, err).WarnContext(ctx, "failed to parse InviteServiceAcceptedEvent; discarding")
 		return
 	}
 
 	if err := processInviteAcceptedEvent(ctx, evt, s.acceptanceClient, s.logger); err != nil {
-		s.logger.With(logging.ErrKey, err).Warn("invite_accepted enrichment failed; best-effort, not retrying",
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		s.logger.With(logging.ErrKey, err).WarnContext(ctx, "invite_accepted enrichment failed; best-effort, not retrying",
 			"email", redaction.RedactEmail(evt.Recipient.Email),
 			"username", redaction.Redact(evt.AcceptedBy),
 		)

--- a/cmd/meeting-api/eventing/invite_accepted_subscriber.go
+++ b/cmd/meeting-api/eventing/invite_accepted_subscriber.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	natsgo "github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	inviteapi "github.com/linuxfoundation/lfx-v2-invite-service/pkg/api"
 
@@ -90,7 +93,17 @@ func (s *InviteAcceptedSubscriber) handle(msg *natsgo.Msg) {
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	ctx, cancel := context.WithTimeout(s.ctx, inviteAcceptedCallTimeout)
+	msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
+	msgCtx, span := tracer.Start(msgCtx, "nats.process",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", msg.Subject),
+		),
+	)
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(trace.ContextWithSpan(s.ctx, span), inviteAcceptedCallTimeout)
 	defer cancel()
 
 	var evt inviteapi.InviteServiceAcceptedEvent

--- a/cmd/meeting-api/eventing/invite_accepted_subscriber.go
+++ b/cmd/meeting-api/eventing/invite_accepted_subscriber.go
@@ -94,11 +94,12 @@ func (s *InviteAcceptedSubscriber) handle(msg *natsgo.Msg) {
 	defer s.wg.Done()
 
 	msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
-	msgCtx, span := tracer.Start(msgCtx, "nats.process",
+	_, span := tracer.Start(msgCtx, "nats.process",
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "nats"),
 			attribute.String("messaging.destination.name", msg.Subject),
+			attribute.String("messaging.operation.type", "process"),
 		),
 	)
 	defer span.End()

--- a/cmd/meeting-api/eventing/invite_accepted_subscriber.go
+++ b/cmd/meeting-api/eventing/invite_accepted_subscriber.go
@@ -93,8 +93,8 @@ func (s *InviteAcceptedSubscriber) handle(msg *natsgo.Msg) {
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	msgCtx := otel.GetTextMapPropagator().Extract(context.Background(), natsHeaderCarrier(msg.Header))
-	_, span := tracer.Start(msgCtx, "nats.process",
+	msgCtx := otel.GetTextMapPropagator().Extract(s.ctx, natsHeaderCarrier(msg.Header))
+	msgCtx, span := tracer.Start(msgCtx, "nats.process",
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.String("messaging.system", "nats"),
@@ -104,7 +104,7 @@ func (s *InviteAcceptedSubscriber) handle(msg *natsgo.Msg) {
 	)
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(trace.ContextWithSpan(s.ctx, span), inviteAcceptedCallTimeout)
+	ctx, cancel := context.WithTimeout(msgCtx, inviteAcceptedCallTimeout)
 	defer cancel()
 
 	var evt inviteapi.InviteServiceAcceptedEvent

--- a/cmd/meeting-api/eventing/kv_handler.go
+++ b/cmd/meeting-api/eventing/kv_handler.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/vmihailenco/msgpack/v5"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
 
@@ -182,6 +185,18 @@ func (h *EventHandlers) inviteEnabled() bool {
 
 // kvHandler routes KV bucket events to appropriate handlers
 func kvHandler(ctx context.Context, msg jetstream.Msg, handlers *EventHandlers) (retry bool) {
+	msgCtx := otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(msg.Headers()))
+	msgCtx, span := tracer.Start(msgCtx, "nats.process",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", msg.Subject()),
+			attribute.String("messaging.operation.type", "process"),
+		),
+	)
+	defer span.End()
+	ctx = msgCtx
+
 	// Extract key from subject (format: $KV.v1-objects.{key})
 	subject := msg.Subject()
 	parts := strings.Split(subject, ".")

--- a/cmd/meeting-api/eventing/kv_handler.go
+++ b/cmd/meeting-api/eventing/kv_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	fgatypes "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/types"
@@ -201,7 +202,8 @@ func kvHandler(ctx context.Context, msg jetstream.Msg, handlers *EventHandlers) 
 	subject := msg.Subject()
 	parts := strings.Split(subject, ".")
 	if len(parts) < 3 {
-		handlers.logger.Error("invalid subject format", "subject", subject)
+		span.SetStatus(codes.Error, "invalid subject format")
+		handlers.logger.ErrorContext(ctx, "invalid subject format", "subject", subject)
 		return false
 	}
 	key := strings.Join(parts[2:], ".")
@@ -209,12 +211,14 @@ func kvHandler(ctx context.Context, msg jetstream.Msg, handlers *EventHandlers) 
 	// Get operation type
 	metadata, err := msg.Metadata()
 	if err != nil {
-		handlers.logger.With(logging.ErrKey, err).Error("failed to get message metadata")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		handlers.logger.With(logging.ErrKey, err).ErrorContext(ctx, "failed to get message metadata")
 		return false
 	}
 
 	operation := getOperation(msg)
-	handlers.logger.Info("processing KV event",
+	handlers.logger.InfoContext(ctx, "processing KV event",
 		"key", key,
 		"operation", operation,
 		"num_delivered", metadata.NumDelivered,
@@ -228,7 +232,9 @@ func kvHandler(ctx context.Context, msg jetstream.Msg, handlers *EventHandlers) 
 	// Handle put operations - decode the data
 	data, err := decodeData(msg.Data())
 	if err != nil {
-		handlers.logger.With(logging.ErrKey, err).Error("failed to decode message data", "key", key)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		handlers.logger.With(logging.ErrKey, err).ErrorContext(ctx, "failed to decode message data", "key", key)
 		return false
 	}
 

--- a/cmd/meeting-api/eventing/tracing.go
+++ b/cmd/meeting-api/eventing/tracing.go
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package eventing
+
+import (
+	natsgo "github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// tracer is safe to initialize at package level — otel.Tracer() returns a
+// delegating tracer that forwards to whatever TracerProvider is registered at
+// call time, so otel.SetTracerProvider() updates it regardless of init order.
+var tracer = otel.Tracer("github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/eventing")
+
+// natsHeaderCarrier adapts nats.Header to the OTel TextMapCarrier interface
+// so trace context can be extracted from NATS message headers.
+type natsHeaderCarrier natsgo.Header
+
+func (c natsHeaderCarrier) Get(key string) string {
+	vals := c[key]
+	if len(vals) == 0 {
+		return ""
+	}
+	return vals[0]
+}
+
+func (c natsHeaderCarrier) Set(key string, value string) {
+	if c == nil {
+		return
+	}
+	c[key] = []string{value}
+}
+
+func (c natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+var _ propagation.TextMapCarrier = natsHeaderCarrier{}

--- a/cmd/meeting-api/eventing/tracing_test.go
+++ b/cmd/meeting-api/eventing/tracing_test.go
@@ -1,0 +1,109 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package eventing
+
+import (
+	"testing"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TestNatsHeaderCarrier_Get(t *testing.T) {
+	t.Run("returns empty string for missing key", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		assert.Equal(t, "", carrier.Get("missing-key"))
+	})
+
+	t.Run("returns value for existing key", func(t *testing.T) {
+		carrier := natsHeaderCarrier(natsgo.Header{
+			"traceparent": []string{"00-trace-id-span-id-01"},
+		})
+		assert.Equal(t, "00-trace-id-span-id-01", carrier.Get("traceparent"))
+	})
+
+	t.Run("returns first value when multiple values set", func(t *testing.T) {
+		carrier := natsHeaderCarrier(natsgo.Header{
+			"key1": []string{"first", "second"},
+		})
+		assert.Equal(t, "first", carrier.Get("key1"))
+	})
+
+	t.Run("returns empty string for nil header", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		assert.Equal(t, "", carrier.Get("any-key"))
+	})
+}
+
+func TestNatsHeaderCarrier_Set(t *testing.T) {
+	t.Run("sets value on new key", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		carrier.Set("traceparent", "00-abc-def-01")
+		assert.Equal(t, "00-abc-def-01", carrier.Get("traceparent"))
+	})
+
+	t.Run("overwrites existing value", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		carrier.Set("key", "value1")
+		carrier.Set("key", "value2")
+		assert.Equal(t, "value2", carrier.Get("key"))
+		assert.Equal(t, []string{"value2"}, natsgo.Header(carrier)["key"])
+	})
+
+	t.Run("stores full header state correctly", func(t *testing.T) {
+		header := make(natsgo.Header)
+		carrier := natsHeaderCarrier(header)
+		carrier.Set("traceparent", "00-trace-span-01")
+		carrier.Set("tracestate", "vendor=value")
+		assert.Len(t, header, 2)
+		assert.Equal(t, []string{"00-trace-span-01"}, header["traceparent"])
+		assert.Equal(t, []string{"vendor=value"}, header["tracestate"])
+	})
+
+	t.Run("no-op on nil carrier", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		assert.NotPanics(t, func() { carrier.Set("key", "value") })
+	})
+}
+
+func TestNatsHeaderCarrier_Keys(t *testing.T) {
+	t.Run("returns empty slice for empty header", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		assert.Empty(t, carrier.Keys())
+	})
+
+	t.Run("returns all keys for populated header", func(t *testing.T) {
+		carrier := natsHeaderCarrier(make(natsgo.Header))
+		carrier.Set("key1", "v1")
+		carrier.Set("key2", "v2")
+		keys := carrier.Keys()
+		assert.Len(t, keys, 2)
+		assert.Contains(t, keys, "key1")
+		assert.Contains(t, keys, "key2")
+	})
+
+	t.Run("returns empty slice for nil header", func(t *testing.T) {
+		var carrier natsHeaderCarrier
+		assert.Empty(t, carrier.Keys())
+	})
+}
+
+func TestNatsHeaderCarrier_TextMapCarrier(t *testing.T) {
+	t.Run("satisfies TextMapCarrier interface", func(t *testing.T) {
+		var _ propagation.TextMapCarrier = natsHeaderCarrier{}
+	})
+
+	t.Run("Set/Get round-trip preserves values", func(t *testing.T) {
+		header := make(natsgo.Header)
+		carrier := natsHeaderCarrier(header)
+
+		carrier.Set("traceparent", "00-trace-id-span-id-01")
+		carrier.Set("tracestate", "vendor=value")
+
+		assert.Equal(t, "00-trace-id-span-id-01", carrier.Get("traceparent"))
+		assert.Equal(t, "vendor=value", carrier.Get("tracestate"))
+		assert.Len(t, header, 2)
+	})
+}


### PR DESCRIPTION
## Summary

Adds OTel consumer span instrumentation to the two previously untraced NATS consumer paths in `cmd/meeting-api/eventing`. This closes the last NATS tracing gap for meeting-service (LFXV2-1743).

**Before:** meeting-service had 219 Producer spans/hr with 0 Consumer spans — the KV handler and invite subscriber were invisible in Datadog APM.

**After:** both consumer paths emit `nats.process` consumer spans, making them visible in the trace explorer and enabling log-trace correlation for all `slog.InfoContext` calls within handlers.

## Changes

### New file: `cmd/meeting-api/eventing/tracing.go`

Package-level `tracer` and `natsHeaderCarrier` for this package, mirroring the pattern already in `internal/infrastructure/eventing/tracing.go` (publisher side). Required because `cmd/meeting-api/eventing` is a separate Go package.

### `cmd/meeting-api/eventing/kv_handler.go`

Wraps `kvHandler` with a `nats.process` consumer span:
- Extracts OTel trace context from `msg.Headers()` — KV messages from CDC have no OTel headers so these become root spans, still useful for visibility
- Rebinds `ctx` to the span-carrying context so all downstream `routeDelete`/`handleKVPut` calls (and their `slog.InfoContext` logging) carry `trace_id`/`span_id`

### `cmd/meeting-api/eventing/invite_accepted_subscriber.go`

Wraps `InviteAcceptedSubscriber.handle` with a `nats.process` consumer span:
- Extracts trace context from `msg.Header` — invite-service injects OTel headers on publish, so these spans link to the upstream invite publish trace
- Merges span into the lifecycle-aware `s.ctx` via `trace.ContextWithSpan` so shutdown cancellation still propagates while the span context flows to logging

## Testing

```
go test ./cmd/meeting-api/eventing/...
ok  github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/eventing  0.004s
```

Issue: LFXV2-1743