### PR TITLE
feat: record HTTP client errors on OTel spans

### DIFF
--- a/internal/infrastructure/proxy/client.go
+++ b/internal/infrastructure/proxy/client.go
@@ -21,6 +21,8 @@ import (
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/redaction"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
 )
 
@@ -169,7 +171,7 @@ func (c *Client) CreateZoomMeeting(ctx context.Context, req *itx.CreateZoomMeeti
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -211,7 +213,7 @@ func (c *Client) GetZoomMeeting(ctx context.Context, meetingID string) (*itx.Zoo
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -252,7 +254,7 @@ func (c *Client) DeleteZoomMeeting(ctx context.Context, meetingID string) error 
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -294,7 +296,7 @@ func (c *Client) UpdateZoomMeeting(ctx context.Context, meetingID string, req *i
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -330,7 +332,7 @@ func (c *Client) GetMeetingCount(ctx context.Context, projectID string) (*itx.Me
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -396,7 +398,7 @@ func (c *Client) GetMeetingJoinLink(ctx context.Context, req *itx.GetJoinLinkReq
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -445,7 +447,7 @@ func (c *Client) CreateRegistrant(ctx context.Context, meetingID string, req *it
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -487,7 +489,7 @@ func (c *Client) GetRegistrant(ctx context.Context, meetingID, registrantID stri
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -535,7 +537,7 @@ func (c *Client) UpdateRegistrant(ctx context.Context, meetingID, registrantID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -570,7 +572,7 @@ func (c *Client) DeleteRegistrant(ctx context.Context, meetingID, registrantID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -606,7 +608,7 @@ func (c *Client) GetRegistrantICS(ctx context.Context, meetingID, registrantID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Return ICS content as-is (binary data)
@@ -644,7 +646,7 @@ func (c *Client) ResendRegistrantInvitation(ctx context.Context, meetingID, regi
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -691,7 +693,7 @@ func (c *Client) ResendMeetingInvitations(ctx context.Context, meetingID string,
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -726,7 +728,7 @@ func (c *Client) RegisterCommitteeMembers(ctx context.Context, meetingID string)
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -768,7 +770,7 @@ func (c *Client) UpdateOccurrence(ctx context.Context, meetingID, occurrenceID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -803,7 +805,7 @@ func (c *Client) DeleteOccurrence(ctx context.Context, meetingID, occurrenceID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -846,7 +848,7 @@ func (c *Client) SubmitMeetingResponse(ctx context.Context, meetingAndOccurrence
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -894,7 +896,7 @@ func (c *Client) CreatePastMeeting(ctx context.Context, req *itx.CreatePastMeeti
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -936,7 +938,7 @@ func (c *Client) GetPastMeeting(ctx context.Context, pastMeetingID string) (*itx
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -986,7 +988,7 @@ func (c *Client) UpdatePastMeeting(ctx context.Context, pastMeetingID string, re
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Success - ITX returns 204 No Content, return nil
@@ -1023,7 +1025,7 @@ func (c *Client) DeletePastMeeting(ctx context.Context, pastMeetingID string) er
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -1059,7 +1061,7 @@ func (c *Client) GetPastMeetingSummary(ctx context.Context, pastMeetingID, summa
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -1108,7 +1110,7 @@ func (c *Client) UpdatePastMeetingSummary(ctx context.Context, pastMeetingID, su
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -1149,6 +1151,22 @@ func (c *Client) mapHTTPError(statusCode int, body []byte) error {
 	}
 }
 
+// recordAndMapHTTPError maps a non-2xx status code to a domain error and, for
+// 5xx responses, records the error on the active OTel span so that Datadog
+// surfaces error.message / error.type.
+func (c *Client) recordAndMapHTTPError(ctx context.Context, statusCode int, body []byte) error {
+	err := c.mapHTTPError(statusCode, body)
+	if statusCode >= 500 {
+		// Record a status-only error for telemetry to avoid leaking upstream
+		// server-supplied message text (which may echo user-identifiable data).
+		// The full domain error with the original message is returned to the caller.
+		span := trace.SpanFromContext(ctx)
+		span.RecordError(fmt.Errorf("HTTP %d", statusCode))
+		span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", statusCode))
+	}
+	return err
+}
+
 // CreateInvitee creates an invitee for a past meeting via the ITX proxy
 func (c *Client) CreateInvitee(ctx context.Context, pastMeetingID string, req *itx.CreateInviteeRequest) (*itx.InviteeResponse, error) {
 	url := fmt.Sprintf("%s/v2/zoom/past_meetings/%s/invitees", c.config.BaseURL, pastMeetingID)
@@ -1186,7 +1204,7 @@ func (c *Client) CreateInvitee(ctx context.Context, pastMeetingID string, req *i
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -1235,7 +1253,7 @@ func (c *Client) UpdateInvitee(ctx context.Context, pastMeetingID, inviteeID str
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Success - ITX returns 204 No Content, return nil
@@ -1272,7 +1290,7 @@ func (c *Client) DeleteInvitee(ctx context.Context, pastMeetingID, inviteeID str
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -1315,7 +1333,7 @@ func (c *Client) CreateAttendee(ctx context.Context, pastMeetingID string, req *
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Unmarshal response
@@ -1364,7 +1382,7 @@ func (c *Client) UpdateAttendee(ctx context.Context, pastMeetingID, attendeeID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Success - ITX returns 204 No Content, return nil
@@ -1401,7 +1419,7 @@ func (c *Client) DeleteAttendee(ctx context.Context, pastMeetingID, attendeeID s
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -1459,7 +1477,7 @@ func (c *Client) CreateMeetingAttachmentPresignURL(ctx context.Context, meetingI
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1512,7 +1530,7 @@ func (c *Client) GetMeetingAttachmentDownloadURL(ctx context.Context, meetingID,
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1572,7 +1590,7 @@ func (c *Client) CreatePastMeetingAttachmentPresignURL(ctx context.Context, meet
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1625,7 +1643,7 @@ func (c *Client) GetPastMeetingAttachmentDownloadURL(ctx context.Context, meetin
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1685,7 +1703,7 @@ func (c *Client) CreateMeetingAttachment(ctx context.Context, meetingID string, 
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1738,7 +1756,7 @@ func (c *Client) GetMeetingAttachment(ctx context.Context, meetingID, attachment
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1799,7 +1817,7 @@ func (c *Client) UpdateMeetingAttachment(ctx context.Context, meetingID, attachm
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// ITX returns 204 No Content on successful update
@@ -1846,7 +1864,7 @@ func (c *Client) DeleteMeetingAttachment(ctx context.Context, meetingID, attachm
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -1900,7 +1918,7 @@ func (c *Client) CreatePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -1953,7 +1971,7 @@ func (c *Client) GetPastMeetingAttachment(ctx context.Context, meetingAndOccurre
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, c.mapHTTPError(resp.StatusCode, respBody)
+		return nil, c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// Parse response
@@ -2014,7 +2032,7 @@ func (c *Client) UpdatePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	// ITX returns 204 No Content on successful update
@@ -2061,7 +2079,7 @@ func (c *Client) DeletePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil
@@ -2108,7 +2126,7 @@ func (c *Client) AcceptInvite(ctx context.Context, email, username string) error
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return c.mapHTTPError(resp.StatusCode, respBody)
+		return c.recordAndMapHTTPError(ctx, resp.StatusCode, respBody)
 	}
 
 	return nil

--- a/internal/infrastructure/proxy/client_otel_test.go
+++ b/internal/infrastructure/proxy/client_otel_test.go
@@ -1,0 +1,122 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func newTestTracer(t *testing.T) (trace.Tracer, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp.Tracer("test"), sr
+}
+
+func hasExceptionEvent(spans []sdktrace.ReadOnlySpan) bool {
+	for _, s := range spans {
+		for _, e := range s.Events() {
+			if e.Name == "exception" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func exceptionMessage(spans []sdktrace.ReadOnlySpan) string {
+	for _, s := range spans {
+		for _, e := range s.Events() {
+			if e.Name == "exception" {
+				for _, a := range e.Attributes {
+					if string(a.Key) == "exception.message" {
+						return a.Value.AsString()
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func hasErrorStatus(spans []sdktrace.ReadOnlySpan) bool {
+	for _, s := range spans {
+		if s.Status().Code == codes.Error {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRecordAndMapHTTPError_5xx_RecordsErrorOnSpan(t *testing.T) {
+	tracer, sr := newTestTracer(t)
+	ctx, span := tracer.Start(context.Background(), "op")
+
+	c := &Client{}
+	err := c.recordAndMapHTTPError(ctx, 500, []byte(`{"message":"internal error"}`))
+	span.End()
+
+	if err == nil {
+		t.Fatal("expected error from 5xx status")
+	}
+	if !hasExceptionEvent(sr.Ended()) {
+		t.Error("RecordError should have been called on the span for a 5xx response")
+	}
+	if !hasErrorStatus(sr.Ended()) {
+		t.Error("SetStatus(codes.Error) should have been called on the span for a 5xx response")
+	}
+	// Verify sanitization: exception.message must be the safe "HTTP <code>" form,
+	// not the raw upstream error body which may contain PII.
+	if msg := exceptionMessage(sr.Ended()); msg != "HTTP 500" {
+		t.Errorf("exception.message = %q, want %q", msg, "HTTP 500")
+	}
+}
+
+func TestRecordAndMapHTTPError_503_RecordsErrorOnSpan(t *testing.T) {
+	tracer, sr := newTestTracer(t)
+	ctx, span := tracer.Start(context.Background(), "op")
+
+	c := &Client{}
+	err := c.recordAndMapHTTPError(ctx, 503, []byte(`{"message":"service unavailable"}`))
+	span.End()
+
+	if err == nil {
+		t.Fatal("expected error from 503 status")
+	}
+	if !hasExceptionEvent(sr.Ended()) {
+		t.Error("RecordError should have been called on the span for a 503 response")
+	}
+	if !hasErrorStatus(sr.Ended()) {
+		t.Error("SetStatus(codes.Error) should have been called on the span for a 503 response")
+	}
+	if msg := exceptionMessage(sr.Ended()); msg != "HTTP 503" {
+		t.Errorf("exception.message = %q, want %q", msg, "HTTP 503")
+	}
+}
+
+func TestRecordAndMapHTTPError_4xx_DoesNotRecordErrorOnSpan(t *testing.T) {
+	tracer, sr := newTestTracer(t)
+	ctx, span := tracer.Start(context.Background(), "op")
+
+	c := &Client{}
+	err := c.recordAndMapHTTPError(ctx, 404, []byte(`{"message":"not found"}`))
+	span.End()
+
+	if err == nil {
+		t.Fatal("expected error from 4xx status")
+	}
+	if hasExceptionEvent(sr.Ended()) {
+		t.Error("RecordError must not be called on the span for a 4xx response")
+	}
+	if hasErrorStatus(sr.Ended()) {
+		t.Error("SetStatus(codes.Error) must not be called on the span for a 4xx response")
+	}
+}

--- a/internal/infrastructure/userservice/client.go
+++ b/internal/infrastructure/userservice/client.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
@@ -290,7 +292,16 @@ func (c *Client) doJSON(ctx context.Context, token, method, reqURL string, body,
 		"method", method, "status", resp.StatusCode, "body_len", len(respBody))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return mapHTTPError(resp.StatusCode, respBody)
+		domainErr := mapHTTPError(resp.StatusCode, respBody)
+		if resp.StatusCode >= 500 {
+			// Record a status-only error for telemetry to avoid leaking PII
+			// (email addresses can appear in user-service error bodies).
+			// The full domain error with the original message is returned to the caller.
+			span := trace.SpanFromContext(ctx)
+			span.RecordError(fmt.Errorf("HTTP %d", resp.StatusCode))
+			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", resp.StatusCode))
+		}
+		return domainErr
 	}
 
 	if out == nil || len(respBody) == 0 {

--- a/internal/infrastructure/userservice/client_otel_test.go
+++ b/internal/infrastructure/userservice/client_otel_test.go
@@ -1,0 +1,112 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package userservice
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func newTestTracer(t *testing.T) (trace.Tracer, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp.Tracer("test"), sr
+}
+
+func hasExceptionEvent(spans []sdktrace.ReadOnlySpan) bool {
+	for _, s := range spans {
+		for _, e := range s.Events() {
+			if e.Name == "exception" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func exceptionMessage(spans []sdktrace.ReadOnlySpan) string {
+	for _, s := range spans {
+		for _, e := range s.Events() {
+			if e.Name == "exception" {
+				for _, a := range e.Attributes {
+					if string(a.Key) == "exception.message" {
+						return a.Value.AsString()
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func hasErrorStatus(spans []sdktrace.ReadOnlySpan) bool {
+	for _, s := range spans {
+		if s.Status().Code == codes.Error {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDoJSON_5xx_RecordsErrorOnSpan(t *testing.T) {
+	tracer, sr := newTestTracer(t)
+	ctx, span := tracer.Start(context.Background(), "op")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := newClient(server.Client(), server.URL)
+	err := c.doJSON(ctx, testToken, http.MethodGet, server.URL+"/user-service/v1/me", nil, nil)
+	span.End()
+
+	if err == nil {
+		t.Fatal("expected error from 5xx response")
+	}
+	if !hasExceptionEvent(sr.Ended()) {
+		t.Error("RecordError should have been called on the span for a 5xx response")
+	}
+	if !hasErrorStatus(sr.Ended()) {
+		t.Error("SetStatus(codes.Error) should have been called on the span for a 5xx response")
+	}
+	// Verify sanitization: exception.message must be the safe "HTTP <code>" form,
+	// not the raw domain error which may contain upstream PII.
+	if msg := exceptionMessage(sr.Ended()); msg != "HTTP 500" {
+		t.Errorf("exception.message = %q, want %q", msg, "HTTP 500")
+	}
+}
+
+func TestDoJSON_4xx_DoesNotRecordErrorOnSpan(t *testing.T) {
+	tracer, sr := newTestTracer(t)
+	ctx, span := tracer.Start(context.Background(), "op")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := newClient(server.Client(), server.URL)
+	err := c.doJSON(ctx, testToken, http.MethodGet, server.URL+"/user-service/v1/me", nil, nil)
+	span.End()
+
+	if err == nil {
+		t.Fatal("expected error from 4xx response")
+	}
+	if hasExceptionEvent(sr.Ended()) {
+		t.Error("RecordError must not be called on the span for a 4xx response")
+	}
+	if hasErrorStatus(sr.Ended()) {
+		t.Error("SetStatus(codes.Error) must not be called on the span for a 4xx response")
+	}
+}


### PR DESCRIPTION
## What

Adds call-site `span.RecordError()` and `span.SetStatus(codes.Error, ...)` at HTTP error boundaries in the `userservice` and `proxy` infrastructure clients so that Datadog surfaces `error.message` and `error.type` on OTel spans.

**Changed files:**
- `userservice/client.go` — calls `span.RecordError` and `span.SetStatus` in `doJSON` for 5xx responses; records a sanitized `"HTTP <status>"` message to avoid exposing email addresses in telemetry
- `userservice/client_otel_test.go` — OTel tests verifying exception events and error status are set for 5xx, and not set for 4xx
- `proxy/client.go` — `recordAndMapHTTPError` helper wraps `mapHTTPError` with `span.RecordError` and `span.SetStatus` for 5xx; records a sanitized `"HTTP <status>"` message to avoid echoing upstream server error text
- `proxy/client_otel_test.go` — OTel tests verifying the same for proxy responses

4xx responses (401, 403, 404) are intentionally excluded — they represent expected application behaviour, not errors.

## Why

Investigation of Datadog APM showed error spans from `lfx-v2-meeting-service` HTTP clients with no error details attached. The Go `otelhttp` transport marks non-2xx HTTP responses as span errors but does not call `span.RecordError()`, so `error.message` and `error.type` are never populated in Datadog.

Recording at the call site is simpler than a transport wrapper and records errors on the handler span (the parent) rather than on the otelhttp child span — making them immediately visible in Datadog APM without needing to traverse the span tree. Error messages are sanitized to `"HTTP <status>"` to prevent user-service email addresses or upstream proxy error text from appearing in Datadog traces.

This is consistent with the approach taken in `lfx-v2-fga-sync` (PR #55).

Issue: LFXV2-2660