### PR TITLE
fix(eventing): coerce string auto_email_reminder_time in meeting unmarshal

### DIFF
--- a/cmd/meeting-api/eventing/meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler.go
@@ -249,6 +249,7 @@ func (m *MeetingDBRaw) UnmarshalJSON(data []byte) error {
 		LastBulkRegistrantsJobWarningCount        interface{}       `json:"last_bulk_registrants_job_warning_count"`
 		LastMailingListMembersSyncJobFailedCount  interface{}       `json:"last_mailing_list_members_sync_job_failed_count"`
 		LastMailingListMembersSyncJobWarningCount interface{}       `json:"last_mailing_list_members_sync_job_warning_count"`
+		AutoEmailReminderTime                     interface{}       `json:"auto_email_reminder_time"`
 		Occurrences                               []json.RawMessage `json:"occurrences"`
 		UpdatedOccurrences                        []json.RawMessage `json:"updated_occurrences"`
 		*Alias
@@ -399,6 +400,26 @@ func (m *MeetingDBRaw) UnmarshalJSON(data []byte) error {
 	default:
 		if v != nil {
 			return fmt.Errorf("invalid type for last_mailing_list_members_sync_job_warning_count: %T", v)
+		}
+	}
+
+	// Handle AutoEmailReminderTime
+	switch v := tmp.AutoEmailReminderTime.(type) {
+	case string:
+		if v != "" {
+			val, err := strconv.Atoi(v)
+			if err != nil {
+				return err
+			}
+			m.AutoEmailReminderTime = val
+		}
+	case float64:
+		m.AutoEmailReminderTime = int(v)
+	case int:
+		m.AutoEmailReminderTime = v
+	default:
+		if v != nil {
+			return fmt.Errorf("invalid type for auto_email_reminder_time: %T", v)
 		}
 	}
 

--- a/cmd/meeting-api/eventing/meeting_event_handler_test.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler_test.go
@@ -1,0 +1,50 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package eventing
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// v1 sometimes sends auto_email_reminder_time as a string; unmarshal must coerce it.
+func TestMeetingDBRawUnmarshalAutoEmailReminderTime(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want int
+	}{
+		{"string", `{"auto_email_reminder_time":"10"}`, 10},
+		{"int", `{"auto_email_reminder_time":10}`, 10},
+		{"empty string", `{"auto_email_reminder_time":""}`, 0},
+		{"absent", `{}`, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m MeetingDBRaw
+			err := json.Unmarshal([]byte(tt.json), &m)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, m.AutoEmailReminderTime)
+		})
+	}
+}
+
+// Non-numeric strings and wrong JSON types must still be rejected.
+func TestMeetingDBRawUnmarshalAutoEmailReminderTimeInvalid(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		json string
+	}{
+		{"non-numeric string", `{"auto_email_reminder_time":"soon"}`},
+		{"bool", `{"auto_email_reminder_time":true}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var m MeetingDBRaw
+			require.Error(t, json.Unmarshal([]byte(tt.json), &m))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes PCC-1360: mailing-list members were missing from a meeting's v2 registrant table. When meetings sync from v1 to v2, the meeting record is parsed from JSON, where `auto_email_reminder_time` is expected to be an integer. v1 sometimes sends it as a string so the whole meeting failed to parse. The `v1_meetings` mapping is never written, and every registrant event for that meeting is then skipped. The members are never created as registrants in v2. 

## Fix

- Add `auto_email_reminder_time` to the same string/float64/int coercion the sibling numeric fields already use in `MeetingDBRaw.UnmarshalJSON`. Bad values (non-numeric strings, wrong types) are still rejected.

Ticket: https://linuxfoundation.atlassian.net/browse/PCC-1360

## Test plan

- Added `TestMeetingDBRawUnmarshalAutoEmailReminderTime` (runs in CI via
  `go test ./...`): a string value now coerces to int and parses; int, empty,
  and absent cases still behave correctly.
- `go vet`, `go test -race ./...` (all pass), `go build ./...`, golangci-lint