### PR TITLE
refactor(eventing): extract coerceInt/coerceInt64 helpers to eliminate repeated unmarshal switch blocks

### DIFF
--- a/cmd/meeting-api/eventing/attachment_event_handler.go
+++ b/cmd/meeting-api/eventing/attachment_event_handler.go
@@ -54,9 +54,7 @@ func (a *AttachmentDBRaw) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	var err error
-	a.FileSize, err = coerceInt(tmp.FileSize, "file_size")
-	return err
+	return coerceInt(&a.FileSize, tmp.FileSize, "file_size")
 }
 
 // attachmentActorDBRaw represents the created_by/updated_by actor in raw attachment data.
@@ -287,9 +285,7 @@ func (a *PastMeetingAttachmentDBRaw) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	var err error
-	a.FileSize, err = coerceInt(tmp.FileSize, "file_size")
-	return err
+	return coerceInt(&a.FileSize, tmp.FileSize, "file_size")
 }
 
 // handlePastMeetingAttachmentUpdate processes updates to past meeting attachments

--- a/cmd/meeting-api/eventing/attachment_event_handler.go
+++ b/cmd/meeting-api/eventing/attachment_event_handler.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	indexerConstants "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
@@ -55,23 +54,9 @@ func (a *AttachmentDBRaw) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	switch v := tmp.FileSize.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid value for file_size: %w", err)
-			}
-			a.FileSize = val
-		}
-	case float64:
-		a.FileSize = int(v)
-	case nil:
-		// leave as zero value
-	default:
-		return fmt.Errorf("invalid type for file_size: %T", v)
-	}
-	return nil
+	var err error
+	a.FileSize, err = coerceInt(tmp.FileSize, "file_size")
+	return err
 }
 
 // attachmentActorDBRaw represents the created_by/updated_by actor in raw attachment data.
@@ -302,23 +287,9 @@ func (a *PastMeetingAttachmentDBRaw) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	switch v := tmp.FileSize.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid value for file_size: %w", err)
-			}
-			a.FileSize = val
-		}
-	case float64:
-		a.FileSize = int(v)
-	case nil:
-		// leave as zero value
-	default:
-		return fmt.Errorf("invalid type for file_size: %T", v)
-	}
-	return nil
+	var err error
+	a.FileSize, err = coerceInt(tmp.FileSize, "file_size")
+	return err
 }
 
 // handlePastMeetingAttachmentUpdate processes updates to past meeting attachments

--- a/cmd/meeting-api/eventing/meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"time"
 
@@ -261,166 +260,46 @@ func (m *MeetingDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Handle Duration
-	switch v := tmp.Duration.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.Duration = val
-		}
-	case float64:
-		m.Duration = int(v)
-	case int:
-		m.Duration = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for duration: %T", v)
-		}
+	var err error
+
+	m.Duration, err = coerceInt(tmp.Duration, "duration")
+	if err != nil {
+		return err
 	}
 
-	// Handle EarlyJoinTime
-	switch v := tmp.EarlyJoinTime.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.EarlyJoinTime = val
-		}
-	case float64:
-		m.EarlyJoinTime = int(v)
-	case int:
-		m.EarlyJoinTime = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for early_join_time_minutes: %T", v)
-		}
+	m.EarlyJoinTime, err = coerceInt(tmp.EarlyJoinTime, "early_join_time")
+	if err != nil {
+		return err
 	}
 
-	// Handle LastEndTime (int64)
-	switch v := tmp.LastEndTime.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return err
-			}
-			m.LastEndTime = val
-		}
-	case float64:
-		m.LastEndTime = int64(v)
-	case int64:
-		m.LastEndTime = v
-	case int:
-		m.LastEndTime = int64(v)
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for last_end_time: %T", v)
-		}
+	m.LastEndTime, err = coerceInt64(tmp.LastEndTime, "last_end_time")
+	if err != nil {
+		return err
 	}
 
-	// Handle LastBulkRegistrantsJobFailedCount
-	switch v := tmp.LastBulkRegistrantsJobFailedCount.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.LastBulkRegistrantsJobFailedCount = val
-		}
-	case float64:
-		m.LastBulkRegistrantsJobFailedCount = int(v)
-	case int:
-		m.LastBulkRegistrantsJobFailedCount = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for last_bulk_registrants_job_failed_count: %T", v)
-		}
+	m.LastBulkRegistrantsJobFailedCount, err = coerceInt(tmp.LastBulkRegistrantsJobFailedCount, "last_bulk_registrants_job_failed_count")
+	if err != nil {
+		return err
 	}
 
