### PR TITLE
revert(eventing): remove has_recording from past-meeting index (LFXV2-2652)

### DIFF
--- a/cmd/meeting-api/eventing/past_meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/past_meeting_event_handler.go
@@ -63,11 +63,6 @@ type PastMeetingDBRaw struct {
 	// RecordingEnabled is whether the recording of the past meeting is enabled
 	RecordingEnabled bool `json:"recording_enabled"`
 
-	// HasRecording is true when a real recording exists for the past meeting — specifically when
-	// the largest recording session (by total size) has a non-empty share URL. This is synced from
-	// ITX (see ZoomPastMeeting.HasRecording) rather than computed here.
-	HasRecording bool `json:"has_recording"`
-
 	// ScheduledStartTime is the scheduled start time of the past meeting.
 	// This differs from the actual start time of the meeting because the [Sessions] stores
 	// the actual start and end times of the meeting from Zoom of when it officially started.
@@ -450,7 +445,6 @@ func convertMapToPastMeetingData(
 		ArtifactVisibility:       artifactVisibility,
 		Restricted:               rawPastMeeting.Restricted,
 		RecordingEnabled:         rawPastMeeting.RecordingEnabled,
-		HasRecording:             rawPastMeeting.HasRecording,
 		RecordingAccess:          rawPastMeeting.RecordingAccess,
 		TranscriptEnabled:        rawPastMeeting.TranscriptEnabled,
 		TranscriptAccess:         rawPastMeeting.TranscriptAccess,

--- a/internal/domain/models/event_models.go
+++ b/internal/domain/models/event_models.go
@@ -721,7 +721,6 @@ type PastMeetingEventData struct {
 	ArtifactVisibility       string               `json:"artifact_visibility,omitempty"`
 	Restricted               bool                 `json:"restricted"`
 	RecordingEnabled         bool                 `json:"recording_enabled"`
-	HasRecording             bool                 `json:"has_recording"` // true when a real recording (a session with a share_url) exists; distinct from the RecordingEnabled config flag
 	RecordingAccess          string               `json:"recording_access,omitempty"`
 	TranscriptEnabled        bool                 `json:"transcript_enabled"`
 	TranscriptAccess         string               `json:"transcript_access,omitempty"`


### PR DESCRIPTION
# Summary

Reverts the has_recording field added to past-meeting indexing in PR #208. Past-meeting events no longer carry HasRecording; recording availability is derived downstream from v1_past_meeting_recording instead.