### PR TITLE
fix: stamp updated_by on meetings updated via lfx-v2-meeting-service

### DIFF
--- a/internal/service/itx/meeting_service.go
+++ b/internal/service/itx/meeting_service.go
@@ -44,7 +44,7 @@ func (s *MeetingService) CreateMeeting(ctx context.Context, req *models.CreateIT
 	}
 
 	itxReq := s.transformToITXRequest(req)
-	itxReq.CreatedBy = s.buildCreatedBy(ctx)
+	itxReq.CreatedBy = s.buildRequestingUser(ctx)
 	resp, err := s.meetingClient.CreateZoomMeeting(ctx, itxReq)
 	if err != nil {
 		return nil, err
@@ -85,6 +85,10 @@ func (s *MeetingService) UpdateMeeting(ctx context.Context, meetingID string, re
 	}
 
 	itxReq := s.transformToITXRequest(req)
+	// Stamp updated_by from the authenticated principal. ITX only overwrites the stored
+	// updated_by / updated_by_list when this field is non-zero, so omitting it leaves a
+	// stale value on the record (typically the original creator or last PIS updater).
+	itxReq.UpdatedBy = s.buildRequestingUser(ctx)
 	err := s.meetingClient.UpdateZoomMeeting(ctx, meetingID, itxReq)
 	if err != nil {
 		return err
@@ -158,12 +162,14 @@ func validateMeetingRequest(req *models.CreateITXMeetingRequest) error {
 	return nil
 }
 
-// buildCreatedBy resolves the requesting user's identity (from the JWT principal stashed in
-// ctx by the auth middleware) into an itx.User to stamp as the meeting creator. Returns nil
-// when there is no principal to resolve, or when resolution isn't possible (never blocks
-// meeting creation on identity-resolution failures — degrades to nil, or to a minimal
-// {username, email} record when metadata lookup fails but we still have those from the JWT).
-func (s *MeetingService) buildCreatedBy(ctx context.Context) *itx.User {
+// buildRequestingUser resolves the requesting user's identity (from the JWT principal
+// stashed in ctx by the auth middleware) into an itx.User. Used to stamp the meeting
+// creator on create requests and the updater on update requests. Returns nil when there
+// is no principal to resolve, or when resolution isn't possible (never blocks meeting
+// create/update on identity-resolution failures — degrades to nil, or to a minimal
+// {username, email} record when metadata lookup fails but we still have those from the
+// JWT).
+func (s *MeetingService) buildRequestingUser(ctx context.Context) *itx.User {
 	principal, _ := ctx.Value(constants.PrincipalContextID).(string)
 	if principal == "" {
 		return nil
@@ -176,21 +182,21 @@ func (s *MeetingService) buildCreatedBy(ctx context.Context) *itx.User {
 
 	profile, err := s.userMetadata.ResolveProfile(ctx, principal)
 	if err != nil {
-		slog.WarnContext(ctx, "failed to resolve user profile for meeting created_by; stamping username/email only",
+		slog.WarnContext(ctx, "failed to resolve user profile for meeting created_by/updated_by; stamping username/email only",
 			"username", principal, "err", err)
 		return &itx.User{Username: principal, Email: email}
 	}
 
-	createdBy := &itx.User{
+	user := &itx.User{
 		Username:       principal,
 		Name:           profile.Name,
 		Email:          profile.Email,
 		ProfilePicture: profile.AvatarURL,
 	}
-	if createdBy.Email == "" {
-		createdBy.Email = email
+	if user.Email == "" {
+		user.Email = email
 	}
-	return createdBy
+	return user
 }
 
 // transformToITXRequest transforms domain request to ITX request format

--- a/internal/service/itx/meeting_service_test.go
+++ b/internal/service/itx/meeting_service_test.go
@@ -155,25 +155,86 @@ func TestMeetingService_CreateMeeting_CreatedBy(t *testing.T) {
 	})
 }
 
-func TestMeetingService_UpdateMeeting_NeverSetsCreatedBy(t *testing.T) {
-	client := &fakeMeetingClient{}
-	reader := &fakeUserMetadataReader{
-		profile: &domain.UserProfile{Username: "alice", Name: "Alice Example", Email: "alice@example.com"},
-	}
-	svc := NewMeetingService(client, noOpIDMapper{}, reader)
-
-	req := &models.CreateITXMeetingRequest{
-		ID:         "meeting-1",
-		ProjectUID: "proj-1",
-		Title:      "Test Meeting",
-		StartTime:  "2026-01-01T00:00:00Z",
-		Duration:   30,
-		Visibility: itx.MeetingVisibilityPublic,
+func TestMeetingService_UpdateMeeting_StampsUpdatedByNotCreatedBy(t *testing.T) {
+	baseReq := func() *models.CreateITXMeetingRequest {
+		return &models.CreateITXMeetingRequest{
+			ID:         "meeting-1",
+			ProjectUID: "proj-1",
+			Title:      "Test Meeting",
+			StartTime:  "2026-01-01T00:00:00Z",
+			Duration:   30,
+			Visibility: itx.MeetingVisibilityPublic,
+		}
 	}
 
-	err := svc.UpdateMeeting(ctxWithPrincipal("alice", "alice@example.com"), "meeting-1", req)
-	require.NoError(t, err)
-	require.NotNil(t, client.lastUpdateReq)
-	assert.Nil(t, client.lastUpdateReq.CreatedBy, "update must never stamp created_by, to avoid overwriting the original creator")
-	assert.Empty(t, reader.calls, "resolver should not be invoked on update")
+	t.Run("stamps updated_by from resolved profile and never touches created_by", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		reader := &fakeUserMetadataReader{
+			profile: &domain.UserProfile{Username: "alice", Name: "Alice Example", AvatarURL: "https://example.com/a.jpg", Email: "alice@example.com"},
+		}
+		svc := NewMeetingService(client, noOpIDMapper{}, reader)
+
+		err := svc.UpdateMeeting(ctxWithPrincipal("alice", "alice@heimdall.example.com"), "meeting-1", baseReq())
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq)
+		assert.Nil(t, client.lastUpdateReq.CreatedBy, "update must never stamp created_by, to avoid overwriting the original creator")
+
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy, "update must stamp updated_by so ITX overwrites the stored value instead of preserving stale data")
+		got := client.lastUpdateReq.UpdatedBy
+		assert.Equal(t, "alice", got.Username)
+		assert.Equal(t, "Alice Example", got.Name)
+		assert.Equal(t, "https://example.com/a.jpg", got.ProfilePicture)
+		// The resolved profile email (fresh from the auth service) takes precedence over the
+		// JWT-claimed email, which may be stale on a long-lived token.
+		assert.Equal(t, "alice@example.com", got.Email)
+		assert.Equal(t, []string{"alice"}, reader.calls)
+	})
+
+	t.Run("falls back to JWT email when profile has none", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		reader := &fakeUserMetadataReader{
+			profile: &domain.UserProfile{Username: "alice", Name: "Alice Example"},
+		}
+		svc := NewMeetingService(client, noOpIDMapper{}, reader)
+
+		err := svc.UpdateMeeting(ctxWithPrincipal("alice", "alice@heimdall.example.com"), "meeting-1", baseReq())
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "alice@heimdall.example.com", client.lastUpdateReq.UpdatedBy.Email)
+	})
+
+	t.Run("degrades to username/email when resolver errors", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		reader := &fakeUserMetadataReader{err: errors.New("auth service unavailable")}
+		svc := NewMeetingService(client, noOpIDMapper{}, reader)
+
+		err := svc.UpdateMeeting(ctxWithPrincipal("bob", "bob@heimdall.example.com"), "meeting-1", baseReq())
+		require.NoError(t, err, "resolver failures must never block meeting updates")
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "bob", client.lastUpdateReq.UpdatedBy.Username)
+		assert.Equal(t, "bob@heimdall.example.com", client.lastUpdateReq.UpdatedBy.Email)
+		assert.Empty(t, client.lastUpdateReq.UpdatedBy.Name)
+	})
+
+	t.Run("degrades to username/email when reader is nil (NATS disabled)", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		svc := NewMeetingService(client, noOpIDMapper{}, nil)
+
+		err := svc.UpdateMeeting(ctxWithPrincipal("carol", "carol@heimdall.example.com"), "meeting-1", baseReq())
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "carol", client.lastUpdateReq.UpdatedBy.Username)
+	})
+
+	t.Run("omits updated_by when there is no principal in context", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{Username: "alice"}}
+		svc := NewMeetingService(client, noOpIDMapper{}, reader)
+
+		err := svc.UpdateMeeting(context.Background(), "meeting-1", baseReq())
+		require.NoError(t, err)
+		assert.Nil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Nil(t, client.lastUpdateReq.CreatedBy)
+		assert.Empty(t, reader.calls, "resolver should not be called without a principal")
+	})
 }

