### PR TITLE
fix(deps): bump Go to 1.25.12 (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/linuxfoundation/lfx-v2-meeting-service
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/auth0/go-auth0 v1.38.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.25.11 to 1.25.12 to fix a reachable standard library vulnerability flagged by `govulncheck` in CI.

## Vulnerability

**GO-2026-5856** — Encrypted Client Hello (ECH) privacy leak in `crypto/tls`
- Fixed in: `crypto/tls@go1.25.12`
- Reachable via: NATS TLS connections, HTTP server `ListenAndServe`, and outbound HTTP proxy client

## Change

- `go.mod`: `go 1.25.11` → `go 1.25.12`

All workflows use `go-version-file: go.mod` so no other files need updating.

Issue: LFXV2-1743