### PR TITLE
feat: add meeting registrant reconciliation tool

### DIFF
--- a/scripts/reconcile_meeting_registrants/README.md
+++ b/scripts/reconcile_meeting_registrants/README.md
@@ -1,0 +1,131 @@
+# reconcile_meeting_registrants
+
+Reconciles one meeting's indexed registrants against the authoritative DynamoDB
+registrant table. It repairs rows that are absent from DynamoDB but remain live in
+the `v1-objects` NATS KV bucket and OpenSearch.
+
+Dry-run is the default. Apply writes only `_sdc_deleted_at` to exact NATS keys
+using revision-conditional updates. Existing meeting-service event processing
+then removes the corresponding OpenSearch document and applicable OpenFGA tuple.
+
+## Scope and safety
+
+- OpenSearch supplies the bounded candidate UID list for one meeting.
+- Consistent DynamoDB `BatchGetItem` reads determine active versus stale.
+- The tool never scans DynamoDB or NATS.
+- The tool never writes DynamoDB, OpenSearch, OpenFGA, or ITX.
+- A present DynamoDB row is always active; undocumented status fields are ignored.
+- Apply requires a reviewed plan and exact environment/count confirmations.
+- JSON and MessagePack NATS values retain their original encoding and fields.
+
+The configured table must use one string partition key whose value is the
+registrant UID. Any other key schema is rejected rather than guessed.
+
+## Prerequisites
+
+1. Python 3.11 or newer.
+2. Reachable OpenSearch and NATS endpoints, normally through separately managed
+   read/write access paths or port-forwards. The tool does not invoke `kubectl`.
+3. AWS credentials from the standard credential chain, `--aws-profile`, or
+   `--assume-role-arn`.
+4. Least-privilege AWS permissions:
+   - `sts:GetCallerIdentity`
+   - `sts:AssumeRole` only when `--assume-role-arn` is used
+   - `dynamodb:DescribeTable`
+   - `dynamodb:BatchGetItem`
+5. NATS read access to `v1-objects` and `v1-mappings`; apply/restore also require
+   revision-conditional update access to `v1-objects`.
+
+Install dependencies in an isolated environment:
+
+```bash
+cd scripts/reconcile_meeting_registrants
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements.txt
+```
+
+## Dry-run
+
+```bash
+.venv/bin/python reconcile_meeting_registrants.py \
+  --meeting-id 98727043273 \
+  --opensearch-url http://localhost:9200 \
+  --nats-url nats://localhost:4222 \
+  --dynamodb-table itx-zoom-meetings-registrants-v2 \
+  --aws-region us-east-1 \
+  --aws-profile production-readonly \
+  --plan ./meeting-98727043273-plan.json
+```
+
+Dry-run creates a mode-`0600` plan and prints a redacted summary. Review:
+
+- AWS account, region, table ARN, and discovered key schema
+- every candidate UID and DynamoDB classification
+- NATS revisions, mapping states, encodings, and payload digests
+- active, stale, and candidate totals
+
+The plan contains no raw DynamoDB/NATS values, credentials, names, email
+addresses, or usernames.
+
+## Apply
+
+Use the exact account, table ARN, meeting ID, and stale count from the reviewed
+plan:
+
+```bash
+.venv/bin/python reconcile_meeting_registrants.py \
+  --meeting-id 98727043273 \
+  --opensearch-url http://localhost:9200 \
+  --nats-url nats://localhost:4222 \
+  --dynamodb-table itx-zoom-meetings-registrants-v2 \
+  --aws-region us-east-1 \
+  --aws-profile production-readonly \
+  --plan ./meeting-98727043273-plan.json \
+  --apply \
+  --confirm-meeting-id 98727043273 \
+  --confirm-aws-account 123456789012 \
+  --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example \
+  --confirm-stale-count 8
+```
+
+Before the first write, apply repeats candidate discovery, consistent DynamoDB
+classification, and all NATS reads. Any changed UID, classification, digest,
+mapping, revision, or AWS environment invalidates the plan. After writes, the
+tool waits for stale UIDs to leave OpenSearch and their mappings to become
+tombstoned.
+
+## Restore
+
+Restore one UID only after DynamoDB contains that exact row:
+
+```bash
+.venv/bin/python reconcile_meeting_registrants.py \
+  --meeting-id 98727043273 \
+  --opensearch-url http://localhost:9200 \
+  --nats-url nats://localhost:4222 \
+  --dynamodb-table itx-zoom-meetings-registrants-v2 \
+  --aws-region us-east-1 \
+  --aws-profile production-readonly \
+  --restore <registrant-uid> \
+  --confirm-meeting-id 98727043273 \
+  --confirm-aws-account 123456789012 \
+  --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example
+```
+
+Restore removes only `_sdc_deleted_at` with an expected revision, then waits for
+the same UID to reappear in OpenSearch with a live mapping.
+
+## Failure recovery
+
+- Authentication, table-schema, pagination, decode, mapping, or incomplete
+  DynamoDB-read failures stop before writes.
+- Candidate, authority, digest, mapping, or revision drift requires a new
+  dry-run plan.
+- Partial apply stops on the first failure and reports completed and pending
+  UIDs. Do not reuse the old plan; create and review a new dry-run plan.
+- Verification timeout issues no compensating writes. Inspect the existing event
+  pipeline before retrying.
+- An already marked stale row is not rewritten, but remains included in
+  downstream verification.
+
+The command exits non-zero for every ambiguous, partial, or unverified result.

--- a/scripts/reconcile_meeting_registrants/README.md
+++ b/scripts/reconcile_meeting_registrants/README.md
@@ -52,8 +52,8 @@ python3 -m venv .venv
   --opensearch-url http://localhost:9200 \
   --nats-url nats://localhost:4222 \
   --dynamodb-table itx-zoom-meetings-registrants-v2 \
-  --aws-region us-east-1 \
-  --aws-profile production-readonly \
+  --aws-region us-west-2 \
+  --aws-profile itx_prod \
   --plan ./meeting-98727043273-plan.json
 ```
 
@@ -79,13 +79,13 @@ plan:
   --opensearch-url http://localhost:9200 \
   --nats-url nats://localhost:4222 \
   --dynamodb-table itx-zoom-meetings-registrants-v2 \
-  --aws-region us-east-1 \
-  --aws-profile production-readonly \
+  --aws-region us-west-2 \
+  --aws-profile itx_prod \
   --plan ./meeting-98727043273-plan.json \
   --apply \
   --confirm-meeting-id 98727043273 \
   --confirm-aws-account 123456789012 \
-  --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example \
+  --confirm-table-arn arn:aws:dynamodb:us-west-2:123456789012:table/example \
   --confirm-stale-count 8
 ```
 
@@ -110,12 +110,12 @@ Restore one UID only after DynamoDB contains that exact row:
   --opensearch-url http://localhost:9200 \
   --nats-url nats://localhost:4222 \
   --dynamodb-table itx-zoom-meetings-registrants-v2 \
-  --aws-region us-east-1 \
-  --aws-profile production-readonly \
+  --aws-region us-west-2 \
+  --aws-profile itx_prod \
   --restore <registrant-uid> \
   --confirm-meeting-id 98727043273 \
   --confirm-aws-account 123456789012 \
-  --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example \
+  --confirm-table-arn arn:aws:dynamodb:us-west-2:123456789012:table/example \
   --confirm-opensearch-url http://localhost:9200 \
   --confirm-opensearch-index resources \
   --confirm-nats-url nats://localhost:4222

--- a/scripts/reconcile_meeting_registrants/README.md
+++ b/scripts/reconcile_meeting_registrants/README.md
@@ -60,6 +60,7 @@ python3 -m venv .venv
 Dry-run creates a mode-`0600` plan and prints a redacted summary. Review:
 
 - AWS account, region, table ARN, and discovered key schema
+- sanitized OpenSearch URL/index and NATS URL identities
 - every candidate UID and DynamoDB classification
 - NATS revisions, mapping states, encodings, and payload digests
 - active, stale, and candidate totals
@@ -90,9 +91,9 @@ plan:
 
 Before the first write, apply repeats candidate discovery, consistent DynamoDB
 classification, and all NATS reads. Any changed UID, classification, digest,
-mapping, revision, or AWS environment invalidates the plan. After writes, the
-tool waits for stale UIDs to leave OpenSearch and their mappings to become
-tombstoned.
+mapping, revision, AWS environment, or OpenSearch/NATS target invalidates the
+plan. After writes, the tool waits within the configured verification deadline
+for stale UIDs to leave OpenSearch and their mappings to become tombstoned.
 
 ## Restore
 
@@ -112,8 +113,9 @@ Restore one UID only after DynamoDB contains that exact row:
   --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example
 ```
 
-Restore removes only `_sdc_deleted_at` with an expected revision, then waits for
-the same UID to reappear in OpenSearch with a live mapping.
+Restore requires an existing tombstoned mapping, removes only
+`_sdc_deleted_at` with an expected revision, then waits for the same UID to
+reappear in OpenSearch with a newer live mapping revision.
 
 ## Failure recovery
 

--- a/scripts/reconcile_meeting_registrants/README.md
+++ b/scripts/reconcile_meeting_registrants/README.md
@@ -115,12 +115,17 @@ Restore one UID only after DynamoDB contains that exact row:
   --restore <registrant-uid> \
   --confirm-meeting-id 98727043273 \
   --confirm-aws-account 123456789012 \
-  --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example
+  --confirm-table-arn arn:aws:dynamodb:us-east-1:123456789012:table/example \
+  --confirm-opensearch-url http://localhost:9200 \
+  --confirm-opensearch-index resources \
+  --confirm-nats-url nats://localhost:4222
 ```
 
 Restore requires an existing tombstoned mapping, removes only
 `_sdc_deleted_at` with an expected revision, then waits for the same UID to
-reappear in OpenSearch with a newer live mapping revision.
+reappear in OpenSearch with a newer live mapping revision. The confirmed
+OpenSearch URL/index and NATS URL must exactly match the sanitized runtime
+targets before restore can write.
 
 ## Failure recovery
 

--- a/scripts/reconcile_meeting_registrants/README.md
+++ b/scripts/reconcile_meeting_registrants/README.md
@@ -97,6 +97,11 @@ for stale UIDs to leave OpenSearch and their mappings to become tombstoned.
 
 ## Restore
 