--- a/pkg/models/itx/meetings.go
+++ b/pkg/models/itx/meetings.go
@@ -83,6 +83,12 @@ type CreateZoomMeetingRequest struct {
 	// whatever the caller sends, so this is never set on update requests).
 	CreatedBy *User `json:"created_by,omitempty"`
 
+	// UpdatedBy identifies the requesting user on update requests. ITX only overwrites the
+	// stored updated_by / updated_by_list when this field is non-zero, so it must be
+	// populated on every update to keep the meeting audit trail accurate. Leave nil on
+	// create requests.
+	UpdatedBy *User `json:"updated_by,omitempty"`
+
 	// Update notification
 	Note string `json:"note,omitempty"`
 }


### PR DESCRIPTION
Meeting updates never populated `updated_by` since `CreateZoomMeetingRequest` had no field for it and `UpdateMeeting` stamped nothing. ITX only overwrites the stored `updated_by` / `updated_by_list` when the field is non-zero, so edits made through the LFX v2 UI/API silently preserved whatever was there before (typically the original creator or the last PIS updater), leaving the audit trail incorrect and undermining `updated_by_list`.

Add `UpdatedBy` to `CreateZoomMeetingRequest` and stamp it on every update using the same JWT-principal + auth-service profile resolution as `created_by`, degrading gracefully (never blocking meeting updates) if resolution fails or NATS is unavailable. Rename `buildCreatedBy` to `buildRequestingUser` to reflect its shared use, and never set `created_by` on updates so we don't overwrite the original creator. Registrant and past-meeting updates are similarly asymmetric today and are left as follow-ups.

Issue: [LFXV2-2819](https://linuxfoundation.atlassian.net/browse/LFXV2-2819)

[LFXV2-2819]: https://linuxfoundation.atlassian.net/browse/LFXV2-2819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