-	// Handle LastBulkRegistrantsJobWarningCount
-	switch v := tmp.LastBulkRegistrantsJobWarningCount.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.LastBulkRegistrantsJobWarningCount = val
-		}
-	case float64:
-		m.LastBulkRegistrantsJobWarningCount = int(v)
-	case int:
-		m.LastBulkRegistrantsJobWarningCount = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for last_bulk_registrants_job_warning_count: %T", v)
-		}
+	m.LastBulkRegistrantsJobWarningCount, err = coerceInt(tmp.LastBulkRegistrantsJobWarningCount, "last_bulk_registrants_job_warning_count")
+	if err != nil {
+		return err
 	}
 
-	// Handle LastMailingListMembersSyncJobFailedCount
-	switch v := tmp.LastMailingListMembersSyncJobFailedCount.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.LastMailingListMembersSyncJobFailedCount = val
-		}
-	case float64:
-		m.LastMailingListMembersSyncJobFailedCount = int(v)
-	case int:
-		m.LastMailingListMembersSyncJobFailedCount = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for last_mailing_list_members_sync_job_failed_count: %T", v)
-		}
+	m.LastMailingListMembersSyncJobFailedCount, err = coerceInt(tmp.LastMailingListMembersSyncJobFailedCount, "last_mailing_list_members_sync_job_failed_count")
+	if err != nil {
+		return err
 	}
 
-	// Handle LastMailingListMembersSyncJobWarningCount
-	switch v := tmp.LastMailingListMembersSyncJobWarningCount.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.LastMailingListMembersSyncJobWarningCount = val
-		}
-	case float64:
-		m.LastMailingListMembersSyncJobWarningCount = int(v)
-	case int:
-		m.LastMailingListMembersSyncJobWarningCount = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for last_mailing_list_members_sync_job_warning_count: %T", v)
-		}
+	m.LastMailingListMembersSyncJobWarningCount, err = coerceInt(tmp.LastMailingListMembersSyncJobWarningCount, "last_mailing_list_members_sync_job_warning_count")
+	if err != nil {
+		return err
 	}
 
-	// Handle AutoEmailReminderTime
-	switch v := tmp.AutoEmailReminderTime.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-			m.AutoEmailReminderTime = val
-		}
-	case float64:
-		m.AutoEmailReminderTime = int(v)
-	case int:
-		m.AutoEmailReminderTime = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for auto_email_reminder_time: %T", v)
-		}
+	m.AutoEmailReminderTime, err = coerceInt(tmp.AutoEmailReminderTime, "auto_email_reminder_time")
+	if err != nil {
+		return err
 	}
 
 	// Occurrences are recomputed from RRULE calculation; discard the raw field (already shadowed above).
@@ -452,19 +331,9 @@ func (m *MeetingDBRaw) UnmarshalJSON(data []byte) error {
 				Recurrence:      occTmp.Recurrence,
 				AllFollowing:    occTmp.AllFollowing,
 			}
-			switch v := occTmp.Duration.(type) {
-			case string:
-				if v != "" {
-					val, err := strconv.Atoi(v)
-					if err != nil {
-						return fmt.Errorf("invalid duration in updated_occurrence: %w", err)
-					}
-					occ.Duration = val
-				}
-			case float64:
-				occ.Duration = int(v)
-			case int:
-				occ.Duration = v
+			occ.Duration, err = coerceInt(occTmp.Duration, "duration")
+			if err != nil {
+				return fmt.Errorf("invalid duration in updated_occurrence: %w", err)
 			}
 			m.UpdatedOccurrences = append(m.UpdatedOccurrences, occ)
 		}
@@ -506,124 +375,37 @@ func (r *RecurrenceDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	var err error
+
 	// Handle Type (string from Meltano, int/float64 from other sources)
-	switch v := tmp.Type.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid type format: %w", err)
-			}
-			r.Type = val
-		}
-	case float64:
-		r.Type = int(v)
-	case int:
-		r.Type = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for type: %T", v)
-		}
+	r.Type, err = coerceInt(tmp.Type, "type")
+	if err != nil {
+		return err
 	}
 
