### PR TITLE
fix(registrant): clear username when absent from CDC update payload

### DIFF
--- a/cmd/meeting-api/eventing/registrant_event_handler.go
+++ b/cmd/meeting-api/eventing/registrant_event_handler.go
@@ -216,17 +216,12 @@ func (h *EventHandlers) handleRegistrantUpdate(
 	// that explicitly clears the username field must revoke FGA access even when user_id
 	// still resolves.
 	//
-	// A sparse CDC payload may omit "username" entirely; in that case the field was
-	// decoded to "" by convertMapToRegistrantData, which is indistinguishable from an
-	// explicit clear. Guard with a key-presence check: absent key → retain the stored
-	// username so the revocation comparison sees no change; present key → honour the
-	// new value (including an explicit clear to "").
+	// When v1 removes a username, the CDC payload omits the "username" key entirely —
+	// the same shape as a sparse update that didn't touch the field. Since these two cases
+	// are indistinguishable by key-presence, always use the decoded value: absent key →
+	// empty string, which correctly triggers revocation of the previously-stored username.
 	if indexerAction == indexerConstants.ActionUpdated {
-		if rawUsername, ok := v1Data["username"]; ok {
-			registrantData.Username = utils.GetString(rawUsername)
-		} else {
-			registrantData.Username = oldUsername
-		}
+		registrantData.Username = utils.GetString(v1Data["username"])
 	}
 
 	// If the username was removed or changed during an update, revoke the old FGA access

--- a/cmd/meeting-api/eventing/registrant_event_handler_test.go
+++ b/cmd/meeting-api/eventing/registrant_event_handler_test.go
@@ -288,13 +288,13 @@ func TestProcessInviteAcceptedEvent_clientError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestHandleRegistrantUpdate_SparseUpdate_NoSpuriousRevocation verifies that a sparse CDC
-// update payload — one that omits the "username" key entirely — does not trigger a
-// member_remove even when the stored mapping contains an existing username.
-// This guards against the bug where utils.GetString(v1Data["username"]) returns ""
-// for both an absent key (sparse update) and an explicit clear, making them
-// indistinguishable without the key-presence check.
-func TestHandleRegistrantUpdate_SparseUpdate_NoSpuriousRevocation(t *testing.T) {
+// TestHandleRegistrantUpdate_UsernameCleared verifies that a CDC update that results in an
+// empty username — whether the "username" key is absent (v1 removes the field on clear) or
+// explicitly present as "" — revokes the previously-stored FGA access.
+//
+// Both shapes are treated identically: utils.GetString(v1Data["username"]) returns "" in
+// either case, which correctly triggers a member_remove against the stored oldUsername.
+func TestHandleRegistrantUpdate_UsernameCleared(t *testing.T) {
 	const (
 		registrantUID = "reg-1"
 		meetingID     = "meeting-1"
@@ -304,27 +304,24 @@ func TestHandleRegistrantUpdate_SparseUpdate_NoSpuriousRevocation(t *testing.T) 
 	storedMapping := buildRegistrantMappingValue(registrantUID, oldUsername, meetingID)
 
 	tests := []struct {
-		name                  string
-		v1Data                map[string]interface{}
-		wantAccessDeleteCalls int
+		name   string
+		v1Data map[string]interface{}
 	}{
 		{
-			name: "sparse update (username key absent) does not revoke",
+			name: "username key absent (v1 clear CDC shape) revokes",
 			v1Data: map[string]interface{}{
 				"registrant_id": registrantUID,
 				"meeting_id":    meetingID,
-				// "username" key intentionally absent — simulates sparse CDC payload
+				// "username" key absent — shape v1 sends when username is removed
 			},
-			wantAccessDeleteCalls: 0,
 		},
 		{
-			name: "explicit clear (username key present and empty) revokes",
+			name: "username key present and empty revokes",
 			v1Data: map[string]interface{}{
 				"registrant_id": registrantUID,
 				"meeting_id":    meetingID,
-				"username":      "", // explicit clear — must revoke
+				"username":      "",
 			},
-			wantAccessDeleteCalls: 1,
 		},
 	}
 
@@ -333,22 +330,15 @@ func TestHandleRegistrantUpdate_SparseUpdate_NoSpuriousRevocation(t *testing.T) 
 			mappingsKV := &mockKeyValue{}
 			publisher := &mockEventPublisher{}
 
-			// Parent meeting exists
 			mappingsKV.On("Get", mock.Anything, "v1_meetings."+meetingID).
 				Return(mockKeyValueEntry{key: "v1_meetings." + meetingID, value: []byte("1")}, nil)
-
-			// Existing registrant mapping with a username
 			mappingsKV.On("Get", mock.Anything, "v1_meeting_registrants."+registrantUID).
 				Return(mockKeyValueEntry{key: "v1_meeting_registrants." + registrantUID, value: []byte(storedMapping)}, nil)
-
-			// Mapping write after update
 			mappingsKV.On("Put", mock.Anything, "v1_meeting_registrants."+registrantUID, mock.Anything).
 				Return(uint64(2), nil)
 
 			publisher.On("PublishRegistrantEvent", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-			if tt.wantAccessDeleteCalls > 0 {
-				publisher.On("PublishAccessDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-			}
+			publisher.On("PublishAccessDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 			h := &EventHandlers{
 				publisher:    publisher,
@@ -361,9 +351,54 @@ func TestHandleRegistrantUpdate_SparseUpdate_NoSpuriousRevocation(t *testing.T) 
 			retry := h.handleRegistrantUpdate(context.Background(), "itx-zoom-meetings-registrants-v2."+registrantUID, tt.v1Data)
 
 			assert.False(t, retry)
-			publisher.AssertNumberOfCalls(t, "PublishAccessDelete", tt.wantAccessDeleteCalls)
+			publisher.AssertNumberOfCalls(t, "PublishAccessDelete", 1)
 			mappingsKV.AssertExpectations(t)
 			publisher.AssertExpectations(t)
 		})
 	}
+}
+
+// TestHandleRegistrantUpdate_UsernameUnchanged verifies that an update where the username
+// is the same as the stored value does not trigger a member_remove.
+func TestHandleRegistrantUpdate_UsernameUnchanged(t *testing.T) {
+	const (
+		registrantUID = "reg-2"
+		meetingID     = "meeting-2"
+		username      = "bob"
+	)
+
+	storedMapping := buildRegistrantMappingValue(registrantUID, username, meetingID)
+
+	mappingsKV := &mockKeyValue{}
+	publisher := &mockEventPublisher{}
+
+	mappingsKV.On("Get", mock.Anything, "v1_meetings."+meetingID).
+		Return(mockKeyValueEntry{key: "v1_meetings." + meetingID, value: []byte("1")}, nil)
+	mappingsKV.On("Get", mock.Anything, "v1_meeting_registrants."+registrantUID).
+		Return(mockKeyValueEntry{key: "v1_meeting_registrants." + registrantUID, value: []byte(storedMapping)}, nil)
+	mappingsKV.On("Put", mock.Anything, "v1_meeting_registrants."+registrantUID, mock.Anything).
+		Return(uint64(2), nil)
+
+	publisher.On("PublishRegistrantEvent", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	h := &EventHandlers{
+		publisher:    publisher,
+		userLookup:   stubV1UserLookup{},
+		idMapper:     stubIDMapper{},
+		v1MappingsKV: mappingsKV,
+		logger:       slog.Default(),
+	}
+
+	v1Data := map[string]interface{}{
+		"registrant_id": registrantUID,
+		"meeting_id":    meetingID,
+		"username":      username,
+	}
+
+	retry := h.handleRegistrantUpdate(context.Background(), "itx-zoom-meetings-registrants-v2."+registrantUID, v1Data)
+
+	assert.False(t, retry)
+	publisher.AssertNumberOfCalls(t, "PublishAccessDelete", 0)
+	mappingsKV.AssertExpectations(t)
+	publisher.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

- Removes the `v1Data["username"]` key-presence guard added in PR #218 from `handleRegistrantUpdate`
- When v1 removes a username from a registrant record, the CDC payload omits the `username` key — the same shape as a sparse update that didn't touch the field; the two cases are indistinguishable by key-presence, so the guard was silently blocking legitimate clears from revoking FGA access
- Reverts to `utils.GetString(v1Data["username"])` which returns `""` for an absent key, correctly triggering `member_remove` for the previously-stored username
- Participant handlers (`handleInviteeUpdate`, `handleAttendeeUpdate`) are unaffected — they already read `lf_sso` from the decoded struct without any key-presence guard and behave correctly

## Tests

- Renamed `TestHandleRegistrantUpdate_SparseUpdate_NoSpuriousRevocation` → `TestHandleRegistrantUpdate_UsernameCleared` and updated both sub-cases (absent key and explicit empty string) to assert revocation occurs
- Added `TestHandleRegistrantUpdate_UsernameUnchanged` to confirm no `member_remove` is published when the username is the same as the stored value

## Ticket

[LFXV2-2599](https://jira.linuxfoundation.org/browse/LFXV2-2599)

[LFXV2-2599]: https://linuxfoundation.atlassian.net/browse/LFXV2-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