+Restore is an optional emergency rollback, not part of the normal reconciliation
+workflow. Use it only to reverse an incorrect soft-delete after confirming that
+DynamoDB again contains the exact registrant; the standard workflow ends after
+dry-run, apply, and downstream verification.
+
 Restore one UID only after DynamoDB contains that exact row:
 
 ```bash

--- a/scripts/reconcile_meeting_registrants/common.py
+++ b/scripts/reconcile_meeting_registrants/common.py
@@ -97,12 +97,45 @@ async def get_entry(store: KVStore, key: str) -> KVEntry:
         raise ReconciliationError(f"NATS KV read failed for {key}") from error
 
 
-def mapping_state(value: Any) -> str:
+def mapping_state(
+    value: Any, expected_uid: str | None = None, expected_meeting_id: str | None = None
+) -> str:
     raw = value.encode() if isinstance(value, str) else bytes(value)
     if raw == LIVE_MAPPING:
         return "live"
     if raw == TOMBSTONE_MAPPING:
         return "tombstoned"
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return "unknown"
+    try:
+        data = json.loads(decoded)
+    except json.JSONDecodeError:
+        parts = decoded.split("|", 2)
+        if len(parts) == 3 and parts[0] and parts[2]:
+            if expected_uid is not None and parts[0] != expected_uid:
+                return "unknown"
+            if expected_meeting_id is not None and parts[2] != expected_meeting_id:
+                return "unknown"
+            return "live"
+        return "unknown"
+    if (
+        isinstance(data, dict)
+        and isinstance(data.get("uid"), str)
+        and data["uid"]
+        and isinstance(data.get("username"), str)
+        and isinstance(data.get("meeting_id"), str)
+        and data["meeting_id"]
+    ):
+        if expected_uid is not None and data["uid"] != expected_uid:
+            return "unknown"
+        if (
+            expected_meeting_id is not None
+            and data["meeting_id"] != expected_meeting_id
+        ):
+            return "unknown"
+        return "live"
     return "unknown"
 
 

--- a/scripts/reconcile_meeting_registrants/common.py
+++ b/scripts/reconcile_meeting_registrants/common.py
@@ -1,3 +1,6 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 """NATS KV and payload helpers adapted from existing migration scripts."""
 
 import hashlib

--- a/scripts/reconcile_meeting_registrants/common.py
+++ b/scripts/reconcile_meeting_registrants/common.py
@@ -1,0 +1,142 @@
+"""NATS KV and payload helpers adapted from existing migration scripts."""
+
+import hashlib
+import json
+from typing import Any, Protocol
+
+import msgpack
+import nats
+
+REGISTRANT_PREFIX = "itx-zoom-meetings-registrants-v2."
+MAPPING_PREFIX = "v1_meeting_registrants."
+DELETED_FIELD = "_sdc_deleted_at"
+LIVE_MAPPING = b"1"
+TOMBSTONE_MAPPING = b"!del"
+
+
+class ReconciliationError(RuntimeError):
+    """A safe, operator-facing reconciliation failure."""
+
+
+class NotFoundError(ReconciliationError):
+    """An expected KV key was not found."""
+
+
+class RevisionConflictError(ReconciliationError):
+    """A KV revision changed concurrently."""
+
+
+class PlanDriftError(ReconciliationError):
+    """Current state differs from the reviewed plan."""
+
+
+class VerificationError(ReconciliationError):
+    """Downstream state did not converge before the deadline."""
+
+
+class KVEntry(Protocol):
+    value: bytes
+    revision: int
+
+
+class KVStore(Protocol):
+    async def get(self, key: str) -> KVEntry: ...
+
+    async def update(self, key: str, value: bytes, last: int) -> int: ...
+
+
+def registrant_key(uid: str) -> str:
+    return f"{REGISTRANT_PREFIX}{uid}"
+
+
+def mapping_key(uid: str) -> str:
+    return f"{MAPPING_PREFIX}{uid}"
+
+
+def encode_payload(payload: dict[str, Any], encoding: str) -> bytes:
+    if encoding == "json":
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    if encoding == "msgpack":
+        return msgpack.packb(payload, use_bin_type=True)
+    raise ReconciliationError(f"unsupported payload encoding: {encoding}")
+
+
+def decode_payload(raw: bytes) -> tuple[dict[str, Any], str]:
+    try:
+        payload = json.loads(raw)
+        if isinstance(payload, dict):
+            return payload, "json"
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        pass
+    try:
+        payload = msgpack.unpackb(raw, raw=False, strict_map_key=False)
+        if isinstance(payload, dict):
+            return payload, "msgpack"
+    except (ValueError, TypeError, msgpack.ExtraData):
+        pass
+    raise ReconciliationError("registrant payload is neither JSON nor MessagePack")
+
+
+def payload_digest(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+async def get_entry(store: KVStore, key: str) -> KVEntry:
+    try:
+        return await store.get(key)
+    except NotFoundError:
+        raise
+    except Exception as error:
+        if error.__class__.__name__ in {"KeyNotFoundError", "NotFoundError"}:
+            raise NotFoundError(key) from error
+        raise ReconciliationError(f"NATS KV read failed for {key}") from error
+
+
+def mapping_state(value: Any) -> str:
+    raw = value.encode() if isinstance(value, str) else bytes(value)
+    if raw == LIVE_MAPPING:
+        return "live"
+    if raw == TOMBSTONE_MAPPING:
+        return "tombstoned"
+    return "unknown"
+
+
+class NATSKV:
+    def __init__(self, store: Any) -> None:
+        self.store = store
+
+    async def get(self, key: str) -> Any:
+        try:
+            return await self.store.get(key)
+        except Exception as error:
+            if error.__class__.__name__ in {"KeyNotFoundError", "NotFoundError"}:
+                raise NotFoundError(key) from error
+            raise ReconciliationError(f"NATS KV read failed for {key}") from error
+
+    async def update(self, key: str, value: bytes, last: int) -> int:
+        try:
+            return await self.store.update(key, value, last=last)
+        except Exception as error:
+            if error.__class__.__name__ in {
+                "KeyWrongLastSequenceError",
+                "BadRequestError",
+            }:
+                raise RevisionConflictError(key) from error
+            raise ReconciliationError(f"NATS KV update failed for {key}") from error
+
+
+async def open_nats(
+    nats_url: str, connect_timeout: float
+) -> tuple[Any, NATSKV, NATSKV]:
+    try:
+        connection = await nats.connect(
+            servers=[nats_url], connect_timeout=connect_timeout
+        )
+        jetstream = connection.jetstream()
+        values = NATSKV(await jetstream.key_value("v1-objects"))
+        mappings = NATSKV(await jetstream.key_value("v1-mappings"))
+        return connection, values, mappings
+    except Exception as error:
+        raise ReconciliationError("NATS connection failed") from error

--- a/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
@@ -204,20 +204,21 @@ def target_identity(config: Config) -> TargetIdentity:
     if not config.opensearch_index:
         raise ReconciliationError("OpenSearch index must not be empty")
     return TargetIdentity(
-        opensearch_url=_sanitize_endpoint(config.opensearch_url),
+        opensearch_url=_sanitize_endpoint(config.opensearch_url, {"http", "https"}),
         opensearch_index=config.opensearch_index,
-        nats_url=_sanitize_endpoint(config.nats_url),
+        nats_url=_sanitize_endpoint(config.nats_url, {"nats", "tls", "ws", "wss"}),
     )
 
 
-def _sanitize_endpoint(value: str) -> str:
+def _sanitize_endpoint(value: str, allowed_schemes: set[str]) -> str:
     try:
         parsed = urlsplit(value)
         hostname = parsed.hostname
         port = parsed.port
     except ValueError as error:
         raise ReconciliationError("target endpoint is malformed") from error
-    if not parsed.scheme or not hostname:
+    scheme = parsed.scheme.lower()
+    if scheme not in allowed_schemes or not hostname:
         raise ReconciliationError("target endpoint must include scheme and host")
     if (
         parsed.username is not None
@@ -230,7 +231,7 @@ def _sanitize_endpoint(value: str) -> str:
         )
     host = f"[{hostname.lower()}]" if ":" in hostname else hostname.lower()
     netloc = f"{host}:{port}" if port is not None else host
-    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path.rstrip("/"), "", ""))
+    return urlunsplit((scheme, netloc, parsed.path.rstrip("/"), "", ""))
 
 
 def _validate_args(
@@ -305,7 +306,10 @@ class OpenSearchDiscovery:
             request_timeout=timeout,
             json=body,
         )
-        return bool(self._hits(payload))
+        uids = self._uids(self._hits(payload))
+        if any(result_uid != uid for result_uid in uids):
+            raise ReconciliationError("OpenSearch returned an unexpected object_id")
+        return bool(uids)
 
     def _first_page(self, meeting_id: str) -> dict[str, Any]:
         body = {
@@ -352,7 +356,10 @@ class OpenSearchDiscovery:
 
     @staticmethod
     def _hits(payload: dict[str, Any]) -> list[dict[str, Any]]:
-        hits = payload.get("hits", {}).get("hits")
+        container = payload.get("hits")
+        if not isinstance(container, dict):
+            raise ReconciliationError("OpenSearch response has malformed hits")
+        hits = container.get("hits")
         if not isinstance(hits, list):
             raise ReconciliationError("OpenSearch response has malformed hits")
         return hits
@@ -800,6 +807,14 @@ async def restore_candidate(
     if payload.get(DELETED_FIELD) in (None, ""):
         raise ReconciliationError("restore UID is not soft-deleted")
     del payload[DELETED_FIELD]
+    if authority.classify([uid]).get(uid) != "active":
+        raise ReconciliationError("DynamoDB no longer contains the restore UID")
+    current_mapping = await get_entry(mappings, mapping_key(uid))
+    if (
+        current_mapping.revision != mapping_entry.revision
+        or mapping_state(current_mapping.value) != "tombstoned"
+    ):
+        raise ReconciliationError("restore UID mapping changed before write")
     try:
         await values.update(
             registrant_key(uid),
@@ -810,7 +825,7 @@ async def restore_candidate(
         if isinstance(error, RevisionConflictError):
             raise
         raise ReconciliationError(f"NATS KV restore failed for {uid}") from error
-    return mapping_entry.revision
+    return current_mapping.revision
 
 
 async def verify_apply(
@@ -972,21 +987,22 @@ def _assume_role(session: Any, config: Config) -> Any:
 async def run(config: Config) -> dict[str, Any]:
     if requests is None:
         raise ReconciliationError("requests is not installed")
+    targets = target_identity(config)
     if config.mode == "apply":
         reviewed_plan = read_plan(config.plan_path)
-        if target_identity(config) != reviewed_plan.targets:
+        if targets != reviewed_plan.targets:
             raise PlanDriftError("runtime targets differ from the reviewed plan")
     sts, dynamodb = build_aws_clients(config)
     authority = DynamoAuthority(sts, dynamodb, config.dynamodb_table, config.aws_region)
     environment = authority.discover_environment()
     discovery = OpenSearchDiscovery(
         requests.Session(),
-        config.opensearch_url,
-        config.opensearch_index,
+        targets.opensearch_url,
+        targets.opensearch_index,
         config.request_timeout,
     )
     connection, values, mappings = await open_nats(
-        config.nats_url, config.request_timeout
+        targets.nats_url, config.request_timeout
     )
     try:
         if config.mode == "dry-run":

--- a/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
@@ -89,6 +89,9 @@ class Config:
     confirm_aws_account: str | None
     confirm_table_arn: str | None
     confirm_stale_count: int | None
+    confirm_opensearch_url: str | None
+    confirm_opensearch_index: str | None
+    confirm_nats_url: str | None
     request_timeout: float
     verify_timeout: float
     verify_interval: float
@@ -167,6 +170,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--confirm-aws-account")
     parser.add_argument("--confirm-table-arn")
     parser.add_argument("--confirm-stale-count", type=int)
+    parser.add_argument("--confirm-opensearch-url")
+    parser.add_argument("--confirm-opensearch-index")
+    parser.add_argument("--confirm-nats-url")
     parser.add_argument("--request-timeout", type=float, default=15.0)
     parser.add_argument("--verify-timeout", type=float, default=60.0)
     parser.add_argument("--verify-interval", type=float, default=2.0)
@@ -194,6 +200,9 @@ def parse_args(argv: list[str] | None = None) -> Config:
         confirm_aws_account=args.confirm_aws_account,
         confirm_table_arn=args.confirm_table_arn,
         confirm_stale_count=args.confirm_stale_count,
+        confirm_opensearch_url=args.confirm_opensearch_url,
+        confirm_opensearch_index=args.confirm_opensearch_index,
+        confirm_nats_url=args.confirm_nats_url,
         request_timeout=args.request_timeout,
         verify_timeout=args.verify_timeout,
         verify_interval=args.verify_interval,
@@ -257,6 +266,15 @@ def _validate_args(
         parser.error("write modes require meeting, account, and table confirmations")
     if mode == "apply" and args.confirm_stale_count is None:
         parser.error("apply requires --confirm-stale-count")
+    if mode == "restore" and any(
+        value is None
+        for value in (
+            args.confirm_opensearch_url,
+            args.confirm_opensearch_index,
+            args.confirm_nats_url,
+        )
+    ):
+        parser.error("restore requires OpenSearch and NATS target confirmations")
 
 
 class OpenSearchDiscovery:
@@ -1091,6 +1109,16 @@ async def _run_restore(
     mappings: KVStore,
 ) -> dict[str, Any]:
     uid = config.restore_uid or ""
+    confirmed_targets = target_identity(
+        replace(
+            config,
+            opensearch_url=config.confirm_opensearch_url or "",
+            opensearch_index=config.confirm_opensearch_index or "",
+            nats_url=config.confirm_nats_url or "",
+        )
+    )
+    if confirmed_targets != target_identity(config):
+        raise ReconciliationError("restore target confirmations do not match")
     confirmations = RestoreConfirmations(
         config.confirm_meeting_id or "",
         config.confirm_aws_account or "",

--- a/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
@@ -1,0 +1,967 @@
+#!/usr/bin/env python3
+"""Reconcile indexed meeting registrants against authoritative DynamoDB rows."""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Iterable, Protocol
+
+try:
+    import boto3
+except ImportError:  # pragma: no cover - exercised by the dependency check
+    boto3 = None
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - exercised by the dependency check
+    requests = None
+
+from common import (
+    DELETED_FIELD,
+    KVStore,
+    PlanDriftError,
+    ReconciliationError,
+    RevisionConflictError,
+    VerificationError,
+    decode_payload,
+    encode_payload,
+    get_entry,
+    mapping_key,
+    mapping_state,
+    open_nats,
+    payload_digest,
+    registrant_key,
+)
+
+PLAN_VERSION = 1
+
+
+class Discovery(Protocol):
+    def discover(self, meeting_id: str) -> list[str]: ...
+
+    def contains(self, meeting_id: str, uid: str) -> bool: ...
+
+
+class Authority(Protocol):
+    def classify(self, uids: Iterable[str]) -> dict[str, str]: ...
+
+
+class HTTPResponse(Protocol):
+    def raise_for_status(self) -> None: ...
+
+    def json(self) -> Any: ...
+
+
+class HTTPSession(Protocol):
+    def post(self, url: str, **kwargs: Any) -> HTTPResponse: ...
+
+    def delete(self, url: str, **kwargs: Any) -> HTTPResponse: ...
+
+
+@dataclass(frozen=True)
+class Config:
+    meeting_id: str
+    mode: str
+    restore_uid: str | None
+    opensearch_url: str
+    opensearch_index: str
+    nats_url: str
+    dynamodb_table: str
+    aws_region: str
+    aws_profile: str | None
+    assume_role_arn: str | None
+    plan_path: Path
+    confirm_meeting_id: str | None
+    confirm_aws_account: str | None
+    confirm_table_arn: str | None
+    confirm_stale_count: int | None
+    request_timeout: float
+    verify_timeout: float
+    verify_interval: float
+
+
+@dataclass(frozen=True)
+class Environment:
+    account: str
+    region: str
+    table_arn: str
+    table_name: str
+    key_name: str
+    key_type: str
+
+
+@dataclass(frozen=True)
+class CandidateSnapshot:
+    uid: str
+    classification: str
+    revision: int
+    encoding: str
+    digest: str
+    mapping_state: str
+    mapping_revision: int
+    deleted: bool
+
+
+@dataclass(frozen=True)
+class Plan:
+    version: int
+    meeting_id: str
+    environment: Environment
+    candidates: list[CandidateSnapshot]
+
+
+@dataclass(frozen=True)
+class Confirmations:
+    meeting_id: str
+    aws_account: str
+    table_arn: str
+    stale_count: int
+
+
+@dataclass(frozen=True)
+class RestoreConfirmations:
+    meeting_id: str
+    aws_account: str
+    table_arn: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reconcile one meeting's indexed registrants with DynamoDB."
+    )
+    parser.add_argument("--meeting-id", required=True)
+    parser.add_argument("--opensearch-url", required=True)
+    parser.add_argument("--opensearch-index", default="resources")
+    parser.add_argument("--nats-url", required=True)
+    parser.add_argument("--dynamodb-table", required=True)
+    parser.add_argument("--aws-region", default="us-east-1")
+    parser.add_argument("--aws-profile")
+    parser.add_argument("--assume-role-arn")
+    parser.add_argument("--plan", default="reconciliation-plan.json")
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--apply", action="store_true")
+    modes.add_argument("--restore", metavar="REGISTRANT_UID")
+    parser.add_argument("--confirm-meeting-id")
+    parser.add_argument("--confirm-aws-account")
+    parser.add_argument("--confirm-table-arn")
+    parser.add_argument("--confirm-stale-count", type=int)
+    parser.add_argument("--request-timeout", type=float, default=15.0)
+    parser.add_argument("--verify-timeout", type=float, default=60.0)
+    parser.add_argument("--verify-interval", type=float, default=2.0)
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> Config:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    mode = "apply" if args.apply else "restore" if args.restore else "dry-run"
+    _validate_args(parser, args, mode)
+    return Config(
+        meeting_id=args.meeting_id,
+        mode=mode,
+        restore_uid=args.restore,
+        opensearch_url=args.opensearch_url.rstrip("/"),
+        opensearch_index=args.opensearch_index,
+        nats_url=args.nats_url,
+        dynamodb_table=args.dynamodb_table,
+        aws_region=args.aws_region,
+        aws_profile=args.aws_profile,
+        assume_role_arn=args.assume_role_arn,
+        plan_path=Path(args.plan),
+        confirm_meeting_id=args.confirm_meeting_id,
+        confirm_aws_account=args.confirm_aws_account,
+        confirm_table_arn=args.confirm_table_arn,
+        confirm_stale_count=args.confirm_stale_count,
+        request_timeout=args.request_timeout,
+        verify_timeout=args.verify_timeout,
+        verify_interval=args.verify_interval,
+    )
+
+
+def _validate_args(
+    parser: argparse.ArgumentParser, args: argparse.Namespace, mode: str
+) -> None:
+    if args.request_timeout <= 0 or args.verify_timeout < 0:
+        parser.error("timeouts must be positive")
+    if args.verify_interval < 0:
+        parser.error("verify interval must not be negative")
+    confirmations = (
+        args.confirm_meeting_id,
+        args.confirm_aws_account,
+        args.confirm_table_arn,
+    )
+    if mode in {"apply", "restore"} and any(value is None for value in confirmations):
+        parser.error("write modes require meeting, account, and table confirmations")
+    if mode == "apply" and args.confirm_stale_count is None:
+        parser.error("apply requires --confirm-stale-count")
+
+
+class OpenSearchDiscovery:
+    def __init__(
+        self,
+        session: HTTPSession,
+        base_url: str,
+        index: str,
+        timeout: float,
+    ) -> None:
+        self.session = session
+        self.base_url = base_url.rstrip("/")
+        self.index = index
+        self.timeout = timeout
+
+    def discover(self, meeting_id: str) -> list[str]:
+        scroll_id: str | None = None
+        found: set[str] = set()
+        try:
+            payload = self._first_page(meeting_id)
+            while True:
+                scroll_id = _required_string(payload, "_scroll_id")
+                hits = self._hits(payload)
+                if not hits:
+                    return sorted(found)
+                found.update(self._uids(hits))
+                payload = self._next_page(scroll_id)
+        finally:
+            if scroll_id is not None:
+                self._clear_scroll(scroll_id)
+
+    def contains(self, meeting_id: str, uid: str) -> bool:
+        body = {
+            "size": 1,
+            "_source": ["object_id"],
+            "query": {
+                "bool": {
+                    "filter": [
+                        *self._meeting_filter(meeting_id),
+                        {"term": {"object_id": uid}},
+                    ]
+                }
+            },
+        }
+        payload = self._post(f"{self.base_url}/{self.index}/_search", json=body)
+        return bool(self._hits(payload))
+
+    def _first_page(self, meeting_id: str) -> dict[str, Any]:
+        body = {
+            "size": 500,
+            "_source": ["object_id"],
+            "query": {"bool": {"filter": self._meeting_filter(meeting_id)}},
+        }
+        return self._post(
+            f"{self.base_url}/{self.index}/_search",
+            params={"scroll": "1m"},
+            json=body,
+        )
+
+    @staticmethod
+    def _meeting_filter(meeting_id: str) -> list[dict[str, Any]]:
+        return [
+            {"term": {"object_type": "v1_meeting_registrant"}},
+            {"term": {"data.meeting_id": meeting_id}},
+        ]
+
+    def _next_page(self, scroll_id: str) -> dict[str, Any]:
+        return self._post(
+            f"{self.base_url}/_search/scroll",
+            json={"scroll": "1m", "scroll_id": scroll_id},
+        )
+
+    def _post(self, url: str, **kwargs: Any) -> dict[str, Any]:
+        try:
+            response = self.session.post(url, timeout=self.timeout, **kwargs)
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as error:
+            raise ReconciliationError("OpenSearch request failed") from error
+        if not isinstance(payload, dict):
+            raise ReconciliationError("OpenSearch returned malformed JSON")
+        return payload
+
+    @staticmethod
+    def _hits(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        hits = payload.get("hits", {}).get("hits")
+        if not isinstance(hits, list):
+            raise ReconciliationError("OpenSearch response has malformed hits")
+        return hits
+
+    @staticmethod
+    def _uids(hits: Iterable[dict[str, Any]]) -> list[str]:
+        uids = []
+        for hit in hits:
+            source = hit.get("_source") if isinstance(hit, dict) else None
+            uid = source.get("object_id") if isinstance(source, dict) else None
+            if not isinstance(uid, str) or not uid:
+                raise ReconciliationError("OpenSearch hit lacks object_id")
+            uids.append(uid)
+        return uids
+
+    def _clear_scroll(self, scroll_id: str) -> None:
+        try:
+            response = self.session.delete(
+                f"{self.base_url}/_search/scroll",
+                timeout=self.timeout,
+                json={"scroll_id": [scroll_id]},
+            )
+            response.raise_for_status()
+        except Exception as error:
+            raise ReconciliationError("OpenSearch scroll cleanup failed") from error
+
+
+class DynamoAuthority:
+    def __init__(
+        self,
+        sts_client: Any,
+        dynamodb_client: Any,
+        table_name: str,
+        region: str,
+        sleep: Callable[[float], None] = time.sleep,
+        max_retries: int = 3,
+    ) -> None:
+        self.sts = sts_client
+        self.dynamodb = dynamodb_client
+        self.table_name = table_name
+        self.region = region
+        self.sleep = sleep
+        self.max_retries = max_retries
+        self.environment: Environment | None = None
+
+    def discover_environment(self) -> Environment:
+        try:
+            identity = self.sts.get_caller_identity()
+            table = self.dynamodb.describe_table(TableName=self.table_name)["Table"]
+            environment = self._parse_environment(identity, table)
+        except ReconciliationError:
+            raise
+        except Exception as error:
+            raise ReconciliationError(
+                "AWS identity or DynamoDB table discovery failed"
+            ) from error
+        self.environment = environment
+        return environment
+
+    def _parse_environment(
+        self, identity: dict[str, Any], table: dict[str, Any]
+    ) -> Environment:
+        schema = table.get("KeySchema")
+        definitions = table.get("AttributeDefinitions")
+        if not isinstance(schema, list) or len(schema) != 1:
+            raise ReconciliationError("DynamoDB table key schema is unsupported")
+        key_name = schema[0].get("AttributeName")
+        key_type = _attribute_type(definitions, key_name)
+        account = identity.get("Account")
+        table_arn = table.get("TableArn")
+        if schema[0].get("KeyType") != "HASH" or key_type != "S":
+            raise ReconciliationError("DynamoDB table key schema is unsupported")
+        if not all(isinstance(value, str) and value for value in (account, table_arn)):
+            raise ReconciliationError("AWS environment identity is malformed")
+        self._validate_table_arn(table_arn, account)
+        return Environment(
+            account, self.region, table_arn, self.table_name, key_name, key_type
+        )
+
+    def _validate_table_arn(self, table_arn: str, account: str) -> None:
+        parts = table_arn.split(":", 5)
+        expected_resource = f"table/{self.table_name}"
+        if (
+            len(parts) != 6
+            or parts[0] != "arn"
+            or parts[2] != "dynamodb"
+            or parts[3] != self.region
+            or parts[4] != account
+            or parts[5] != expected_resource
+        ):
+            raise ReconciliationError(
+                "DynamoDB table ARN does not match the AWS environment"
+            )
+
+    def build_key(self, uid: str) -> dict[str, dict[str, str]]:
+        if self.environment is None:
+            raise ReconciliationError("DynamoDB environment is not initialized")
+        return {self.environment.key_name: {self.environment.key_type: uid}}
+
+    def classify(self, uids: Iterable[str]) -> dict[str, str]:
+        unique = sorted(set(uids))
+        if self.environment is None:
+            raise ReconciliationError("DynamoDB environment is not initialized")
+        active: set[str] = set()
+        for offset in range(0, len(unique), 100):
+            active.update(self._read_batch(unique[offset : offset + 100]))
+        return {uid: ("active" if uid in active else "stale") for uid in unique}
+
+    def _read_batch(self, uids: list[str]) -> set[str]:
+        request = {
+            self.table_name: {
+                "Keys": [self.build_key(uid) for uid in uids],
+                "ConsistentRead": True,
+            }
+        }
+        active: set[str] = set()
+        for attempt in range(self.max_retries + 1):
+            response = self._batch_get(request)
+            active.update(self._response_uids(response))
+            request = response.get("UnprocessedKeys") or {}
+            if not request:
+                return active
+            if attempt < self.max_retries:
+                self.sleep(min(0.1 * (2**attempt), 1.0))
+        raise ReconciliationError("DynamoDB left candidate keys unresolved")
+
+    def _batch_get(self, request: dict[str, Any]) -> dict[str, Any]:
+        try:
+            response = self.dynamodb.batch_get_item(RequestItems=request)
+        except Exception as error:
+            raise ReconciliationError("DynamoDB batch read failed") from error
+        if not isinstance(response, dict):
+            raise ReconciliationError("DynamoDB returned malformed batch data")
+        responses = response.get("Responses")
+        unprocessed = response.get("UnprocessedKeys")
+        if (
+            not isinstance(responses, dict)
+            or set(responses) != {self.table_name}
+            or not isinstance(responses[self.table_name], list)
+            or not isinstance(unprocessed, dict)
+        ):
+            raise ReconciliationError("DynamoDB returned incomplete batch data")
+        self._validate_unprocessed_keys(request, unprocessed)
+        return response
+
+    def _validate_unprocessed_keys(
+        self, request: dict[str, Any], unprocessed: dict[str, Any]
+    ) -> None:
+        if set(request) != {self.table_name} or not set(unprocessed) <= {
+            self.table_name
+        }:
+            raise ReconciliationError("DynamoDB returned foreign unprocessed keys")
+        if self.table_name not in unprocessed:
+            return
+        pending = unprocessed[self.table_name]
+        if not isinstance(pending, dict) or not isinstance(pending.get("Keys"), list):
+            raise ReconciliationError("DynamoDB returned malformed unprocessed keys")
+        requested = {
+            json.dumps(key, sort_keys=True) for key in request[self.table_name]["Keys"]
+        }
+        returned = {json.dumps(key, sort_keys=True) for key in pending["Keys"]}
+        if not returned <= requested:
+            raise ReconciliationError("DynamoDB returned unexpected unprocessed keys")
+
+    def _response_uids(self, response: dict[str, Any]) -> set[str]:
+        if self.environment is None:
+            raise ReconciliationError("DynamoDB environment is not initialized")
+        items = response["Responses"][self.table_name]
+        result = set()
+        for item in items:
+            value = item.get(self.environment.key_name, {}).get(
+                self.environment.key_type
+            )
+            if not isinstance(value, str) or not value:
+                raise ReconciliationError("DynamoDB returned a malformed key")
+            result.add(value)
+        return result
+
+
+def _attribute_type(definitions: Any, key_name: Any) -> str:
+    if not isinstance(definitions, list) or not isinstance(key_name, str):
+        raise ReconciliationError("DynamoDB key metadata is malformed")
+    for definition in definitions:
+        if definition.get("AttributeName") == key_name:
+            value = definition.get("AttributeType")
+            if isinstance(value, str):
+                return value
+    raise ReconciliationError("DynamoDB key type is missing")
+
+
+async def snapshot_candidate(
+    values: KVStore, mappings: KVStore, meeting_id: str, uid: str
+) -> CandidateSnapshot:
+    value_entry = await get_entry(values, registrant_key(uid))
+    mapping_entry = await get_entry(mappings, mapping_key(uid))
+    payload, encoding = decode_payload(value_entry.value)
+    _validate_identity(payload, meeting_id, uid)
+    state = mapping_state(mapping_entry.value)
+    return CandidateSnapshot(
+        uid=uid,
+        classification="",
+        revision=value_entry.revision,
+        encoding=encoding,
+        digest=payload_digest(value_entry.value),
+        mapping_state=state,
+        mapping_revision=mapping_entry.revision,
+        deleted=DELETED_FIELD in payload,
+    )
+
+
+def _validate_identity(payload: dict[str, Any], meeting_id: str, uid: str) -> None:
+    if str(payload.get("meeting_id", "")) != meeting_id:
+        raise ReconciliationError(f"payload meeting mismatch for {uid}")
+    registrant_id = payload.get("registrant_id")
+    if registrant_id not in (None, "", uid):
+        raise ReconciliationError(f"payload registrant mismatch for {uid}")
+
+
+def write_plan(plan: Plan, path: Path) -> None:
+    encoded = json.dumps(
+        asdict(plan), sort_keys=True, indent=2, separators=(",", ": ")
+    ).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(encoded)
+            stream.write(b"\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def read_plan(path: Path) -> Plan:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        environment = Environment(**data["environment"])
+        candidates = [
+            CandidateSnapshot(**candidate) for candidate in data["candidates"]
+        ]
+        plan = Plan(data["version"], data["meeting_id"], environment, candidates)
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise ReconciliationError("plan file is malformed or unreadable") from error
+    if plan.version != PLAN_VERSION:
+        raise ReconciliationError("plan version is unsupported")
+    return plan
+
+
+async def build_plan(
+    meeting_id: str,
+    environment: Environment,
+    discovery: Discovery,
+    authority: Authority,
+    values: KVStore,
+    mappings: KVStore,
+) -> Plan:
+    uids = discovery.discover(meeting_id)
+    classifications = authority.classify(uids)
+    candidates = []
+    for uid in uids:
+        snapshot = await snapshot_candidate(values, mappings, meeting_id, uid)
+        classification = classifications[uid]
+        _validate_candidate_state(snapshot, classification)
+        candidates.append(replace(snapshot, classification=classification))
+    return Plan(PLAN_VERSION, meeting_id, environment, candidates)
+
+
+def _validate_candidate_state(snapshot: CandidateSnapshot, classification: str) -> None:
+    valid_active = (
+        classification == "active"
+        and not snapshot.deleted
+        and snapshot.mapping_state == "live"
+    )
+    valid_stale_pending = (
+        classification == "stale"
+        and not snapshot.deleted
+        and snapshot.mapping_state == "live"
+    )
+    valid_stale_marked = (
+        classification == "stale"
+        and snapshot.deleted
+        and snapshot.mapping_state in {"live", "tombstoned"}
+    )
+    if not (valid_active or valid_stale_pending or valid_stale_marked):
+        raise ReconciliationError(
+            f"indexed candidate has ambiguous state: {snapshot.uid}"
+        )
+
+
+async def apply_plan(
+    plan: Plan,
+    confirmations: Confirmations,
+    discovery: Discovery,
+    authority: Authority,
+    values: KVStore,
+    mappings: KVStore,
+    now: Callable[[], datetime],
+) -> list[str]:
+    _validate_apply_confirmations(plan, confirmations)
+    snapshots = await _revalidate_plan(plan, discovery, authority, values, mappings)
+    completed = []
+    for snapshot in snapshots:
+        if snapshot.classification != "stale":
+            continue
+        try:
+            await _validate_before_write(snapshot, authority, mappings)
+            if not snapshot.deleted:
+                await _soft_delete(plan.meeting_id, snapshot, values, now())
+        except Exception as error:
+            if isinstance(error, PlanDriftError) and not completed:
+                raise
+            pending = [
+                item.uid
+                for item in snapshots
+                if item.classification == "stale" and item.uid not in completed
+            ]
+            raise ReconciliationError(
+                f"partial apply; completed={completed}; pending={pending}"
+            ) from error
+        completed.append(snapshot.uid)
+    return completed
+
+
+async def _validate_before_write(
+    snapshot: CandidateSnapshot, authority: Authority, mappings: KVStore
+) -> None:
+    if authority.classify([snapshot.uid]).get(snapshot.uid) != "stale":
+        raise PlanDriftError(
+            f"DynamoDB contains candidate before write: {snapshot.uid}"
+        )
+    mapping = await get_entry(mappings, mapping_key(snapshot.uid))
+    if (
+        mapping.revision != snapshot.mapping_revision
+        or mapping_state(mapping.value) != snapshot.mapping_state
+    ):
+        raise PlanDriftError(f"mapping changed before write: {snapshot.uid}")
+
+
+def _require_confirmation_match(
+    expected: tuple[Any, ...], actual: tuple[Any, ...], message: str
+) -> None:
+    if actual != expected:
+        raise PlanDriftError(message)
+
+
+def _validate_apply_confirmations(plan: Plan, confirmations: Confirmations) -> None:
+    stale_count = sum(
+        1 for candidate in plan.candidates if candidate.classification == "stale"
+    )
+    expected = (
+        plan.meeting_id,
+        plan.environment.account,
+        plan.environment.table_arn,
+        stale_count,
+    )
+    actual = (
+        confirmations.meeting_id,
+        confirmations.aws_account,
+        confirmations.table_arn,
+        confirmations.stale_count,
+    )
+    _require_confirmation_match(
+        expected, actual, "apply confirmations do not match the plan"
+    )
+
+
+async def _revalidate_plan(
+    plan: Plan,
+    discovery: Discovery,
+    authority: Authority,
+    values: KVStore,
+    mappings: KVStore,
+) -> list[CandidateSnapshot]:
+    uids = discovery.discover(plan.meeting_id)
+    if uids != sorted(candidate.uid for candidate in plan.candidates):
+        raise PlanDriftError("indexed candidates changed after dry-run")
+    classifications = authority.classify(uids)
+    current = []
+    for uid in uids:
+        snapshot = await snapshot_candidate(values, mappings, plan.meeting_id, uid)
+        current.append(replace(snapshot, classification=classifications[uid]))
+    if current != plan.candidates:
+        raise PlanDriftError("authoritative or NATS state changed after dry-run")
+    return current
+
+
+async def _soft_delete(
+    meeting_id: str,
+    snapshot: CandidateSnapshot,
+    values: KVStore,
+    marked_at: datetime,
+) -> None:
+    entry = await get_entry(values, registrant_key(snapshot.uid))
+    if entry.revision != snapshot.revision:
+        raise RevisionConflictError(snapshot.uid)
+    payload, encoding = decode_payload(entry.value)
+    _validate_identity(payload, meeting_id, snapshot.uid)
+    payload[DELETED_FIELD] = _rfc3339(marked_at)
+    try:
+        await values.update(
+            registrant_key(snapshot.uid),
+            encode_payload(payload, encoding),
+            last=snapshot.revision,
+        )
+    except Exception as error:
+        if isinstance(error, RevisionConflictError):
+            raise
+        raise ReconciliationError(
+            f"NATS KV update failed for {snapshot.uid}"
+        ) from error
+
+
+async def restore_candidate(
+    meeting_id: str,
+    uid: str,
+    environment: Environment,
+    confirmations: RestoreConfirmations,
+    authority: Authority,
+    values: KVStore,
+) -> None:
+    _require_confirmation_match(
+        (meeting_id, environment.account, environment.table_arn),
+        (confirmations.meeting_id, confirmations.aws_account, confirmations.table_arn),
+        "restore confirmations do not match",
+    )
+    if authority.classify([uid]).get(uid) != "active":
+        raise ReconciliationError("DynamoDB does not contain the restore UID")
+    entry = await get_entry(values, registrant_key(uid))
+    payload, encoding = decode_payload(entry.value)
+    _validate_identity(payload, meeting_id, uid)
+    if DELETED_FIELD not in payload:
+        raise ReconciliationError("restore UID is not soft-deleted")
+    del payload[DELETED_FIELD]
+    try:
+        await values.update(
+            registrant_key(uid),
+            encode_payload(payload, encoding),
+            last=entry.revision,
+        )
+    except Exception as error:
+        if isinstance(error, RevisionConflictError):
+            raise
+        raise ReconciliationError(f"NATS KV restore failed for {uid}") from error
+
+
+async def verify_apply(
+    meeting_id: str,
+    uids: list[str],
+    discovery: Discovery,
+    mappings: KVStore,
+    timeout: float,
+    interval: float,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        incomplete = []
+        for uid in uids:
+            if discovery.contains(meeting_id, uid):
+                incomplete.append(uid)
+                continue
+            entry = await get_entry(mappings, mapping_key(uid))
+            if mapping_state(entry.value) != "tombstoned":
+                incomplete.append(uid)
+        if not incomplete:
+            return
+        if time.monotonic() >= deadline:
+            raise VerificationError(f"apply verification incomplete: {incomplete}")
+        await sleep(interval)
+
+
+async def verify_restore(
+    meeting_id: str,
+    uid: str,
+    discovery: Discovery,
+    mappings: KVStore,
+    timeout: float,
+    interval: float,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while True:
+        entry = await get_entry(mappings, mapping_key(uid))
+        if discovery.contains(meeting_id, uid) and mapping_state(entry.value) == "live":
+            return
+        if time.monotonic() >= deadline:
+            raise VerificationError(f"restore verification incomplete: {uid}")
+        await sleep(interval)
+
+
+def build_aws_clients(config: Config) -> tuple[Any, Any]:
+    if boto3 is None:
+        raise ReconciliationError("boto3 is not installed")
+    session = boto3.Session(
+        profile_name=config.aws_profile, region_name=config.aws_region
+    )
+    if config.assume_role_arn:
+        session = _assume_role(session, config)
+    return session.client("sts"), session.client("dynamodb")
+
+
+def _assume_role(session: Any, config: Config) -> Any:
+    try:
+        response = session.client("sts").assume_role(
+            RoleArn=config.assume_role_arn,
+            RoleSessionName="meeting-registrant-reconciliation",
+        )
+        credentials = response["Credentials"]
+        return boto3.Session(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            region_name=config.aws_region,
+        )
+    except Exception as error:
+        raise ReconciliationError("AWS role assumption failed") from error
+
+
+async def run(config: Config) -> dict[str, Any]:
+    if requests is None:
+        raise ReconciliationError("requests is not installed")
+    sts, dynamodb = build_aws_clients(config)
+    authority = DynamoAuthority(sts, dynamodb, config.dynamodb_table, config.aws_region)
+    environment = authority.discover_environment()
+    discovery = OpenSearchDiscovery(
+        requests.Session(),
+        config.opensearch_url,
+        config.opensearch_index,
+        config.request_timeout,
+    )
+    connection, values, mappings = await open_nats(
+        config.nats_url, config.request_timeout
+    )
+    try:
+        if config.mode == "dry-run":
+            return await _run_dry(
+                config, environment, discovery, authority, values, mappings
+            )
+        if config.mode == "apply":
+            return await _run_apply(
+                config, environment, discovery, authority, values, mappings
+            )
+        return await _run_restore(
+            config, environment, discovery, authority, values, mappings
+        )
+    finally:
+        await connection.close()
+
+
+async def _run_dry(
+    config: Config,
+    environment: Environment,
+    discovery: Discovery,
+    authority: Authority,
+    values: KVStore,
+    mappings: KVStore,
+) -> dict[str, Any]:
+    plan = await build_plan(
+        config.meeting_id, environment, discovery, authority, values, mappings
+    )
+    write_plan(plan, config.plan_path)
+    return _summary("dry-run", plan.candidates)
+
+
+async def _run_apply(
+    config: Config,
+    environment: Environment,
+    discovery: Discovery,
+    authority: Authority,
+    values: KVStore,
+    mappings: KVStore,
+) -> dict[str, Any]:
+    plan = read_plan(config.plan_path)
+    if config.meeting_id != plan.meeting_id:
+        raise PlanDriftError("target meeting differs from the reviewed plan")
+    if environment != plan.environment:
+        raise PlanDriftError("AWS environment differs from the plan")
+    confirmations = Confirmations(
+        config.confirm_meeting_id or "",
+        config.confirm_aws_account or "",
+        config.confirm_table_arn or "",
+        config.confirm_stale_count if config.confirm_stale_count is not None else -1,
+    )
+    completed = await apply_plan(
+        plan,
+        confirmations,
+        discovery,
+        authority,
+        values,
+        mappings,
+        now=lambda: datetime.now(timezone.utc),
+    )
+    await verify_apply(
+        plan.meeting_id,
+        completed,
+        discovery,
+        mappings,
+        config.verify_timeout,
+        config.verify_interval,
+    )
+    return {"mode": "apply", "meeting_id": plan.meeting_id, "completed": completed}
+
+
+async def _run_restore(
+    config: Config,
+    environment: Environment,
+    discovery: Discovery,
+    authority: Authority,
+    values: KVStore,
+    mappings: KVStore,
+) -> dict[str, Any]:
+    uid = config.restore_uid or ""
+    confirmations = RestoreConfirmations(
+        config.confirm_meeting_id or "",
+        config.confirm_aws_account or "",
+        config.confirm_table_arn or "",
+    )
+    await restore_candidate(
+        config.meeting_id, uid, environment, confirmations, authority, values
+    )
+    await verify_restore(
+        config.meeting_id,
+        uid,
+        discovery,
+        mappings,
+        config.verify_timeout,
+        config.verify_interval,
+    )
+    return {"mode": "restore", "meeting_id": config.meeting_id, "completed": [uid]}
+
+
+def _summary(mode: str, candidates: list[CandidateSnapshot]) -> dict[str, Any]:
+    active = [
+        candidate.uid
+        for candidate in candidates
+        if candidate.classification == "active"
+    ]
+    stale = [
+        candidate.uid for candidate in candidates if candidate.classification == "stale"
+    ]
+    return {
+        "mode": mode,
+        "candidate_count": len(candidates),
+        "active_count": len(active),
+        "stale_count": len(stale),
+        "active_uids": active,
+        "stale_uids": stale,
+    }
+
+
+def _required_string(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value:
+        raise ReconciliationError(f"response lacks {name}")
+    return value
+
+
+def _rfc3339(value: datetime) -> str:
+    return (
+        value.astimezone(timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        result = asyncio.run(run(parse_args(argv)))
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except ReconciliationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 """Reconcile indexed meeting registrants against authoritative DynamoDB rows."""
 
 import argparse

--- a/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
@@ -159,7 +159,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--opensearch-index", default="resources")
     parser.add_argument("--nats-url", required=True)
     parser.add_argument("--dynamodb-table", required=True)
-    parser.add_argument("--aws-region", default="us-east-1")
+    parser.add_argument("--aws-region", default="us-west-2")
     parser.add_argument("--aws-profile")
     parser.add_argument("--assume-role-arn")
     parser.add_argument("--plan", default="reconciliation-plan.json")
@@ -977,12 +977,17 @@ def _complete_future(
 def build_aws_clients(config: Config) -> tuple[Any, Any]:
     if boto3 is None:
         raise ReconciliationError("boto3 is not installed")
-    session = boto3.Session(
-        profile_name=config.aws_profile, region_name=config.aws_region
-    )
-    if config.assume_role_arn:
-        session = _assume_role(session, config)
-    return session.client("sts"), session.client("dynamodb")
+    try:
+        session = boto3.Session(
+            profile_name=config.aws_profile, region_name=config.aws_region
+        )
+        if config.assume_role_arn:
+            session = _assume_role(session, config)
+        return session.client("sts"), session.client("dynamodb")
+    except ReconciliationError:
+        raise
+    except Exception as error:
+        raise ReconciliationError("AWS client initialization failed") from error
 
 
 def _assume_role(session: Any, config: Config) -> Any:

--- a/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/reconcile_meeting_registrants.py
@@ -7,13 +7,16 @@
 import argparse
 import asyncio
 import json
+import math
 import os
 import sys
+import threading
 import time
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, Protocol
+from urllib.parse import urlsplit, urlunsplit
 
 try:
     import boto3
@@ -42,13 +45,15 @@ from common import (
     registrant_key,
 )
 
-PLAN_VERSION = 1
+PLAN_VERSION = 2
 
 
 class Discovery(Protocol):
     def discover(self, meeting_id: str) -> list[str]: ...
 
-    def contains(self, meeting_id: str, uid: str) -> bool: ...
+    def contains(
+        self, meeting_id: str, uid: str, timeout: float | None = None
+    ) -> bool: ...
 
 
 class Authority(Protocol):
@@ -112,10 +117,18 @@ class CandidateSnapshot:
 
 
 @dataclass(frozen=True)
+class TargetIdentity:
+    opensearch_url: str
+    opensearch_index: str
+    nats_url: str
+
+
+@dataclass(frozen=True)
 class Plan:
     version: int
     meeting_id: str
     environment: Environment
+    targets: TargetIdentity
     candidates: list[CandidateSnapshot]
 
 
@@ -187,9 +200,49 @@ def parse_args(argv: list[str] | None = None) -> Config:
     )
 
 
+def target_identity(config: Config) -> TargetIdentity:
+    if not config.opensearch_index:
+        raise ReconciliationError("OpenSearch index must not be empty")
+    return TargetIdentity(
+        opensearch_url=_sanitize_endpoint(config.opensearch_url),
+        opensearch_index=config.opensearch_index,
+        nats_url=_sanitize_endpoint(config.nats_url),
+    )
+
+
+def _sanitize_endpoint(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as error:
+        raise ReconciliationError("target endpoint is malformed") from error
+    if not parsed.scheme or not hostname:
+        raise ReconciliationError("target endpoint must include scheme and host")
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ReconciliationError(
+            "target endpoint must not include credentials, query, or fragment"
+        )
+    host = f"[{hostname.lower()}]" if ":" in hostname else hostname.lower()
+    netloc = f"{host}:{port}" if port is not None else host
+    return urlunsplit((parsed.scheme.lower(), netloc, parsed.path.rstrip("/"), "", ""))
+
+
 def _validate_args(
     parser: argparse.ArgumentParser, args: argparse.Namespace, mode: str
 ) -> None:
+    timing_values = (
+        args.request_timeout,
+        args.verify_timeout,
+        args.verify_interval,
+    )
+    if not all(math.isfinite(value) for value in timing_values):
+        parser.error("timing values must be finite")
     if args.request_timeout <= 0 or args.verify_timeout < 0:
         parser.error("timeouts must be positive")
     if args.verify_interval < 0:
@@ -234,7 +287,7 @@ class OpenSearchDiscovery:
             if scroll_id is not None:
                 self._clear_scroll(scroll_id)
 
-    def contains(self, meeting_id: str, uid: str) -> bool:
+    def contains(self, meeting_id: str, uid: str, timeout: float | None = None) -> bool:
         body = {
             "size": 1,
             "_source": ["object_id"],
@@ -247,7 +300,11 @@ class OpenSearchDiscovery:
                 }
             },
         }
-        payload = self._post(f"{self.base_url}/{self.index}/_search", json=body)
+        payload = self._post(
+            f"{self.base_url}/{self.index}/_search",
+            request_timeout=timeout,
+            json=body,
+        )
         return bool(self._hits(payload))
 
     def _first_page(self, meeting_id: str) -> dict[str, Any]:
@@ -275,9 +332,16 @@ class OpenSearchDiscovery:
             json={"scroll": "1m", "scroll_id": scroll_id},
         )
 
-    def _post(self, url: str, **kwargs: Any) -> dict[str, Any]:
+    def _post(
+        self, url: str, request_timeout: float | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
         try:
-            response = self.session.post(url, timeout=self.timeout, **kwargs)
+            timeout = (
+                self.timeout
+                if request_timeout is None
+                else min(self.timeout, request_timeout)
+            )
+            response = self.session.post(url, timeout=timeout, **kwargs)
             response.raise_for_status()
             payload = response.json()
         except Exception as error:
@@ -446,6 +510,8 @@ class DynamoAuthority:
         pending = unprocessed[self.table_name]
         if not isinstance(pending, dict) or not isinstance(pending.get("Keys"), list):
             raise ReconciliationError("DynamoDB returned malformed unprocessed keys")
+        if pending.get("ConsistentRead") is not True:
+            raise ReconciliationError("DynamoDB retry is not consistently read")
         requested = {
             json.dumps(key, sort_keys=True) for key in request[self.table_name]["Keys"]
         }
@@ -486,7 +552,7 @@ async def snapshot_candidate(
     mapping_entry = await get_entry(mappings, mapping_key(uid))
     payload, encoding = decode_payload(value_entry.value)
     _validate_identity(payload, meeting_id, uid)
-    state = mapping_state(mapping_entry.value)
+    state = mapping_state(mapping_entry.value, uid, meeting_id)
     return CandidateSnapshot(
         uid=uid,
         classification="",
@@ -495,7 +561,7 @@ async def snapshot_candidate(
         digest=payload_digest(value_entry.value),
         mapping_state=state,
         mapping_revision=mapping_entry.revision,
-        deleted=DELETED_FIELD in payload,
+        deleted=payload.get(DELETED_FIELD) not in (None, ""),
     )
 
 
@@ -528,10 +594,13 @@ def read_plan(path: Path) -> Plan:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
         environment = Environment(**data["environment"])
+        targets = TargetIdentity(**data["targets"])
         candidates = [
             CandidateSnapshot(**candidate) for candidate in data["candidates"]
         ]
-        plan = Plan(data["version"], data["meeting_id"], environment, candidates)
+        plan = Plan(
+            data["version"], data["meeting_id"], environment, targets, candidates
+        )
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         raise ReconciliationError("plan file is malformed or unreadable") from error
     if plan.version != PLAN_VERSION:
@@ -542,6 +611,7 @@ def read_plan(path: Path) -> Plan:
 async def build_plan(
     meeting_id: str,
     environment: Environment,
+    targets: TargetIdentity,
     discovery: Discovery,
     authority: Authority,
     values: KVStore,
@@ -555,7 +625,7 @@ async def build_plan(
         classification = classifications[uid]
         _validate_candidate_state(snapshot, classification)
         candidates.append(replace(snapshot, classification=classification))
-    return Plan(PLAN_VERSION, meeting_id, environment, candidates)
+    return Plan(PLAN_VERSION, meeting_id, environment, targets, candidates)
 
 
 def _validate_candidate_state(snapshot: CandidateSnapshot, classification: str) -> None:
@@ -710,7 +780,8 @@ async def restore_candidate(
     confirmations: RestoreConfirmations,
     authority: Authority,
     values: KVStore,
-) -> None:
+    mappings: KVStore,
+) -> int:
     _require_confirmation_match(
         (meeting_id, environment.account, environment.table_arn),
         (confirmations.meeting_id, confirmations.aws_account, confirmations.table_arn),
@@ -718,10 +789,15 @@ async def restore_candidate(
     )
     if authority.classify([uid]).get(uid) != "active":
         raise ReconciliationError("DynamoDB does not contain the restore UID")
+    mapping_entry = await get_entry(mappings, mapping_key(uid))
+    if mapping_state(mapping_entry.value) != "tombstoned":
+        raise ReconciliationError("restore UID mapping is not tombstoned")
     entry = await get_entry(values, registrant_key(uid))
     payload, encoding = decode_payload(entry.value)
     _validate_identity(payload, meeting_id, uid)
-    if DELETED_FIELD not in payload:
+    if payload.get("registrant_id") != uid:
+        raise ReconciliationError(f"restore payload registrant mismatch for {uid}")
+    if payload.get(DELETED_FIELD) in (None, ""):
         raise ReconciliationError("restore UID is not soft-deleted")
     del payload[DELETED_FIELD]
     try:
@@ -734,6 +810,7 @@ async def restore_candidate(
         if isinstance(error, RevisionConflictError):
             raise
         raise ReconciliationError(f"NATS KV restore failed for {uid}") from error
+    return mapping_entry.revision
 
 
 async def verify_apply(
@@ -749,17 +826,21 @@ async def verify_apply(
     while True:
         incomplete = []
         for uid in uids:
-            if discovery.contains(meeting_id, uid):
+            message = f"apply verification incomplete: {incomplete or uids}"
+            if await _contains_before_deadline(
+                discovery, meeting_id, uid, deadline, message
+            ):
                 incomplete.append(uid)
                 continue
-            entry = await get_entry(mappings, mapping_key(uid))
+            entry = await _get_before_deadline(
+                mappings, mapping_key(uid), deadline, message
+            )
             if mapping_state(entry.value) != "tombstoned":
                 incomplete.append(uid)
         if not incomplete:
             return
-        if time.monotonic() >= deadline:
-            raise VerificationError(f"apply verification incomplete: {incomplete}")
-        await sleep(interval)
+        message = f"apply verification incomplete: {incomplete}"
+        await sleep(min(interval, _remaining_time(deadline, message)))
 
 
 async def verify_restore(
@@ -767,18 +848,97 @@ async def verify_restore(
     uid: str,
     discovery: Discovery,
     mappings: KVStore,
+    after_mapping_revision: int,
     timeout: float,
     interval: float,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
 ) -> None:
     deadline = time.monotonic() + timeout
     while True:
-        entry = await get_entry(mappings, mapping_key(uid))
-        if discovery.contains(meeting_id, uid) and mapping_state(entry.value) == "live":
+        message = f"restore verification incomplete: {uid}"
+        entry = await _get_before_deadline(
+            mappings, mapping_key(uid), deadline, message
+        )
+        if (
+            await _contains_before_deadline(
+                discovery, meeting_id, uid, deadline, message
+            )
+            and mapping_state(entry.value, uid, meeting_id) == "live"
+            and entry.revision > after_mapping_revision
+        ):
             return
-        if time.monotonic() >= deadline:
-            raise VerificationError(f"restore verification incomplete: {uid}")
-        await sleep(interval)
+        await sleep(min(interval, _remaining_time(deadline, message)))
+
+
+def _remaining_time(deadline: float, message: str) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise VerificationError(message)
+    return remaining
+
+
+async def _get_before_deadline(
+    mappings: KVStore, key: str, deadline: float, message: str
+) -> Any:
+    remaining = _remaining_time(deadline, message)
+    try:
+        return await asyncio.wait_for(
+            get_entry(mappings, key),
+            timeout=remaining,
+        )
+    except TimeoutError as error:
+        raise VerificationError(message) from error
+
+
+async def _contains_before_deadline(
+    discovery: Discovery,
+    meeting_id: str,
+    uid: str,
+    deadline: float,
+    message: str,
+) -> bool:
+    remaining = _remaining_time(deadline, message)
+    try:
+        return await asyncio.wait_for(
+            _run_in_daemon_thread(
+                discovery.contains,
+                meeting_id,
+                uid,
+                remaining,
+            ),
+            timeout=remaining,
+        )
+    except TimeoutError as error:
+        raise VerificationError(message) from error
+
+
+async def _run_in_daemon_thread(function: Callable[..., Any], *args: Any) -> Any:
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    def run() -> None:
+        try:
+            result, error = function(*args), None
+        except Exception as caught:
+            result, error = None, caught
+        try:
+            loop.call_soon_threadsafe(_complete_future, future, result, error)
+        except RuntimeError:
+            pass
+
+    threading.Thread(target=run, daemon=True).start()
+    return await future
+
+
+def _complete_future(
+    future: asyncio.Future[Any], result: Any, error: Exception | None
+) -> None:
+    if future.done():
+        return
+    if error is not None:
+        future.set_exception(error)
+    else:
+        future.set_result(result)
 
 
 def build_aws_clients(config: Config) -> tuple[Any, Any]:
@@ -812,6 +972,10 @@ def _assume_role(session: Any, config: Config) -> Any:
 async def run(config: Config) -> dict[str, Any]:
     if requests is None:
         raise ReconciliationError("requests is not installed")
+    if config.mode == "apply":
+        reviewed_plan = read_plan(config.plan_path)
+        if target_identity(config) != reviewed_plan.targets:
+            raise PlanDriftError("runtime targets differ from the reviewed plan")
     sts, dynamodb = build_aws_clients(config)
     authority = DynamoAuthority(sts, dynamodb, config.dynamodb_table, config.aws_region)
     environment = authority.discover_environment()
@@ -849,7 +1013,13 @@ async def _run_dry(
     mappings: KVStore,
 ) -> dict[str, Any]:
     plan = await build_plan(
-        config.meeting_id, environment, discovery, authority, values, mappings
+        config.meeting_id,
+        environment,
+        target_identity(config),
+        discovery,
+        authority,
+        values,
+        mappings,
     )
     write_plan(plan, config.plan_path)
     return _summary("dry-run", plan.candidates)
@@ -866,6 +1036,8 @@ async def _run_apply(
     plan = read_plan(config.plan_path)
     if config.meeting_id != plan.meeting_id:
         raise PlanDriftError("target meeting differs from the reviewed plan")
+    if target_identity(config) != plan.targets:
+        raise PlanDriftError("runtime targets differ from the reviewed plan")
     if environment != plan.environment:
         raise PlanDriftError("AWS environment differs from the plan")
     confirmations = Confirmations(
@@ -908,14 +1080,21 @@ async def _run_restore(
         config.confirm_aws_account or "",
         config.confirm_table_arn or "",
     )
-    await restore_candidate(
-        config.meeting_id, uid, environment, confirmations, authority, values
+    mapping_revision = await restore_candidate(
+        config.meeting_id,
+        uid,
+        environment,
+        confirmations,
+        authority,
+        values,
+        mappings,
     )
     await verify_restore(
         config.meeting_id,
         uid,
         discovery,
         mappings,
+        mapping_revision,
         config.verify_timeout,
         config.verify_interval,
     )

--- a/scripts/reconcile_meeting_registrants/requirements.txt
+++ b/scripts/reconcile_meeting_registrants/requirements.txt
@@ -1,0 +1,4 @@
+boto3
+msgpack
+nats-py
+requests

--- a/scripts/reconcile_meeting_registrants/requirements.txt
+++ b/scripts/reconcile_meeting_registrants/requirements.txt
@@ -1,7 +1,8 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 
-boto3
-msgpack
-nats-py
-requests
+boto3==1.43.49
+botocore[crt]==1.43.49
+msgpack==1.2.1
+nats-py==2.15.0
+requests==2.34.2

--- a/scripts/reconcile_meeting_registrants/requirements.txt
+++ b/scripts/reconcile_meeting_registrants/requirements.txt
@@ -1,3 +1,6 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 boto3
 msgpack
 nats-py

--- a/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
@@ -164,6 +164,21 @@ class ConfigTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             reconcile.parse_args(cli_args("--apply"))
 
+    def test_restore_requires_target_confirmations(self):
+        with self.assertRaises(SystemExit):
+            reconcile.parse_args(
+                cli_args(
+                    "--restore",
+                    "uid-1",
+                    "--confirm-meeting-id",
+                    "987",
+                    "--confirm-aws-account",
+                    "123",
+                    "--confirm-table-arn",
+                    "arn:table",
+                )
+            )
+
     def test_literal_credentials_are_not_cli_options(self):
         parser = reconcile.build_parser()
         option_strings = {
@@ -1276,6 +1291,12 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
                 "123",
                 "--confirm-table-arn",
                 "arn:table",
+                "--confirm-opensearch-url",
+                "http://search",
+                "--confirm-opensearch-index",
+                "resources",
+                "--confirm-nats-url",
+                "nats://localhost:4222",
                 meeting_id="meeting-1",
                 table="reg",
             )
@@ -1288,6 +1309,39 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
                 FakeAuthority(["uid-1"]),
                 values,
                 mappings,
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_restore_rejects_target_confirmation_mismatch_before_write(self):
+        config = reconcile.parse_args(
+            cli_args(
+                "--restore",
+                "uid-1",
+                "--confirm-meeting-id",
+                "meeting-1",
+                "--confirm-aws-account",
+                "123",
+                "--confirm-table-arn",
+                "arn:table",
+                "--confirm-opensearch-url",
+                "http://search",
+                "--confirm-opensearch-index",
+                "resources",
+                "--confirm-nats-url",
+                "nats://other.example:4222",
+                meeting_id="meeting-1",
+                table="reg",
+            )
+        )
+        values = FakeKV({})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile._run_restore(
+                config,
+                ENVIRONMENT,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority(["uid-1"]),
+                values,
+                FakeKV({}),
             )
         self.assertEqual([], values.updates)
 
@@ -1310,6 +1364,12 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
                 "123",
                 "--confirm-table-arn",
                 "arn:table",
+                "--confirm-opensearch-url",
+                "http://search",
+                "--confirm-opensearch-index",
+                "resources",
+                "--confirm-nats-url",
+                "nats://localhost:4222",
                 "--verify-timeout",
                 "0.01",
                 "--verify-interval",

--- a/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
@@ -2,8 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 import asyncio
+import json
 import os
 import tempfile
+import time
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -115,11 +117,13 @@ class FakeAuthority:
 class FakeDiscovery:
     def __init__(self, uids):
         self.uids = list(uids)
+        self.timeouts = []
 
     def discover(self, meeting_id):
         return list(self.uids)
 
-    def contains(self, meeting_id, uid):
+    def contains(self, meeting_id, uid, timeout=None):
+        self.timeouts.append(timeout)
         return uid in self.uids
 
 
@@ -138,6 +142,9 @@ def cli_args(*extra, meeting_id="987", table="registrants"):
 
 
 ENVIRONMENT = reconcile.Environment("123", "us-east-1", "arn:table", "reg", "id", "S")
+TARGETS = reconcile.TargetIdentity(
+    "http://search", "resources", "nats://localhost:4222"
+)
 
 
 class ConfigTests(unittest.TestCase):
@@ -165,6 +172,16 @@ class ConfigTests(unittest.TestCase):
         self.assertNotIn("--aws-access-key-id", option_strings)
         self.assertNotIn("--aws-secret-access-key", option_strings)
         self.assertNotIn("--aws-session-token", option_strings)
+
+    def test_non_finite_timing_values_are_rejected(self):
+        for option, value in (
+            ("--request-timeout", "nan"),
+            ("--verify-timeout", "inf"),
+            ("--verify-interval", "nan"),
+        ):
+            with self.subTest(option=option, value=value):
+                with self.assertRaises(SystemExit):
+                    reconcile.parse_args(cli_args(option, value))
 
 
 class OpenSearchTests(unittest.TestCase):
@@ -394,6 +411,22 @@ class DynamoDBTests(unittest.TestCase):
         with self.assertRaises(reconcile.ReconciliationError):
             authority.classify(["uid-1"])
 
+    def test_unprocessed_keys_without_consistent_read_fail_closed(self):
+        response = {
+            "Responses": {"reg": []},
+            "UnprocessedKeys": {"reg": {"Keys": [{"id": {"S": "uid-1"}}]}},
+        }
+        authority = reconcile.DynamoAuthority(
+            Mock(),
+            FakeDynamo([response, {"Responses": {"reg": []}, "UnprocessedKeys": {}}]),
+            "reg",
+            "us-east-1",
+            sleep=lambda _: None,
+        )
+        authority.environment = ENVIRONMENT
+        with self.assertRaises(reconcile.ReconciliationError):
+            authority.classify(["uid-1"])
+
     def test_classification_batches_one_hundred_keys_without_scan(self):
         uids = [f"uid-{number:03d}" for number in range(101)]
         dynamo = FakeDynamo(
@@ -525,6 +558,57 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("live", snapshot.mapping_state)
         self.assertEqual(64, len(snapshot.digest))
 
+    async def test_snapshot_ignores_empty_delete_markers(self):
+        for marker in (None, ""):
+            payload = {
+                "meeting_id": "meeting-1",
+                "registrant_id": "uid-1",
+                "_sdc_deleted_at": marker,
+            }
+            values = FakeKV(
+                {
+                    reconcile.registrant_key("uid-1"): Entry(
+                        reconcile.encode_payload(payload, "json"), 7
+                    )
+                }
+            )
+            mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+            snapshot = await reconcile.snapshot_candidate(
+                values, mappings, "meeting-1", "uid-1"
+            )
+            self.assertFalse(snapshot.deleted)
+
+    async def test_mapping_state_accepts_current_producer_formats(self):
+        values = (
+            b'{"uid":"uid-1","username":"","meeting_id":"meeting-1"}',
+            b"uid-1||meeting-1",
+        )
+        for value in values:
+            with self.subTest(value=value):
+                self.assertEqual("live", reconcile.mapping_state(value))
+
+    async def test_mismatched_mapping_identity_fails_closed(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(payload, "json"), 7
+                )
+            }
+        )
+        mapping = b'{"uid":"uid-other","username":"","meeting_id":"meeting-2"}'
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(mapping, 3)})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.build_plan(
+                "meeting-1",
+                ENVIRONMENT,
+                TARGETS,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority([]),
+                values,
+                mappings,
+            )
+
     async def test_mismatched_payload_fails_closed(self):
         values = FakeKV(
             {
@@ -544,9 +628,10 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
     async def test_plan_is_deterministic_redacted_and_private(self):
         environment = ENVIRONMENT
         plan = reconcile.Plan(
-            version=1,
+            version=reconcile.PLAN_VERSION,
             meeting_id="meeting-1",
             environment=environment,
+            targets=TARGETS,
             candidates=[
                 reconcile.CandidateSnapshot(
                     "uid-1", "stale", 7, "json", "abc", "live", 3, False
@@ -562,6 +647,101 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
             self.assertNotIn("token", raw)
             self.assertEqual(0o600, os.stat(path).st_mode & 0o777)
 
+    async def test_dry_run_plan_pins_sanitized_targets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "plan.json"
+            config = reconcile.parse_args(
+                cli_args(
+                    "--opensearch-url",
+                    "https://search.example/base/",
+                    "--opensearch-index",
+                    "resources-prod",
+                    "--nats-url",
+                    "nats://nats.example:4222",
+                    "--plan",
+                    str(plan_path),
+                )
+            )
+            payload = {"meeting_id": "987", "registrant_id": "uid-1"}
+            await reconcile._run_dry(
+                config,
+                ENVIRONMENT,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority(["uid-1"]),
+                FakeKV(
+                    {
+                        reconcile.registrant_key("uid-1"): Entry(
+                            reconcile.encode_payload(payload, "json"), 7
+                        )
+                    }
+                ),
+                FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)}),
+            )
+            raw = plan_path.read_text()
+        self.assertIn("https://search.example/base", raw)
+        self.assertIn("resources-prod", raw)
+        self.assertIn("nats://nats.example:4222", raw)
+
+    async def test_target_identity_rejects_credential_and_query_aliases(self):
+        for option, value in (
+            ("--opensearch-url", "https://user:secret@search.example"),
+            ("--nats-url", "nats://token@nats.example:4222"),
+            ("--opensearch-url", "https://search.example?cluster=other"),
+        ):
+            with self.subTest(option=option, value=value):
+                config = reconcile.parse_args(cli_args(option, value))
+                with self.assertRaises(reconcile.ReconciliationError):
+                    reconcile.target_identity(config)
+
+    async def test_apply_rejects_targets_different_from_reviewed_plan(self):
+        plan = reconcile.Plan(
+            reconcile.PLAN_VERSION,
+            "meeting-1",
+            ENVIRONMENT,
+            TARGETS,
+            [],
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "plan.json"
+            reconcile.write_plan(plan, path)
+            data = json.loads(path.read_text())
+            data["targets"] = {
+                "opensearch_url": "https://search.prod",
+                "opensearch_index": "resources",
+                "nats_url": "nats://nats.prod:4222",
+            }
+            path.write_text(json.dumps(data))
+            config = reconcile.parse_args(
+                cli_args(
+                    "--opensearch-url",
+                    "https://search.dev",
+                    "--nats-url",
+                    "nats://nats.dev:4222",
+                    "--plan",
+                    str(path),
+                    "--apply",
+                    "--confirm-meeting-id",
+                    "meeting-1",
+                    "--confirm-aws-account",
+                    "123",
+                    "--confirm-table-arn",
+                    "arn:table",
+                    "--confirm-stale-count",
+                    "0",
+                    meeting_id="meeting-1",
+                    table="reg",
+                )
+            )
+            with self.assertRaises(reconcile.PlanDriftError):
+                await reconcile._run_apply(
+                    config,
+                    ENVIRONMENT,
+                    FakeDiscovery([]),
+                    FakeAuthority([]),
+                    FakeKV({}),
+                    FakeKV({}),
+                )
+
     async def test_unknown_mapping_prevents_applicable_plan(self):
         payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
         values = FakeKV(
@@ -576,6 +756,7 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
             await reconcile.build_plan(
                 "meeting-1",
                 ENVIRONMENT,
+                TARGETS,
                 FakeDiscovery(["uid-1"]),
                 FakeAuthority([]),
                 values,
@@ -600,6 +781,7 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
                     await reconcile.build_plan(
                         "meeting-1",
                         ENVIRONMENT,
+                        TARGETS,
                         FakeDiscovery(["uid-1"]),
                         FakeAuthority([]),
                         values,
@@ -623,6 +805,7 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
         plan = await reconcile.build_plan(
             "meeting-1",
             ENVIRONMENT,
+            TARGETS,
             FakeDiscovery(["uid-1"]),
             FakeAuthority([]),
             values,
@@ -649,6 +832,7 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
             await reconcile.build_plan(
                 "meeting-1",
                 ENVIRONMENT,
+                TARGETS,
                 FakeDiscovery(["uid-1"]),
                 FakeAuthority(["uid-1"]),
                 values,
@@ -659,9 +843,10 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
 class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
     def make_plan(self, digest, revision=7, deleted=False):
         return reconcile.Plan(
-            version=1,
+            version=reconcile.PLAN_VERSION,
             meeting_id="meeting-1",
             environment=ENVIRONMENT,
+            targets=TARGETS,
             candidates=[
                 reconcile.CandidateSnapshot(
                     "uid-1",
@@ -774,9 +959,10 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
             }
         )
         plan = reconcile.Plan(
-            1,
+            reconcile.PLAN_VERSION,
             "meeting-1",
             ENVIRONMENT,
+            TARGETS,
             [
                 reconcile.CandidateSnapshot(
                     "uid-1",
@@ -900,6 +1086,7 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
         }
         raw = reconcile.encode_payload(payload, "msgpack")
         values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)})
         await reconcile.restore_candidate(
             "meeting-1",
             "uid-1",
@@ -907,6 +1094,7 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
             reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
             FakeAuthority(["uid-1"]),
             values,
+            mappings,
         )
         decoded, encoding = reconcile.decode_payload(values.updates[0][1])
         self.assertEqual("msgpack", encoding)
@@ -923,6 +1111,7 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
                 reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
                 FakeAuthority([]),
                 values,
+                FakeKV({}),
             )
         self.assertEqual([], values.updates)
 
@@ -931,6 +1120,7 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
             {"meeting_id": "meeting-1", "registrant_id": "uid-1"}, "json"
         )
         values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)})
         with self.assertRaises(reconcile.ReconciliationError):
             await reconcile.restore_candidate(
                 "meeting-1",
@@ -939,8 +1129,131 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
                 reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
                 FakeAuthority(["uid-1"]),
                 values,
+                mappings,
             )
         self.assertEqual([], values.updates)
+
+    async def test_restore_rejects_empty_delete_markers(self):
+        for marker in (None, ""):
+            payload = {
+                "meeting_id": "meeting-1",
+                "registrant_id": "uid-1",
+                "_sdc_deleted_at": marker,
+            }
+            raw = reconcile.encode_payload(payload, "json")
+            values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+            mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)})
+            with self.subTest(marker=marker):
+                with self.assertRaises(reconcile.ReconciliationError):
+                    await reconcile.restore_candidate(
+                        "meeting-1",
+                        "uid-1",
+                        ENVIRONMENT,
+                        reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+                        FakeAuthority(["uid-1"]),
+                        values,
+                        mappings,
+                    )
+            self.assertEqual([], values.updates)
+
+    async def test_restore_rejects_missing_payload_registrant_id(self):
+        raw = reconcile.encode_payload(
+            {
+                "meeting_id": "meeting-1",
+                "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+            },
+            "json",
+        )
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.restore_candidate(
+                "meeting-1",
+                "uid-1",
+                ENVIRONMENT,
+                reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+                FakeAuthority(["uid-1"]),
+                values,
+                mappings,
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_restore_requires_tombstoned_mapping_before_write(self):
+        raw = reconcile.encode_payload(
+            {
+                "meeting_id": "meeting-1",
+                "registrant_id": "uid-1",
+                "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+            },
+            "json",
+        )
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        config = reconcile.parse_args(
+            cli_args(
+                "--restore",
+                "uid-1",
+                "--confirm-meeting-id",
+                "meeting-1",
+                "--confirm-aws-account",
+                "123",
+                "--confirm-table-arn",
+                "arn:table",
+                meeting_id="meeting-1",
+                table="reg",
+            )
+        )
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile._run_restore(
+                config,
+                ENVIRONMENT,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority(["uid-1"]),
+                values,
+                mappings,
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_restore_verification_requires_newer_live_mapping_revision(self):
+        raw = reconcile.encode_payload(
+            {
+                "meeting_id": "meeting-1",
+                "registrant_id": "uid-1",
+                "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+            },
+            "json",
+        )
+        config = reconcile.parse_args(
+            cli_args(
+                "--restore",
+                "uid-1",
+                "--confirm-meeting-id",
+                "meeting-1",
+                "--confirm-aws-account",
+                "123",
+                "--confirm-table-arn",
+                "arn:table",
+                "--verify-timeout",
+                "0.01",
+                "--verify-interval",
+                "0",
+                meeting_id="meeting-1",
+                table="reg",
+            )
+        )
+        mappings = SequencedGetKV(
+            reconcile.mapping_key("uid-1"),
+            [Entry(b"!del", 3), Entry(b"1", 3)],
+        )
+        with self.assertRaises(reconcile.VerificationError):
+            await reconcile._run_restore(
+                config,
+                ENVIRONMENT,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority(["uid-1"]),
+                FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)}),
+                mappings,
+            )
 
 
 class VerificationTests(unittest.IsolatedAsyncioTestCase):
@@ -980,6 +1293,7 @@ class VerificationTests(unittest.IsolatedAsyncioTestCase):
             "uid-1",
             discovery,
             mappings,
+            after_mapping_revision=3,
             timeout=0.05,
             interval=0,
         )
@@ -996,6 +1310,92 @@ class VerificationTests(unittest.IsolatedAsyncioTestCase):
                 interval=0,
             )
         self.assertEqual([], mappings.updates)
+
+    async def test_verification_passes_remaining_budget_to_discovery(self):
+        discovery = FakeDiscovery(["uid-1"])
+        delays = []
+
+        async def stop_after_sleep(delay):
+            delays.append(delay)
+            raise RuntimeError("stop")
+
+        with self.assertRaisesRegex(RuntimeError, "stop"):
+            await reconcile.verify_apply(
+                "meeting-1",
+                ["uid-1"],
+                discovery,
+                FakeKV({}),
+                timeout=0.05,
+                interval=10,
+                sleep=stop_after_sleep,
+            )
+        self.assertGreater(delays[0], 0)
+        self.assertLessEqual(delays[0], 0.05)
+        self.assertGreater(discovery.timeouts[0], 0)
+        self.assertLessEqual(discovery.timeouts[0], 0.05)
+
+    async def test_verification_bounds_blocking_mapping_read(self):
+        class BlockingKV:
+            async def get(self, key):
+                await asyncio.Event().wait()
+
+        discovery = FakeDiscovery([])
+        try:
+            await asyncio.wait_for(
+                reconcile.verify_apply(
+                    "meeting-1",
+                    ["uid-1"],
+                    discovery,
+                    BlockingKV(),
+                    timeout=0.01,
+                    interval=0,
+                ),
+                timeout=0.1,
+            )
+        except Exception as error:
+            self.assertIsInstance(error, reconcile.VerificationError)
+        else:
+            self.fail("blocking mapping read did not time out")
+
+    async def test_verification_bounds_blocking_discovery_call(self):
+        class BlockingDiscovery(FakeDiscovery):
+            def contains(self, meeting_id, uid, timeout=None):
+                time.sleep(0.2)
+                return True
+
+        started = time.monotonic()
+        with self.assertRaises(reconcile.VerificationError):
+            await reconcile.verify_apply(
+                "meeting-1",
+                ["uid-1"],
+                BlockingDiscovery(["uid-1"]),
+                FakeKV({}),
+                timeout=0.01,
+                interval=0,
+            )
+        self.assertLess(time.monotonic() - started, 0.1)
+
+
+class VerificationWallClockTests(unittest.TestCase):
+    def test_cli_runner_does_not_wait_for_timed_out_discovery_worker(self):
+        class BlockingDiscovery(FakeDiscovery):
+            def contains(self, meeting_id, uid, timeout=None):
+                time.sleep(0.2)
+                return True
+
+        started = time.monotonic()
+        with self.assertRaises(reconcile.VerificationError):
+            asyncio.run(
+                reconcile.verify_apply(
+                    "meeting-1",
+                    ["uid-1"],
+                    BlockingDiscovery(["uid-1"]),
+                    FakeKV({}),
+                    timeout=0.01,
+                    interval=0,
+                )
+            )
+        self.assertLess(time.monotonic() - started, 0.1)
 
 
 class OutputTests(unittest.TestCase):

--- a/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
@@ -236,6 +236,14 @@ class OpenSearchTests(unittest.TestCase):
             client.discover("meeting-1")
         self.assertEqual(1, len(session.deletes))
 
+    def test_malformed_hits_container_fails_closed(self):
+        session = FakeHTTPSession(
+            [FakeResponse({"_scroll_id": "scroll-1", "hits": []})]
+        )
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        with self.assertRaises(reconcile.ReconciliationError):
+            client.discover("meeting-1")
+
     def test_contains_issues_one_scoped_query_without_scrolling(self):
         session = FakeHTTPSession(
             [FakeResponse({"hits": {"hits": [{"_source": {"object_id": "uid-1"}}]}})]
@@ -258,6 +266,12 @@ class OpenSearchTests(unittest.TestCase):
         session = FakeHTTPSession([FakeResponse({"hits": {"hits": []}})])
         client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
         self.assertFalse(client.contains("meeting-1", "uid-1"))
+
+    def test_contains_rejects_malformed_hit(self):
+        session = FakeHTTPSession([FakeResponse({"hits": {"hits": [{}]}})])
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        with self.assertRaises(reconcile.ReconciliationError):
+            client.contains("meeting-1", "uid-1")
 
     def test_empty_result_returns_no_candidates(self):
         session = FakeHTTPSession(
@@ -687,11 +701,24 @@ class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
             ("--opensearch-url", "https://user:secret@search.example"),
             ("--nats-url", "nats://token@nats.example:4222"),
             ("--opensearch-url", "https://search.example?cluster=other"),
+            ("--opensearch-url", "ftp://search.example"),
+            ("--nats-url", "http://nats.example:4222"),
         ):
             with self.subTest(option=option, value=value):
                 config = reconcile.parse_args(cli_args(option, value))
                 with self.assertRaises(reconcile.ReconciliationError):
                     reconcile.target_identity(config)
+
+    async def test_run_rejects_invalid_target_before_aws_clients(self):
+        config = reconcile.parse_args(
+            cli_args("--nats-url", "nats://token@nats.example:4222")
+        )
+        with patch.object(
+            reconcile, "build_aws_clients", side_effect=RuntimeError("network")
+        ) as aws_clients:
+            with self.assertRaises(reconcile.ReconciliationError):
+                await reconcile.run(config)
+        aws_clients.assert_not_called()
 
     async def test_apply_rejects_targets_different_from_reviewed_plan(self):
         plan = reconcile.Plan(
@@ -1178,6 +1205,56 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual([], values.updates)
 
+    async def test_restore_rechecks_dynamo_immediately_before_write(self):
+        payload = {
+            "meeting_id": "meeting-1",
+            "registrant_id": "uid-1",
+            "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+        }
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)})
+        authority = Mock()
+        authority.classify.side_effect = [
+            {"uid-1": "active"},
+            {"uid-1": "stale"},
+        ]
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.restore_candidate(
+                "meeting-1",
+                "uid-1",
+                ENVIRONMENT,
+                reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+                authority,
+                values,
+                mappings,
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_restore_rechecks_mapping_revision_before_write(self):
+        payload = {
+            "meeting_id": "meeting-1",
+            "registrant_id": "uid-1",
+            "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+        }
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        mappings = SequencedGetKV(
+            reconcile.mapping_key("uid-1"),
+            [Entry(b"!del", 3), Entry(b"!del", 4)],
+        )
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.restore_candidate(
+                "meeting-1",
+                "uid-1",
+                ENVIRONMENT,
+                reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+                FakeAuthority(["uid-1"]),
+                values,
+                mappings,
+            )
+        self.assertEqual([], values.updates)
+
     async def test_restore_requires_tombstoned_mapping_before_write(self):
         raw = reconcile.encode_payload(
             {
@@ -1243,7 +1320,7 @@ class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
         )
         mappings = SequencedGetKV(
             reconcile.mapping_key("uid-1"),
-            [Entry(b"!del", 3), Entry(b"1", 3)],
+            [Entry(b"!del", 3), Entry(b"!del", 3), Entry(b"1", 3)],
         )
         with self.assertRaises(reconcile.VerificationError):
             await reconcile._run_restore(

--- a/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
@@ -156,6 +156,10 @@ class ConfigTests(unittest.TestCase):
         config = reconcile.parse_args(cli_args())
         self.assertEqual("dry-run", config.mode)
 
+    def test_default_aws_region_matches_itx(self):
+        config = reconcile.parse_args(cli_args())
+        self.assertEqual("us-west-2", config.aws_region)
+
     def test_apply_and_restore_are_mutually_exclusive(self):
         with self.assertRaises(SystemExit):
             reconcile.parse_args(cli_args("--apply", "--restore", "uid-1"))
@@ -520,8 +524,33 @@ class DynamoDBTests(unittest.TestCase):
         self.assertEqual(assumed_session.client("sts"), sts)
         self.assertEqual(assumed_session.client("dynamodb"), dynamo)
         fake_boto.Session.assert_any_call(
-            profile_name="readonly", region_name="us-east-1"
+            profile_name="readonly", region_name="us-west-2"
         )
+
+    def test_aws_client_builder_redacts_initialization_failure(self):
+        config = reconcile.parse_args(cli_args("--aws-profile", "readonly"))
+        fake_boto = Mock()
+        fake_boto.Session.side_effect = RuntimeError(
+            "credential-process secret details"
+        )
+        with patch.object(reconcile, "boto3", fake_boto):
+            with self.assertRaises(reconcile.ReconciliationError) as caught:
+                reconcile.build_aws_clients(config)
+        self.assertEqual("AWS client initialization failed", str(caught.exception))
+        self.assertNotIn("credential-process", str(caught.exception))
+
+    def test_aws_client_builder_preserves_assume_role_error(self):
+        config = reconcile.parse_args(
+            cli_args("--assume-role-arn", "arn:aws:iam::123:role/reconcile")
+        )
+        expected = reconcile.ReconciliationError("AWS role assumption failed")
+        with (
+            patch.object(reconcile.boto3, "Session", return_value=Mock()),
+            patch.object(reconcile, "_assume_role", side_effect=expected),
+            self.assertRaises(reconcile.ReconciliationError) as caught,
+        ):
+            reconcile.build_aws_clients(config)
+        self.assertIs(expected, caught.exception)
 
     def test_sts_or_table_failure_does_not_expose_dependency_details(self):
         sts = Mock()

--- a/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
@@ -1,3 +1,6 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
 import asyncio
 import os
 import tempfile

--- a/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
+++ b/scripts/reconcile_meeting_registrants/test_reconcile_meeting_registrants.py
@@ -1,0 +1,1021 @@
+import asyncio
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+from common import NotFoundError
+import reconcile_meeting_registrants as reconcile
+
+
+class FakeResponse:
+    def __init__(self, payload=None, status_code=200):
+        self.payload = payload or {}
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"http status {self.status_code}")
+
+    def json(self):
+        return self.payload
+
+
+class FakeHTTPSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.posts = []
+        self.deletes = []
+
+    def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        return self.responses.pop(0)
+
+    def delete(self, url, **kwargs):
+        self.deletes.append((url, kwargs))
+        return FakeResponse()
+
+
+class FakeDynamo:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def batch_get_item(self, **kwargs):
+        self.requests.append(kwargs)
+        return self.responses.pop(0)
+
+
+class Entry:
+    def __init__(self, value, revision):
+        self.value = value
+        self.revision = revision
+
+
+class FakeKV:
+    def __init__(self, entries=None):
+        self.entries = dict(entries or {})
+        self.updates = []
+
+    async def get(self, key):
+        if key not in self.entries:
+            raise NotFoundError(key)
+        return self.entries[key]
+
+    async def update(self, key, value, last):
+        current = self.entries.get(key)
+        if current is None or current.revision != last:
+            raise reconcile.RevisionConflictError(key)
+        self.updates.append((key, value, last))
+        self.entries[key] = Entry(value, last + 1)
+        return last + 1
+
+
+class FailingUpdateKV(FakeKV):
+    def __init__(self, entries=None, fail_key=None):
+        super().__init__(entries)
+        self.fail_key = fail_key
+
+    async def update(self, key, value, last):
+        if key == self.fail_key:
+            raise reconcile.RevisionConflictError(key)
+        return await super().update(key, value, last)
+
+
+class SequencedGetKV(FakeKV):
+    def __init__(self, key, entries):
+        super().__init__({key: entries[-1]})
+        self.key = key
+        self.sequence = list(entries)
+
+    async def get(self, key):
+        if key != self.key:
+            return await super().get(key)
+        if len(self.sequence) > 1:
+            return self.sequence.pop(0)
+        return self.sequence[0]
+
+
+class FakeAuthority:
+    def __init__(self, active):
+        self.active = set(active)
+
+    def classify(self, uids):
+        return {
+            uid: ("active" if uid in self.active else "stale")
+            for uid in sorted(set(uids))
+        }
+
+
+class FakeDiscovery:
+    def __init__(self, uids):
+        self.uids = list(uids)
+
+    def discover(self, meeting_id):
+        return list(self.uids)
+
+    def contains(self, meeting_id, uid):
+        return uid in self.uids
+
+
+def cli_args(*extra, meeting_id="987", table="registrants"):
+    return [
+        "--meeting-id",
+        meeting_id,
+        "--opensearch-url",
+        "http://search",
+        "--nats-url",
+        "nats://localhost:4222",
+        "--dynamodb-table",
+        table,
+        *extra,
+    ]
+
+
+ENVIRONMENT = reconcile.Environment("123", "us-east-1", "arn:table", "reg", "id", "S")
+
+
+class ConfigTests(unittest.TestCase):
+    def test_meeting_id_is_required(self):
+        with self.assertRaises(SystemExit):
+            reconcile.parse_args([])
+
+    def test_dry_run_is_default(self):
+        config = reconcile.parse_args(cli_args())
+        self.assertEqual("dry-run", config.mode)
+
+    def test_apply_and_restore_are_mutually_exclusive(self):
+        with self.assertRaises(SystemExit):
+            reconcile.parse_args(cli_args("--apply", "--restore", "uid-1"))
+
+    def test_apply_requires_plan_and_confirmations(self):
+        with self.assertRaises(SystemExit):
+            reconcile.parse_args(cli_args("--apply"))
+
+    def test_literal_credentials_are_not_cli_options(self):
+        parser = reconcile.build_parser()
+        option_strings = {
+            option for action in parser._actions for option in action.option_strings
+        }
+        self.assertNotIn("--aws-access-key-id", option_strings)
+        self.assertNotIn("--aws-secret-access-key", option_strings)
+        self.assertNotIn("--aws-session-token", option_strings)
+
+
+class OpenSearchTests(unittest.TestCase):
+    def test_discovery_uses_exact_filters_and_deduplicates_pages(self):
+        session = FakeHTTPSession(
+            [
+                FakeResponse(
+                    {
+                        "_scroll_id": "scroll-1",
+                        "hits": {
+                            "hits": [
+                                {"_source": {"object_id": "uid-2"}},
+                                {"_source": {"object_id": "uid-1"}},
+                            ]
+                        },
+                    }
+                ),
+                FakeResponse(
+                    {
+                        "_scroll_id": "scroll-2",
+                        "hits": {"hits": [{"_source": {"object_id": "uid-1"}}]},
+                    }
+                ),
+                FakeResponse({"_scroll_id": "scroll-2", "hits": {"hits": []}}),
+            ]
+        )
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        self.assertEqual(["uid-1", "uid-2"], client.discover("meeting-1"))
+        query = session.posts[0][1]["json"]["query"]["bool"]["filter"]
+        self.assertEqual(
+            [
+                {"term": {"object_type": "v1_meeting_registrant"}},
+                {"term": {"data.meeting_id": "meeting-1"}},
+            ],
+            query,
+        )
+        self.assertEqual(1, len(session.deletes))
+
+    def test_malformed_hit_fails_closed_and_clears_scroll(self):
+        session = FakeHTTPSession(
+            [
+                FakeResponse(
+                    {
+                        "_scroll_id": "scroll-1",
+                        "hits": {"hits": [{"_source": {}}]},
+                    }
+                )
+            ]
+        )
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        with self.assertRaises(reconcile.ReconciliationError):
+            client.discover("meeting-1")
+        self.assertEqual(1, len(session.deletes))
+
+    def test_contains_issues_one_scoped_query_without_scrolling(self):
+        session = FakeHTTPSession(
+            [FakeResponse({"hits": {"hits": [{"_source": {"object_id": "uid-1"}}]}})]
+        )
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        self.assertTrue(client.contains("meeting-1", "uid-1"))
+        self.assertEqual(1, len(session.posts))
+        query = session.posts[0][1]["json"]["query"]["bool"]["filter"]
+        self.assertEqual(
+            [
+                {"term": {"object_type": "v1_meeting_registrant"}},
+                {"term": {"data.meeting_id": "meeting-1"}},
+                {"term": {"object_id": "uid-1"}},
+            ],
+            query,
+        )
+        self.assertEqual(0, len(session.deletes))
+
+    def test_contains_returns_false_without_a_hit(self):
+        session = FakeHTTPSession([FakeResponse({"hits": {"hits": []}})])
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        self.assertFalse(client.contains("meeting-1", "uid-1"))
+
+    def test_empty_result_returns_no_candidates(self):
+        session = FakeHTTPSession(
+            [FakeResponse({"_scroll_id": "scroll-1", "hits": {"hits": []}})]
+        )
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        self.assertEqual([], client.discover("meeting-1"))
+
+    def test_scroll_cleanup_failure_fails_closed(self):
+        session = FakeHTTPSession(
+            [FakeResponse({"_scroll_id": "scroll-1", "hits": {"hits": []}})]
+        )
+        session.delete = Mock(return_value=FakeResponse(status_code=500))
+        client = reconcile.OpenSearchDiscovery(session, "http://search", "resources", 5)
+        with self.assertRaises(reconcile.ReconciliationError):
+            client.discover("meeting-1")
+
+
+class DynamoDBTests(unittest.TestCase):
+    def test_environment_discovers_identity_and_hash_key(self):
+        sts = Mock()
+        sts.get_caller_identity.return_value = {
+            "Account": "123456789012",
+            "Arn": "arn:aws:iam::123456789012:role/reconcile",
+        }
+        dynamo = Mock()
+        dynamo.describe_table.return_value = {
+            "Table": {
+                "TableArn": "arn:aws:dynamodb:us-east-1:123456789012:table/reg",
+                "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+                "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
+            }
+        }
+        authority = reconcile.DynamoAuthority(
+            sts, dynamo, "reg", "us-east-1", sleep=lambda _: None
+        )
+        environment = authority.discover_environment()
+        self.assertEqual("123456789012", environment.account)
+        self.assertEqual("id", environment.key_name)
+        self.assertEqual({"id": {"S": "uid-1"}}, authority.build_key("uid-1"))
+
+    def test_composite_key_is_rejected_without_scan(self):
+        sts = Mock()
+        sts.get_caller_identity.return_value = {"Account": "123"}
+        dynamo = Mock()
+        dynamo.describe_table.return_value = {
+            "Table": {
+                "TableArn": "arn:table",
+                "KeySchema": [
+                    {"AttributeName": "meeting_id", "KeyType": "HASH"},
+                    {"AttributeName": "id", "KeyType": "RANGE"},
+                ],
+                "AttributeDefinitions": [
+                    {"AttributeName": "meeting_id", "AttributeType": "S"},
+                    {"AttributeName": "id", "AttributeType": "S"},
+                ],
+            }
+        }
+        authority = reconcile.DynamoAuthority(
+            sts, dynamo, "reg", "us-east-1", sleep=lambda _: None
+        )
+        with self.assertRaises(reconcile.ReconciliationError):
+            authority.discover_environment()
+        dynamo.scan.assert_not_called()
+
+    def test_classification_retries_unprocessed_keys(self):
+        dynamo = FakeDynamo(
+            [
+                {
+                    "Responses": {"reg": [{"id": {"S": "uid-1"}}]},
+                    "UnprocessedKeys": {
+                        "reg": {
+                            "Keys": [{"id": {"S": "uid-2"}}],
+                            "ConsistentRead": True,
+                        }
+                    },
+                },
+                {"Responses": {"reg": []}, "UnprocessedKeys": {}},
+            ]
+        )
+        authority = reconcile.DynamoAuthority(
+            Mock(), dynamo, "reg", "us-east-1", sleep=lambda _: None
+        )
+        authority.environment = reconcile.Environment(
+            account="123",
+            region="us-east-1",
+            table_arn="arn:table",
+            table_name="reg",
+            key_name="id",
+            key_type="S",
+        )
+        result = authority.classify(["uid-2", "uid-1", "uid-1"])
+        self.assertEqual({"uid-1": "active", "uid-2": "stale"}, result)
+        self.assertTrue(dynamo.requests[0]["RequestItems"]["reg"]["ConsistentRead"])
+
+    def test_unresolved_keys_fail_closed(self):
+        request = {
+            "reg": {
+                "Keys": [{"id": {"S": "uid-1"}}],
+                "ConsistentRead": True,
+            }
+        }
+        dynamo = FakeDynamo(
+            [{"Responses": {"reg": []}, "UnprocessedKeys": request} for _ in range(4)]
+        )
+        authority = reconcile.DynamoAuthority(
+            Mock(),
+            dynamo,
+            "reg",
+            "us-east-1",
+            sleep=lambda _: None,
+            max_retries=3,
+        )
+        authority.environment = ENVIRONMENT
+        with self.assertRaises(reconcile.ReconciliationError):
+            authority.classify(["uid-1"])
+
+    def test_malformed_batch_response_cannot_be_classified_as_absent(self):
+        malformed_responses = (
+            {"UnprocessedKeys": {}},
+            {"Responses": {}, "UnprocessedKeys": {}},
+            {"Responses": {"reg": []}, "UnprocessedKeys": []},
+        )
+        for response in malformed_responses:
+            authority = reconcile.DynamoAuthority(
+                Mock(),
+                FakeDynamo([response]),
+                "reg",
+                "us-east-1",
+                sleep=lambda _: None,
+            )
+            authority.environment = ENVIRONMENT
+            with self.subTest(response=response):
+                with self.assertRaises(reconcile.ReconciliationError):
+                    authority.classify(["uid-1"])
+
+    def test_foreign_unprocessed_table_fails_closed(self):
+        dynamo = FakeDynamo(
+            [
+                {
+                    "Responses": {"reg": []},
+                    "UnprocessedKeys": {"other": {"Keys": [{"id": {"S": "uid-1"}}]}},
+                },
+                {"Responses": {"reg": []}, "UnprocessedKeys": {}},
+            ]
+        )
+        authority = reconcile.DynamoAuthority(
+            Mock(), dynamo, "reg", "us-east-1", sleep=lambda _: None
+        )
+        authority.environment = ENVIRONMENT
+        with self.assertRaises(reconcile.ReconciliationError):
+            authority.classify(["uid-1"])
+
+    def test_classification_batches_one_hundred_keys_without_scan(self):
+        uids = [f"uid-{number:03d}" for number in range(101)]
+        dynamo = FakeDynamo(
+            [
+                {"Responses": {"reg": []}, "UnprocessedKeys": {}},
+                {"Responses": {"reg": []}, "UnprocessedKeys": {}},
+            ]
+        )
+        authority = reconcile.DynamoAuthority(
+            Mock(), dynamo, "reg", "us-east-1", sleep=lambda _: None
+        )
+        authority.environment = ENVIRONMENT
+        result = authority.classify(uids)
+        self.assertEqual(101, len(result))
+        self.assertEqual(2, len(dynamo.requests))
+        self.assertTrue(all(value == "stale" for value in result.values()))
+
+    def test_present_item_is_active_even_with_deleted_status_field(self):
+        dynamo = FakeDynamo(
+            [
+                {
+                    "Responses": {
+                        "reg": [
+                            {
+                                "id": {"S": "uid-1"},
+                                "status": {"S": "deleted"},
+                            }
+                        ]
+                    },
+                    "UnprocessedKeys": {},
+                }
+            ]
+        )
+        authority = reconcile.DynamoAuthority(
+            Mock(), dynamo, "reg", "us-east-1", sleep=lambda _: None
+        )
+        authority.environment = ENVIRONMENT
+        self.assertEqual({"uid-1": "active"}, authority.classify(["uid-1"]))
+
+    def test_aws_client_builder_uses_profile_and_assumed_role(self):
+        config = reconcile.parse_args(
+            cli_args(
+                "--aws-profile",
+                "readonly",
+                "--assume-role-arn",
+                "arn:aws:iam::123:role/reconcile",
+            )
+        )
+        source_session = Mock()
+        assumed_session = Mock()
+        fake_boto = Mock()
+        fake_boto.Session.side_effect = [source_session, assumed_session]
+        source_session.client.return_value.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "redacted",
+                "SecretAccessKey": "redacted",
+                "SessionToken": "redacted",
+            }
+        }
+        with patch.object(reconcile, "boto3", fake_boto):
+            sts, dynamo = reconcile.build_aws_clients(config)
+        self.assertEqual(assumed_session.client("sts"), sts)
+        self.assertEqual(assumed_session.client("dynamodb"), dynamo)
+        fake_boto.Session.assert_any_call(
+            profile_name="readonly", region_name="us-east-1"
+        )
+
+    def test_sts_or_table_failure_does_not_expose_dependency_details(self):
+        sts = Mock()
+        sts.get_caller_identity.side_effect = RuntimeError(
+            "secret-token dependency body"
+        )
+        authority = reconcile.DynamoAuthority(
+            sts, Mock(), "reg", "us-east-1", sleep=lambda _: None
+        )
+        with self.assertRaises(reconcile.ReconciliationError) as caught:
+            authority.discover_environment()
+        self.assertNotIn("secret-token", str(caught.exception))
+
+    def test_table_arn_must_match_sts_account_region_and_name(self):
+        sts = Mock()
+        sts.get_caller_identity.return_value = {"Account": "123"}
+        base_table = {
+            "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+            "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
+        }
+        invalid_arns = (
+            "arn:aws:dynamodb:us-east-1:999:table/reg",
+            "arn:aws:dynamodb:us-west-2:123:table/reg",
+            "arn:aws:s3:us-east-1:123:table/reg",
+            "arn:aws:dynamodb:us-east-1:123:table/other",
+        )
+        for table_arn in invalid_arns:
+            dynamo = Mock()
+            dynamo.describe_table.return_value = {
+                "Table": {**base_table, "TableArn": table_arn}
+            }
+            authority = reconcile.DynamoAuthority(
+                sts, dynamo, "reg", "us-east-1", sleep=lambda _: None
+            )
+            with self.subTest(table_arn=table_arn):
+                with self.assertRaises(reconcile.ReconciliationError):
+                    authority.discover_environment()
+
+
+class PayloadAndPlanTests(unittest.IsolatedAsyncioTestCase):
+    async def test_json_and_messagepack_round_trip(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        for encoding in ("json", "msgpack"):
+            raw = reconcile.encode_payload(payload, encoding)
+            decoded, detected = reconcile.decode_payload(raw)
+            self.assertEqual(payload, decoded)
+            self.assertEqual(encoding, detected)
+
+    async def test_snapshot_records_revision_digest_and_mapping(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(payload, "json"), 7
+                )
+            }
+        )
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        snapshot = await reconcile.snapshot_candidate(
+            values, mappings, "meeting-1", "uid-1"
+        )
+        self.assertEqual(7, snapshot.revision)
+        self.assertEqual("live", snapshot.mapping_state)
+        self.assertEqual(64, len(snapshot.digest))
+
+    async def test_mismatched_payload_fails_closed(self):
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(
+                        {"meeting_id": "other", "registrant_id": "uid-1"},
+                        "json",
+                    ),
+                    7,
+                )
+            }
+        )
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.snapshot_candidate(values, mappings, "meeting-1", "uid-1")
+
+    async def test_plan_is_deterministic_redacted_and_private(self):
+        environment = ENVIRONMENT
+        plan = reconcile.Plan(
+            version=1,
+            meeting_id="meeting-1",
+            environment=environment,
+            candidates=[
+                reconcile.CandidateSnapshot(
+                    "uid-1", "stale", 7, "json", "abc", "live", 3, False
+                )
+            ],
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "plan.json"
+            reconcile.write_plan(plan, path)
+            raw = path.read_text()
+            self.assertEqual(plan, reconcile.read_plan(path))
+            self.assertNotIn("email", raw)
+            self.assertNotIn("token", raw)
+            self.assertEqual(0o600, os.stat(path).st_mode & 0o777)
+
+    async def test_unknown_mapping_prevents_applicable_plan(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(payload, "json"), 7
+                )
+            }
+        )
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"unexpected", 3)})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.build_plan(
+                "meeting-1",
+                ENVIRONMENT,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority([]),
+                values,
+                mappings,
+            )
+
+    async def test_missing_or_tombstoned_mapping_prevents_plan(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(payload, "json"), 7
+                )
+            }
+        )
+        for mappings in (
+            FakeKV({}),
+            FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)}),
+        ):
+            with self.subTest(entries=mappings.entries):
+                with self.assertRaises(reconcile.ReconciliationError):
+                    await reconcile.build_plan(
+                        "meeting-1",
+                        ENVIRONMENT,
+                        FakeDiscovery(["uid-1"]),
+                        FakeAuthority([]),
+                        values,
+                        mappings,
+                    )
+
+    async def test_stale_marked_tombstoned_candidate_is_valid_completed_state(self):
+        payload = {
+            "meeting_id": "meeting-1",
+            "registrant_id": "uid-1",
+            "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+        }
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(payload, "json"), 7
+                )
+            }
+        )
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 3)})
+        plan = await reconcile.build_plan(
+            "meeting-1",
+            ENVIRONMENT,
+            FakeDiscovery(["uid-1"]),
+            FakeAuthority([]),
+            values,
+            mappings,
+        )
+        self.assertTrue(plan.candidates[0].deleted)
+        self.assertEqual("tombstoned", plan.candidates[0].mapping_state)
+
+    async def test_active_soft_deleted_candidate_is_ambiguous(self):
+        payload = {
+            "meeting_id": "meeting-1",
+            "registrant_id": "uid-1",
+            "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+        }
+        values = FakeKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(
+                    reconcile.encode_payload(payload, "json"), 7
+                )
+            }
+        )
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.build_plan(
+                "meeting-1",
+                ENVIRONMENT,
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority(["uid-1"]),
+                values,
+                mappings,
+            )
+
+
+class ApplyRestoreTests(unittest.IsolatedAsyncioTestCase):
+    def make_plan(self, digest, revision=7, deleted=False):
+        return reconcile.Plan(
+            version=1,
+            meeting_id="meeting-1",
+            environment=ENVIRONMENT,
+            candidates=[
+                reconcile.CandidateSnapshot(
+                    "uid-1",
+                    "stale",
+                    revision,
+                    "json",
+                    digest,
+                    "live",
+                    3,
+                    deleted,
+                )
+            ],
+        )
+
+    async def test_apply_adds_marker_with_expected_revision(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        plan = self.make_plan(reconcile.payload_digest(raw))
+        completed = await reconcile.apply_plan(
+            plan,
+            reconcile.Confirmations("meeting-1", "123", "arn:table", 1),
+            FakeDiscovery(["uid-1"]),
+            FakeAuthority([]),
+            values,
+            mappings,
+            now=lambda: datetime(2026, 7, 16, tzinfo=timezone.utc),
+        )
+        self.assertEqual(["uid-1"], completed)
+        key, updated, revision = values.updates[0]
+        decoded, encoding = reconcile.decode_payload(updated)
+        self.assertEqual(reconcile.registrant_key("uid-1"), key)
+        self.assertEqual(7, revision)
+        self.assertEqual("json", encoding)
+        self.assertEqual("2026-07-16T00:00:00Z", decoded["_sdc_deleted_at"])
+
+    async def test_apply_rejects_recreated_dynamo_row_without_write(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        with self.assertRaises(reconcile.PlanDriftError):
+            await reconcile.apply_plan(
+                self.make_plan(reconcile.payload_digest(raw)),
+                reconcile.Confirmations("meeting-1", "123", "arn:table", 1),
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority(["uid-1"]),
+                values,
+                mappings,
+                now=lambda: datetime.now(timezone.utc),
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_apply_rejects_confirmation_mismatch_before_write(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        with self.assertRaises(reconcile.PlanDriftError):
+            await reconcile.apply_plan(
+                self.make_plan(reconcile.payload_digest(raw)),
+                reconcile.Confirmations("meeting-1", "wrong", "arn:table", 1),
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority([]),
+                values,
+                mappings,
+                now=lambda: datetime.now(timezone.utc),
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_already_deleted_stale_uid_is_returned_for_verification(self):
+        payload = {
+            "meeting_id": "meeting-1",
+            "registrant_id": "uid-1",
+            "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+        }
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        plan = self.make_plan(reconcile.payload_digest(raw), deleted=True)
+        completed = await reconcile.apply_plan(
+            plan,
+            reconcile.Confirmations("meeting-1", "123", "arn:table", 1),
+            FakeDiscovery(["uid-1"]),
+            FakeAuthority([]),
+            values,
+            mappings,
+            now=lambda: datetime.now(timezone.utc),
+        )
+        self.assertEqual(["uid-1"], completed)
+        self.assertEqual([], values.updates)
+
+    async def test_revision_conflict_reports_partial_apply_without_retry(self):
+        payload1 = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        payload2 = {"meeting_id": "meeting-1", "registrant_id": "uid-2"}
+        raw1 = reconcile.encode_payload(payload1, "json")
+        raw2 = reconcile.encode_payload(payload2, "json")
+        values = FailingUpdateKV(
+            {
+                reconcile.registrant_key("uid-1"): Entry(raw1, 7),
+                reconcile.registrant_key("uid-2"): Entry(raw2, 8),
+            },
+            fail_key=reconcile.registrant_key("uid-2"),
+        )
+        mappings = FakeKV(
+            {
+                reconcile.mapping_key("uid-1"): Entry(b"1", 3),
+                reconcile.mapping_key("uid-2"): Entry(b"1", 4),
+            }
+        )
+        plan = reconcile.Plan(
+            1,
+            "meeting-1",
+            ENVIRONMENT,
+            [
+                reconcile.CandidateSnapshot(
+                    "uid-1",
+                    "stale",
+                    7,
+                    "json",
+                    reconcile.payload_digest(raw1),
+                    "live",
+                    3,
+                    False,
+                ),
+                reconcile.CandidateSnapshot(
+                    "uid-2",
+                    "stale",
+                    8,
+                    "json",
+                    reconcile.payload_digest(raw2),
+                    "live",
+                    4,
+                    False,
+                ),
+            ],
+        )
+        with self.assertRaises(reconcile.ReconciliationError) as caught:
+            await reconcile.apply_plan(
+                plan,
+                reconcile.Confirmations("meeting-1", "123", "arn:table", 2),
+                FakeDiscovery(["uid-1", "uid-2"]),
+                FakeAuthority([]),
+                values,
+                mappings,
+                now=lambda: datetime.now(timezone.utc),
+            )
+        self.assertIn("completed=['uid-1']", str(caught.exception))
+        self.assertEqual(1, len(values.updates))
+
+    async def test_apply_rechecks_each_uid_immediately_before_write(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        authority = Mock()
+        authority.classify.side_effect = [
+            {"uid-1": "stale"},
+            {"uid-1": "active"},
+        ]
+        with self.assertRaises(reconcile.PlanDriftError):
+            await reconcile.apply_plan(
+                self.make_plan(reconcile.payload_digest(raw)),
+                reconcile.Confirmations("meeting-1", "123", "arn:table", 1),
+                FakeDiscovery(["uid-1"]),
+                authority,
+                values,
+                mappings,
+                now=lambda: datetime.now(timezone.utc),
+            )
+        self.assertEqual([], values.updates)
+        self.assertEqual(2, authority.classify.call_count)
+
+    async def test_apply_rechecks_mapping_revision_before_write(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        raw = reconcile.encode_payload(payload, "json")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        key = reconcile.mapping_key("uid-1")
+        mappings = SequencedGetKV(key, [Entry(b"1", 3), Entry(b"1", 4)])
+        with self.assertRaises(reconcile.PlanDriftError):
+            await reconcile.apply_plan(
+                self.make_plan(reconcile.payload_digest(raw)),
+                reconcile.Confirmations("meeting-1", "123", "arn:table", 1),
+                FakeDiscovery(["uid-1"]),
+                FakeAuthority([]),
+                values,
+                mappings,
+                now=lambda: datetime.now(timezone.utc),
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_run_apply_binds_target_meeting_to_plan(self):
+        payload = {"meeting_id": "meeting-1", "registrant_id": "uid-1"}
+        raw = reconcile.encode_payload(payload, "json")
+        plan = self.make_plan(reconcile.payload_digest(raw))
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 7)})
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "plan.json"
+            reconcile.write_plan(plan, path)
+            config = reconcile.parse_args(
+                cli_args(
+                    "--plan",
+                    str(path),
+                    "--apply",
+                    "--confirm-meeting-id",
+                    "meeting-1",
+                    "--confirm-aws-account",
+                    "123",
+                    "--confirm-table-arn",
+                    "arn:table",
+                    "--confirm-stale-count",
+                    "1",
+                    meeting_id="different-meeting",
+                    table="reg",
+                )
+            )
+            with self.assertRaises(reconcile.PlanDriftError):
+                await reconcile._run_apply(
+                    config,
+                    plan.environment,
+                    FakeDiscovery(["uid-1"]),
+                    FakeAuthority([]),
+                    values,
+                    mappings,
+                )
+        self.assertEqual([], values.updates)
+
+    async def test_restore_requires_dynamo_presence_and_removes_only_marker(self):
+        payload = {
+            "meeting_id": "meeting-1",
+            "registrant_id": "uid-1",
+            "name": "preserved",
+            "_sdc_deleted_at": "2026-07-16T00:00:00Z",
+        }
+        raw = reconcile.encode_payload(payload, "msgpack")
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        await reconcile.restore_candidate(
+            "meeting-1",
+            "uid-1",
+            ENVIRONMENT,
+            reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+            FakeAuthority(["uid-1"]),
+            values,
+        )
+        decoded, encoding = reconcile.decode_payload(values.updates[0][1])
+        self.assertEqual("msgpack", encoding)
+        self.assertEqual("preserved", decoded["name"])
+        self.assertNotIn("_sdc_deleted_at", decoded)
+
+    async def test_restore_rejects_absent_authoritative_row(self):
+        values = FakeKV({})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.restore_candidate(
+                "meeting-1",
+                "uid-1",
+                ENVIRONMENT,
+                reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+                FakeAuthority([]),
+                values,
+            )
+        self.assertEqual([], values.updates)
+
+    async def test_restore_rejects_payload_without_marker(self):
+        raw = reconcile.encode_payload(
+            {"meeting_id": "meeting-1", "registrant_id": "uid-1"}, "json"
+        )
+        values = FakeKV({reconcile.registrant_key("uid-1"): Entry(raw, 9)})
+        with self.assertRaises(reconcile.ReconciliationError):
+            await reconcile.restore_candidate(
+                "meeting-1",
+                "uid-1",
+                ENVIRONMENT,
+                reconcile.RestoreConfirmations("meeting-1", "123", "arn:table"),
+                FakeAuthority(["uid-1"]),
+                values,
+            )
+        self.assertEqual([], values.updates)
+
+
+class VerificationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_apply_verification_waits_for_absence_and_tombstone(self):
+        discovery = FakeDiscovery([])
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"!del", 4)})
+        await reconcile.verify_apply(
+            "meeting-1",
+            ["uid-1"],
+            discovery,
+            mappings,
+            timeout=0.05,
+            interval=0,
+            sleep=lambda _: asyncio.sleep(0),
+        )
+
+    async def test_verification_timeout_makes_no_writes(self):
+        discovery = FakeDiscovery(["uid-1"])
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 3)})
+        with self.assertRaises(reconcile.VerificationError):
+            await reconcile.verify_apply(
+                "meeting-1",
+                ["uid-1"],
+                discovery,
+                mappings,
+                timeout=0,
+                interval=0,
+                sleep=lambda _: asyncio.sleep(0),
+            )
+        self.assertEqual([], mappings.updates)
+
+    async def test_restore_verification_waits_for_index_and_live_mapping(self):
+        discovery = FakeDiscovery(["uid-1"])
+        mappings = FakeKV({reconcile.mapping_key("uid-1"): Entry(b"1", 4)})
+        await reconcile.verify_restore(
+            "meeting-1",
+            "uid-1",
+            discovery,
+            mappings,
+            timeout=0.05,
+            interval=0,
+        )
+
+    async def test_mapping_dependency_failure_does_not_trigger_write(self):
+        mappings = FakeKV({})
+        with self.assertRaises(NotFoundError):
+            await reconcile.verify_apply(
+                "meeting-1",
+                ["uid-1"],
+                FakeDiscovery([]),
+                mappings,
+                timeout=0.05,
+                interval=0,
+            )
+        self.assertEqual([], mappings.updates)
+
+
+class OutputTests(unittest.TestCase):
+    def test_main_prints_only_redacted_summary(self):
+        result = {
+            "mode": "dry-run",
+            "candidate_count": 1,
+            "active_count": 0,
+            "stale_count": 1,
+            "stale_uids": ["uid-1"],
+        }
+        with (
+            patch.object(reconcile, "run", AsyncMock(return_value=result)),
+            patch("builtins.print") as output,
+        ):
+            self.assertEqual(
+                0,
+                reconcile.main(cli_args()),
+            )
+        rendered = output.call_args.args[0]
+        for secret in ("email", "username", "token", "AccessKeyId"):
+            self.assertNotIn(secret, rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a meeting-scoped Python CLI to reconcile indexed registrants against the authoritative DynamoDB registrant table.
- Discover the bounded candidate set from OpenSearch, classify candidates with consistent DynamoDB `BatchGetItem` reads, and repair only confirmed stale `v1-objects` records.
- Default to dry-run, persist a redacted review plan, require explicit environment/count confirmations for apply, and provide a guarded single-UID restore.
- Preserve JSON or MessagePack payload encoding and use revision-conditional NATS KV updates; existing meeting-service eventing performs OpenSearch and applicable OpenFGA cleanup.

## Incident evidence

The production investigation for meeting `98727043273` found:

- Application/ITX aggregate: **42 registrants**
- OpenSearch: **50** `v1_meeting_registrant` documents
- NATS `v1-objects`: **50** matching registrant records
- NATS soft-delete markers: **0** among those records
- Observed drift: **8** stale replica/index candidates

OpenSearch and `v1-objects` agreed, so replaying/reindexing the same KV state would retain the inflated count. The exact stale UIDs still require the production dry-run's authoritative DynamoDB comparison; the tool does not infer them heuristically.

## Root-cause context

DynamoDB removals normally flow through the DynamoDB stream consumer and v1-sync-helper, which writes `_sdc_deleted_at` to `v1-objects`. Meeting-service then publishes the existing indexer delete and applicable OpenFGA member-removal events. The affected records remained live in `v1-objects`, indicating their removal did not complete through that path; the periodic upsert pipeline cannot reconstruct an already-missed removal.

This utility repairs the source replica only. It does **not** update query-service counts, OpenSearch, OpenFGA, ITX, or DynamoDB directly.

## Safety controls

- One required meeting ID; no DynamoDB or NATS scans
- DynamoDB is the sole authority for present/absent classification
- STS account, region, table ARN, and key schema are discovered and validated
- Consistent reads with bounded retry and fail-closed `UnprocessedKeys` validation
- Dry-run plan contains identifiers, revisions, digests, classifications, environment identity, and sanitized target identities only
- Apply rejects OpenSearch/NATS target drift before opening target connections or writing
- Apply revalidates candidates, DynamoDB state, NATS payload digest, mapping state, and revisions before writes
- Each UID is checked against DynamoDB and mapping state immediately before its conditional write
- Explicit meeting/account/table/stale-count confirmations
- Stop-on-first-failure partial-apply reporting; no automatic rollback
- Guarded restore requires DynamoDB presence and removes only `_sdc_deleted_at`
- Bounded downstream verification for index disappearance/reappearance and mapping transitions

## Verification

- [x] Python compilation
- [x] Ruff formatting and lint checks
- [x] 69 Python unit tests
- [x] Python dependency consistency (`pip check`)
- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `make verify`
- [x] Production dry-run and plan review

`golangci-lint run` still reports two pre-existing `errcheck` findings in `cmd/meeting-api/eventing/event_processor.go` and `pkg/utils/map.go`; this scripts-only change does not modify those files.

## Production rollout

1. Establish approved OpenSearch and NATS access paths and use a read-only AWS profile/role.
2. Run dry-run for the supplied meeting ID and retain the redacted plan as evidence.
3. Verify AWS identity/table ARN, target identities, candidate set, stale count, NATS revisions, and payload digests.
4. Run apply only after plan approval and with exact confirmations.
5. Confirm stale UIDs disappear from OpenSearch and mappings become tombstoned.

## Tracking

Jira: [LFXV2-2135](https://linuxfoundation.atlassian.net/browse/LFXV2-2135)

[LFXV2-2135]: https://linuxfoundation.atlassian.net/browse/LFXV2-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