-	// Handle RepeatInterval
-	switch v := tmp.RepeatInterval.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid repeat_interval format: %w", err)
-			}
-			r.RepeatInterval = val
-		}
-	case float64:
-		r.RepeatInterval = int(v)
-	case int:
-		r.RepeatInterval = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for repeat_interval: %T", v)
-		}
+	r.RepeatInterval, err = coerceInt(tmp.RepeatInterval, "repeat_interval")
+	if err != nil {
+		return err
 	}
 
-	// Handle MonthlyDay
-	switch v := tmp.MonthlyDay.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid monthly_day format: %w", err)
-			}
-			r.MonthlyDay = val
-		}
-	case float64:
-		r.MonthlyDay = int(v)
-	case int:
-		r.MonthlyDay = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for monthly_day: %T", v)
-		}
+	r.MonthlyDay, err = coerceInt(tmp.MonthlyDay, "monthly_day")
+	if err != nil {
+		return err
 	}
 
-	// Handle MonthlyWeek
-	switch v := tmp.MonthlyWeek.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid monthly_week format: %w", err)
-			}
-			r.MonthlyWeek = val
-		}
-	case float64:
-		r.MonthlyWeek = int(v)
-	case int:
-		r.MonthlyWeek = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for monthly_week: %T", v)
-		}
+	r.MonthlyWeek, err = coerceInt(tmp.MonthlyWeek, "monthly_week")
+	if err != nil {
+		return err
 	}
 
-	// Handle MonthlyWeekDay
-	switch v := tmp.MonthlyWeekDay.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid monthly_week_day format: %w", err)
-			}
-			r.MonthlyWeekDay = val
-		}
-	case float64:
-		r.MonthlyWeekDay = int(v)
-	case int:
-		r.MonthlyWeekDay = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for monthly_week_day: %T", v)
-		}
+	r.MonthlyWeekDay, err = coerceInt(tmp.MonthlyWeekDay, "monthly_week_day")
+	if err != nil {
+		return err
 	}
 
-	// Handle EndTimes
-	switch v := tmp.EndTimes.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid end_times format: %w", err)
-			}
-			r.EndTimes = val
-		}
-	case float64:
-		r.EndTimes = int(v)
-	case int:
-		r.EndTimes = v
-	default:
-		if v != nil {
-			return fmt.Errorf("invalid type for end_times: %T", v)
-		}
+	r.EndTimes, err = coerceInt(tmp.EndTimes, "end_times")
+	if err != nil {
+		return err
 	}
 
 	// Handle WeeklyDays

--- a/cmd/meeting-api/eventing/meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler.go
@@ -260,45 +260,28 @@ func (m *MeetingDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var err error
-
-	m.Duration, err = coerceInt(tmp.Duration, "duration")
-	if err != nil {
+	if err := coerceInt(&m.Duration, tmp.Duration, "duration"); err != nil {
 		return err
 	}
-
-	m.EarlyJoinTime, err = coerceInt(tmp.EarlyJoinTime, "early_join_time")
-	if err != nil {
+	if err := coerceInt(&m.EarlyJoinTime, tmp.EarlyJoinTime, "early_join_time"); err != nil {
 		return err
 	}
-
-	m.LastEndTime, err = coerceInt64(tmp.LastEndTime, "last_end_time")
-	if err != nil {
+	if err := coerceInt64(&m.LastEndTime, tmp.LastEndTime, "last_end_time"); err != nil {
 		return err
 	}
-
-	m.LastBulkRegistrantsJobFailedCount, err = coerceInt(tmp.LastBulkRegistrantsJobFailedCount, "last_bulk_registrants_job_failed_count")
-	if err != nil {
+	if err := coerceInt(&m.LastBulkRegistrantsJobFailedCount, tmp.LastBulkRegistrantsJobFailedCount, "last_bulk_registrants_job_failed_count"); err != nil {
 		return err
 	}
-
-	m.LastBulkRegistrantsJobWarningCount, err = coerceInt(tmp.LastBulkRegistrantsJobWarningCount, "last_bulk_registrants_job_warning_count")
-	if err != nil {
+	if err := coerceInt(&m.LastBulkRegistrantsJobWarningCount, tmp.LastBulkRegistrantsJobWarningCount, "last_bulk_registrants_job_warning_count"); err != nil {
 		return err
 	}
-
-	m.LastMailingListMembersSyncJobFailedCount, err = coerceInt(tmp.LastMailingListMembersSyncJobFailedCount, "last_mailing_list_members_sync_job_failed_count")
-	if err != nil {
+	if err := coerceInt(&m.LastMailingListMembersSyncJobFailedCount, tmp.LastMailingListMembersSyncJobFailedCount, "last_mailing_list_members_sync_job_failed_count"); err != nil {
 		return err
 	}
-
-	m.LastMailingListMembersSyncJobWarningCount, err = coerceInt(tmp.LastMailingListMembersSyncJobWarningCount, "last_mailing_list_members_sync_job_warning_count")
-	if err != nil {
+	if err := coerceInt(&m.LastMailingListMembersSyncJobWarningCount, tmp.LastMailingListMembersSyncJobWarningCount, "last_mailing_list_members_sync_job_warning_count"); err != nil {
 		return err
 	}
-
-	m.AutoEmailReminderTime, err = coerceInt(tmp.AutoEmailReminderTime, "auto_email_reminder_time")
-	if err != nil {
+	if err := coerceInt(&m.AutoEmailReminderTime, tmp.AutoEmailReminderTime, "auto_email_reminder_time"); err != nil {
 		return err
 	}
 
@@ -331,8 +314,7 @@ func (m *MeetingDBRaw) UnmarshalJSON(data []byte) error {
 				Recurrence:      occTmp.Recurrence,
 				AllFollowing:    occTmp.AllFollowing,
 			}
-			occ.Duration, err = coerceInt(occTmp.Duration, "duration")
-			if err != nil {
+			if err := coerceInt(&occ.Duration, occTmp.Duration, "duration"); err != nil {
 				return fmt.Errorf("invalid duration in updated_occurrence: %w", err)
 			}
 			m.UpdatedOccurrences = append(m.UpdatedOccurrences, occ)
@@ -375,36 +357,23 @@ func (r *RecurrenceDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var err error
-
 	// Handle Type (string from Meltano, int/float64 from other sources)
-	r.Type, err = coerceInt(tmp.Type, "type")
-	if err != nil {
+	if err := coerceInt(&r.Type, tmp.Type, "type"); err != nil {
 		return err
 	}
-
-	r.RepeatInterval, err = coerceInt(tmp.RepeatInterval, "repeat_interval")
-	if err != nil {
+	if err := coerceInt(&r.RepeatInterval, tmp.RepeatInterval, "repeat_interval"); err != nil {
 		return err
 	}
-
-	r.MonthlyDay, err = coerceInt(tmp.MonthlyDay, "monthly_day")
-	if err != nil {
+	if err := coerceInt(&r.MonthlyDay, tmp.MonthlyDay, "monthly_day"); err != nil {
 		return err
 	}
-
-	r.MonthlyWeek, err = coerceInt(tmp.MonthlyWeek, "monthly_week")
-	if err != nil {
+	if err := coerceInt(&r.MonthlyWeek, tmp.MonthlyWeek, "monthly_week"); err != nil {
 		return err
 	}
-
-	r.MonthlyWeekDay, err = coerceInt(tmp.MonthlyWeekDay, "monthly_week_day")
-	if err != nil {
+	if err := coerceInt(&r.MonthlyWeekDay, tmp.MonthlyWeekDay, "monthly_week_day"); err != nil {
 		return err
 	}
-
-	r.EndTimes, err = coerceInt(tmp.EndTimes, "end_times")
-	if err != nil {
+	if err := coerceInt(&r.EndTimes, tmp.EndTimes, "end_times"); err != nil {
 		return err
 	}
 

--- a/cmd/meeting-api/eventing/meeting_event_handler_test.go
+++ b/cmd/meeting-api/eventing/meeting_event_handler_test.go
@@ -48,3 +48,42 @@ func TestMeetingDBRawUnmarshalAutoEmailReminderTimeInvalid(t *testing.T) {
 		})
 	}
 }
+
+// updated_occurrences duration coercion: unknown JSON types (bool, object) are now
+// rejected rather than silently coerced to zero. This is a deliberate tightening over
+// the original switch which had no default case.
+func TestMeetingDBRawUnmarshalUpdatedOccurrenceDuration(t *testing.T) {
+	happyPath := []struct {
+		name    string
+		json    string
+		wantDur int
+	}{
+		{"int", `{"updated_occurrences":[{"duration":30}]}`, 30},
+		{"string", `{"updated_occurrences":[{"duration":"45"}]}`, 45},
+		{"float", `{"updated_occurrences":[{"duration":60.0}]}`, 60},
+		{"absent", `{"updated_occurrences":[{}]}`, 0},
+	}
+	for _, tt := range happyPath {
+		t.Run(tt.name, func(t *testing.T) {
+			var m MeetingDBRaw
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &m))
+			require.Len(t, m.UpdatedOccurrences, 1)
+			assert.Equal(t, tt.wantDur, m.UpdatedOccurrences[0].Duration)
+		})
+	}
+
+	invalidTypes := []struct {
+		name string
+		json string
+	}{
+		{"bool", `{"updated_occurrences":[{"duration":true}]}`},
+		{"object", `{"updated_occurrences":[{"duration":{}}]}`},
+		{"non-numeric string", `{"updated_occurrences":[{"duration":"soon"}]}`},
+	}
+	for _, tt := range invalidTypes {
+		t.Run(tt.name, func(t *testing.T) {
+			var m MeetingDBRaw
+			require.Error(t, json.Unmarshal([]byte(tt.json), &m))
+		})
+	}
+}

--- a/cmd/meeting-api/eventing/past_meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/past_meeting_event_handler.go
@@ -161,20 +161,13 @@ func (p *PastMeetingDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var err error
-
-	p.Duration, err = coerceInt(tmp.Duration, "duration")
-	if err != nil {
+	if err := coerceInt(&p.Duration, tmp.Duration, "duration"); err != nil {
 		return err
 	}
-
-	p.EarlyJoinTime, err = coerceInt(tmp.EarlyJoinTime, "early_join_time")
-	if err != nil {
+	if err := coerceInt(&p.EarlyJoinTime, tmp.EarlyJoinTime, "early_join_time"); err != nil {
 		return err
 	}
-
-	p.Type, err = coerceInt(tmp.Type, "type")
-	if err != nil {
+	if err := coerceInt(&p.Type, tmp.Type, "type"); err != nil {
 		return err
 	}
 

--- a/cmd/meeting-api/eventing/past_meeting_event_handler.go
+++ b/cmd/meeting-api/eventing/past_meeting_event_handler.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 
 	fgaconstants "github.com/linuxfoundation/lfx-v2-fga-sync/pkg/constants"
 	indexerConstants "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
@@ -162,55 +161,21 @@ func (p *PastMeetingDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Handle Duration
-	switch v := tmp.Duration.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid value for duration: %w", err)
-			}
-			p.Duration = val
-		}
-	case float64:
-		p.Duration = int(v)
-	case nil:
-	default:
-		return fmt.Errorf("invalid type for duration: %T", v)
+	var err error
+
+	p.Duration, err = coerceInt(tmp.Duration, "duration")
+	if err != nil {
+		return err
 	}
 
-	// Handle EarlyJoinTime
-	switch v := tmp.EarlyJoinTime.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid value for early_join_time: %w", err)
-			}
-			p.EarlyJoinTime = val
-		}
-	case float64:
-		p.EarlyJoinTime = int(v)
-	case nil:
-	default:
-		return fmt.Errorf("invalid type for early_join_time: %T", v)
+	p.EarlyJoinTime, err = coerceInt(tmp.EarlyJoinTime, "early_join_time")
+	if err != nil {
+		return err
 	}
 
-	// Handle Type
-	switch v := tmp.Type.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid value for type: %w", err)
-			}
-			p.Type = val
-		}
-	case float64:
-		p.Type = int(v)
-	case nil:
-	default:
-		return fmt.Errorf("invalid type for type: %T", v)
+	p.Type, err = coerceInt(tmp.Type, "type")
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/meeting-api/eventing/recording_event_handler.go
+++ b/cmd/meeting-api/eventing/recording_event_handler.go
@@ -105,18 +105,12 @@ func (r *RecordingDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var err error
-
-	r.RecordingCount, err = coerceInt(tmp.RecordingCount, "recording_count")
-	if err != nil {
+	if err := coerceInt(&r.RecordingCount, tmp.RecordingCount, "recording_count"); err != nil {
 		return err
 	}
-
-	r.TotalSize, err = coerceInt64(tmp.TotalSize, "total_size")
-	if err != nil {
+	if err := coerceInt64(&r.TotalSize, tmp.TotalSize, "total_size"); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -149,13 +143,9 @@ func (r *RecordingFileDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var err error
-
-	r.FileSize, err = coerceInt64(tmp.FileSize, "file_size")
-	if err != nil {
+	if err := coerceInt64(&r.FileSize, tmp.FileSize, "file_size"); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -182,13 +172,9 @@ func (r *RecordingSessionDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	var err error
-
-	r.TotalSize, err = coerceInt64(tmp.TotalSize, "total_size")
-	if err != nil {
+	if err := coerceInt64(&r.TotalSize, tmp.TotalSize, "total_size"); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/cmd/meeting-api/eventing/recording_event_handler.go
+++ b/cmd/meeting-api/eventing/recording_event_handler.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strconv"
 
 	indexerConstants "github.com/linuxfoundation/lfx-v2-indexer-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
@@ -106,38 +105,16 @@ func (r *RecordingDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	switch v := tmp.RecordingCount.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.Atoi(v)
-			if err != nil {
-				return fmt.Errorf("invalid value for recording_count: %w", err)
-			}
-			r.RecordingCount = val
-		}
-	case float64:
-		r.RecordingCount = int(v)
-	case nil:
-		// leave as zero value
-	default:
-		return fmt.Errorf("invalid type for recording_count: %T", v)
+	var err error
+
+	r.RecordingCount, err = coerceInt(tmp.RecordingCount, "recording_count")
+	if err != nil {
+		return err
 	}
 
-	switch v := tmp.TotalSize.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("invalid value for total_size: %w", err)
-			}
-			r.TotalSize = val
-		}
-	case float64:
-		r.TotalSize = int64(v)
-	case nil:
-		// leave as zero value
-	default:
-		return fmt.Errorf("invalid type for total_size: %T", v)
+	r.TotalSize, err = coerceInt64(tmp.TotalSize, "total_size")
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -172,21 +149,11 @@ func (r *RecordingFileDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	switch v := tmp.FileSize.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("invalid value for file_size: %w", err)
-			}
-			r.FileSize = val
-		}
-	case float64:
-		r.FileSize = int64(v)
-	case nil:
-		// leave as zero value
-	default:
-		return fmt.Errorf("invalid type for file_size: %T", v)
+	var err error
+
+	r.FileSize, err = coerceInt64(tmp.FileSize, "file_size")
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -215,21 +182,11 @@ func (r *RecordingSessionDBRaw) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	switch v := tmp.TotalSize.(type) {
-	case string:
-		if v != "" {
-			val, err := strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return fmt.Errorf("invalid value for total_size: %w", err)
-			}
-			r.TotalSize = val
-		}
-	case float64:
-		r.TotalSize = int64(v)
-	case nil:
-		// leave as zero value
-	default:
-		return fmt.Errorf("invalid type for total_size: %T", v)
+	var err error
+
+	r.TotalSize, err = coerceInt64(tmp.TotalSize, "total_size")
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/meeting-api/eventing/utils.go
+++ b/cmd/meeting-api/eventing/utils.go
@@ -5,6 +5,7 @@ package eventing
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -78,4 +79,54 @@ func parseName(fullName string) (firstName, lastName string) {
 	}
 	// First part is first name, everything else is last name
 	return parts[0], strings.Join(parts[1:], " ")
+}
+
+// coerceInt converts an interface{} decoded from JSON into an int.
+// Accepts string (numeric or empty), float64, int, and nil; returns an error for any other type.
+func coerceInt(v interface{}, field string) (int, error) {
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return 0, nil
+		}
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("invalid value for %s: %w", field, err)
+		}
+		return n, nil
+	case float64:
+		return int(val), nil
+	case int:
+		return val, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("invalid type for %s: %T", field, v)
+	}
+}
+
+// coerceInt64 converts an interface{} decoded from JSON into an int64.
+// Accepts string (numeric or empty), float64, int64, int, and nil; returns an error for any other type.
+func coerceInt64(v interface{}, field string) (int64, error) {
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return 0, nil
+		}
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid value for %s: %w", field, err)
+		}
+		return n, nil
+	case float64:
+		return int64(val), nil
+	case int64:
+		return val, nil
+	case int:
+		return int64(val), nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("invalid type for %s: %T", field, v)
+	}
 }

--- a/cmd/meeting-api/eventing/utils.go
+++ b/cmd/meeting-api/eventing/utils.go
@@ -81,52 +81,54 @@ func parseName(fullName string) (firstName, lastName string) {
 	return parts[0], strings.Join(parts[1:], " ")
 }
 
-// coerceInt converts an interface{} decoded from JSON into an int.
+// coerceInt decodes a JSON-decoded interface{} into *dest.
 // Accepts string (numeric or empty), float64, int, and nil; returns an error for any other type.
-func coerceInt(v interface{}, field string) (int, error) {
+func coerceInt(dest *int, v interface{}, field string) error {
 	switch val := v.(type) {
 	case string:
 		if val == "" {
-			return 0, nil
+			return nil
 		}
 		n, err := strconv.Atoi(val)
 		if err != nil {
-			return 0, fmt.Errorf("invalid value for %s: %w", field, err)
+			return fmt.Errorf("invalid value for %s: %w", field, err)
 		}
-		return n, nil
+		*dest = n
 	case float64:
-		return int(val), nil
+		*dest = int(val)
 	case int:
-		return val, nil
+		*dest = val
 	case nil:
-		return 0, nil
+		// leave as zero value
 	default:
-		return 0, fmt.Errorf("invalid type for %s: %T", field, v)
+		return fmt.Errorf("invalid type for %s: %T", field, v)
 	}
+	return nil
 }
 
-// coerceInt64 converts an interface{} decoded from JSON into an int64.
+// coerceInt64 decodes a JSON-decoded interface{} into *dest.
 // Accepts string (numeric or empty), float64, int64, int, and nil; returns an error for any other type.
-func coerceInt64(v interface{}, field string) (int64, error) {
+func coerceInt64(dest *int64, v interface{}, field string) error {
 	switch val := v.(type) {
 	case string:
 		if val == "" {
-			return 0, nil
+			return nil
 		}
 		n, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("invalid value for %s: %w", field, err)
+			return fmt.Errorf("invalid value for %s: %w", field, err)
 		}
-		return n, nil
+		*dest = n
 	case float64:
-		return int64(val), nil
+		*dest = int64(val)
 	case int64:
-		return val, nil
+		*dest = val
 	case int:
-		return int64(val), nil
+		*dest = int64(val)
 	case nil:
-		return 0, nil
+		// leave as zero value
 	default:
-		return 0, fmt.Errorf("invalid type for %s: %T", field, v)
+		return fmt.Errorf("invalid type for %s: %T", field, v)
 	}
+	return nil
 }

--- a/cmd/meeting-api/eventing/utils.go
+++ b/cmd/meeting-api/eventing/utils.go
@@ -99,7 +99,7 @@ func coerceInt(dest *int, v interface{}, field string) error {
 	case int:
 		*dest = val
 	case nil:
-		// leave as zero value
+		// leave dest unchanged
 	default:
 		return fmt.Errorf("invalid type for %s: %T", field, v)
 	}
@@ -126,7 +126,7 @@ func coerceInt64(dest *int64, v interface{}, field string) error {
 	case int:
 		*dest = int64(val)
 	case nil:
-		// leave as zero value
+		// leave dest unchanged
 	default:
 		return fmt.Errorf("invalid type for %s: %T", field, v)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #216 — during review of that PR, the repeated type-switch pattern across all event handlers was recognized as an opportunity for a shared helper. This PR extracts that common coercion logic.

- Adds two package-level helpers in `utils.go`: `coerceInt` and `coerceInt64`, which handle the standard v1-JSON coercion pattern (string → parse, float64 → truncate, int/int64 → pass through, nil → leave dest unchanged, anything else → error)
- Replaces 19 identical 12-line type-switch blocks across `meeting_event_handler.go`, `past_meeting_event_handler.go`, `recording_event_handler.go`, and `attachment_event_handler.go`
- Removes the `strconv` import from all four handler files (it moves into `utils.go`)
- Net: **-274 lines**, no behavior change (except `updated_occurrences` duration now rejects unknown JSON types rather than silently zeroing — intentional tightening, covered by `TestMeetingDBRawUnmarshalUpdatedOccurrenceDuration`)

## Test plan

- [x] `go build ./...` — passes
- [x] `go test -race ./...` — all green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./cmd/meeting-api/eventing/...` — one pre-existing `errcheck` finding in `event_processor.go` (not introduced by this PR)

## Related

Follow-up to https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/216

🤖 Generated with [Claude Code](https://claude.ai/code)