### PR TITLE
fix: stamp created_by/updated_by/modified_by on remaining ITX proxy writes

### DIFF
--- a/cmd/meeting-api/api_itx_meeting_attachments.go
+++ b/cmd/meeting-api/api_itx_meeting_attachments.go
@@ -5,22 +5,16 @@ package main
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/service"
 	meetingservice "github.com/linuxfoundation/lfx-v2-meeting-service/gen/meeting_service"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 )
 
-// CreateItxMeetingAttachment creates a meeting attachment via ITX proxy
+// CreateItxMeetingAttachment creates a meeting attachment via ITX proxy.
+// created_by is stamped by MeetingAttachmentService from the principal on ctx
+// (populated by the JWT auth middleware), so we don't re-parse the token here.
 func (s *MeetingsAPI) CreateItxMeetingAttachment(ctx context.Context, p *meetingservice.CreateItxMeetingAttachmentPayload) (*meetingservice.ITXMeetingAttachment, error) {
-	username, err := s.authService.ParsePrincipal(ctx, *p.BearerToken, slog.Default())
-	if err != nil {
-		slog.WarnContext(ctx, "failed to parse username from JWT token", logging.ErrKey, err)
-		return nil, handleError(domain.NewValidationError("failed to parse username from authorization token"))
-	}
-	req := service.ConvertGoaToITXCreateMeetingAttachment(p, username)
+	req := service.ConvertGoaToITXCreateMeetingAttachment(p)
 	resp, err := s.itxMeetingAttachmentService.CreateMeetingAttachment(ctx, p.MeetingID, req)
 	if err != nil {
 		return nil, handleError(err)
@@ -37,15 +31,11 @@ func (s *MeetingsAPI) GetItxMeetingAttachment(ctx context.Context, p *meetingser
 	return service.ConvertITXMeetingAttachmentToGoa(resp), nil
 }
 
-// UpdateItxMeetingAttachment updates a meeting attachment via ITX proxy
+// UpdateItxMeetingAttachment updates a meeting attachment via ITX proxy.
+// updated_by is stamped by MeetingAttachmentService from the principal on ctx.
 func (s *MeetingsAPI) UpdateItxMeetingAttachment(ctx context.Context, p *meetingservice.UpdateItxMeetingAttachmentPayload) error {
-	username, err := s.authService.ParsePrincipal(ctx, *p.BearerToken, slog.Default())
-	if err != nil {
-		slog.WarnContext(ctx, "failed to parse username from JWT token", logging.ErrKey, err)
-		return handleError(domain.NewValidationError("failed to parse username from authorization token"))
-	}
-	req := service.ConvertGoaToITXUpdateMeetingAttachment(p, username)
-	err = s.itxMeetingAttachmentService.UpdateMeetingAttachment(ctx, p.MeetingID, p.AttachmentID, req)
+	req := service.ConvertGoaToITXUpdateMeetingAttachment(p)
+	err := s.itxMeetingAttachmentService.UpdateMeetingAttachment(ctx, p.MeetingID, p.AttachmentID, req)
 	if err != nil {
 		return handleError(err)
 	}
@@ -61,14 +51,11 @@ func (s *MeetingsAPI) DeleteItxMeetingAttachment(ctx context.Context, p *meeting
 	return nil
 }
 
-// CreateItxMeetingAttachmentPresign generates a presigned URL for meeting attachment upload via ITX proxy
+// CreateItxMeetingAttachmentPresign generates a presigned URL for meeting attachment
+// upload via ITX proxy. created_by is stamped by MeetingAttachmentService from the
+// principal on ctx.
 func (s *MeetingsAPI) CreateItxMeetingAttachmentPresign(ctx context.Context, p *meetingservice.CreateItxMeetingAttachmentPresignPayload) (*meetingservice.ITXMeetingAttachmentPresignResponse, error) {
-	username, err := s.authService.ParsePrincipal(ctx, *p.BearerToken, slog.Default())
-	if err != nil {
-		slog.WarnContext(ctx, "failed to parse username from JWT token", logging.ErrKey, err)
-		return nil, handleError(domain.NewValidationError("failed to parse username from authorization token"))
-	}
-	req := service.ConvertGoaToITXCreateMeetingAttachmentPresign(p, username)
+	req := service.ConvertGoaToITXCreateMeetingAttachmentPresign(p)
 	resp, err := s.itxMeetingAttachmentService.CreateMeetingAttachmentPresignURL(ctx, p.MeetingID, req)
 	if err != nil {
 		return nil, handleError(err)

--- a/cmd/meeting-api/api_itx_past_meeting_attachments.go
+++ b/cmd/meeting-api/api_itx_past_meeting_attachments.go
@@ -5,22 +5,16 @@ package main
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/cmd/meeting-api/service"
 	meetingservice "github.com/linuxfoundation/lfx-v2-meeting-service/gen/meeting_service"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/logging"
 )
 
-// CreateItxPastMeetingAttachment creates a past meeting attachment via ITX proxy
+// CreateItxPastMeetingAttachment creates a past meeting attachment via ITX proxy.
+// created_by is stamped by PastMeetingAttachmentService from the principal on ctx
+// (populated by the JWT auth middleware), so we don't re-parse the token here.
 func (s *MeetingsAPI) CreateItxPastMeetingAttachment(ctx context.Context, p *meetingservice.CreateItxPastMeetingAttachmentPayload) (*meetingservice.ITXPastMeetingAttachment, error) {
-	username, err := s.authService.ParsePrincipal(ctx, *p.BearerToken, slog.Default())
-	if err != nil {
-		slog.WarnContext(ctx, "failed to parse username from JWT token", logging.ErrKey, err)
-		return nil, handleError(domain.NewValidationError("failed to parse username from authorization token"))
-	}
-	req := service.ConvertGoaToITXCreatePastMeetingAttachment(p, username)
+	req := service.ConvertGoaToITXCreatePastMeetingAttachment(p)
 	resp, err := s.itxPastMeetingAttachmentService.CreatePastMeetingAttachment(ctx, p.MeetingAndOccurrenceID, req)
 	if err != nil {
 		return nil, handleError(err)
@@ -37,15 +31,11 @@ func (s *MeetingsAPI) GetItxPastMeetingAttachment(ctx context.Context, p *meetin
 	return service.ConvertITXPastMeetingAttachmentToGoa(resp), nil
 }
 
-// UpdateItxPastMeetingAttachment updates a past meeting attachment via ITX proxy
+// UpdateItxPastMeetingAttachment updates a past meeting attachment via ITX proxy.
+// updated_by is stamped by PastMeetingAttachmentService from the principal on ctx.
 func (s *MeetingsAPI) UpdateItxPastMeetingAttachment(ctx context.Context, p *meetingservice.UpdateItxPastMeetingAttachmentPayload) error {
-	username, err := s.authService.ParsePrincipal(ctx, *p.BearerToken, slog.Default())
-	if err != nil {
-		slog.WarnContext(ctx, "failed to parse username from JWT token", logging.ErrKey, err)
-		return handleError(domain.NewValidationError("failed to parse username from authorization token"))
-	}
-	req := service.ConvertGoaToITXUpdatePastMeetingAttachment(p, username)
-	err = s.itxPastMeetingAttachmentService.UpdatePastMeetingAttachment(ctx, p.MeetingAndOccurrenceID, p.AttachmentID, req)
+	req := service.ConvertGoaToITXUpdatePastMeetingAttachment(p)
+	err := s.itxPastMeetingAttachmentService.UpdatePastMeetingAttachment(ctx, p.MeetingAndOccurrenceID, p.AttachmentID, req)
 	if err != nil {
 		return handleError(err)
 	}
@@ -61,14 +51,11 @@ func (s *MeetingsAPI) DeleteItxPastMeetingAttachment(ctx context.Context, p *mee
 	return nil
 }
 
-// CreateItxPastMeetingAttachmentPresign generates a presigned URL for past meeting attachment upload via ITX proxy
+// CreateItxPastMeetingAttachmentPresign generates a presigned URL for past meeting
+// attachment upload via ITX proxy. created_by is stamped by
+// PastMeetingAttachmentService from the principal on ctx.
 func (s *MeetingsAPI) CreateItxPastMeetingAttachmentPresign(ctx context.Context, p *meetingservice.CreateItxPastMeetingAttachmentPresignPayload) (*meetingservice.ITXPastMeetingAttachmentPresignResponse, error) {
-	username, err := s.authService.ParsePrincipal(ctx, *p.BearerToken, slog.Default())
-	if err != nil {
-		slog.WarnContext(ctx, "failed to parse username from JWT token", logging.ErrKey, err)
-		return nil, handleError(domain.NewValidationError("failed to parse username from authorization token"))
-	}
-	req := service.ConvertGoaToITXCreatePastMeetingAttachmentPresign(p, username)
+	req := service.ConvertGoaToITXCreatePastMeetingAttachmentPresign(p)
 	resp, err := s.itxPastMeetingAttachmentService.CreatePastMeetingAttachmentPresignURL(ctx, p.MeetingAndOccurrenceID, req)
 	if err != nil {
 		return nil, handleError(err)

--- a/cmd/meeting-api/main.go
+++ b/cmd/meeting-api/main.go
@@ -110,22 +110,23 @@ func run() int {
 
 	natsURL := os.Getenv("NATS_URL")
 
-	// User metadata reader (LFXV2-2809): resolves the requesting principal's display
-	// profile (name/email/avatar) via the auth service, token-free, so newly created
-	// meetings can stamp created_by. Uses its own NATS connection since it's needed
-	// regardless of whether ID mapping or event processing are enabled; nil (and a
-	// warning) when NATS isn't configured or the connection fails, so meeting creation
-	// still works, just with created_by limited to the JWT-derived username/email
-	// (profile enrichment such as name/avatar is unavailable).
+	// User metadata reader (LFXV2-2809 / LFXV2-2821): resolves the requesting principal's
+	// display profile (name/email/avatar) via the auth service, token-free, so ITX writes
+	// (meetings, registrants, past meetings, invitees, attendees, summaries, attachments)
+	// can stamp created_by / updated_by / modified_by. Uses its own NATS connection since
+	// it's needed regardless of whether ID mapping or event processing are enabled; nil
+	// (and a warning) when NATS isn't configured or the connection fails, so writes still
+	// work, just with audit fields limited to the JWT-derived username/email (profile
+	// enrichment such as name/avatar is unavailable).
 	var userMetadataReader domain.UserMetadataReader
 	var userMetadataNatsConn *natsgo.Conn
 	if natsURL == "" {
-		slog.WarnContext(ctx, "NATS_URL not set; meeting created_by profile enrichment unavailable")
+		slog.WarnContext(ctx, "NATS_URL not set; ITX audit-stamp profile enrichment unavailable (created_by/updated_by/modified_by limited to JWT username/email)")
 	} else {
 		nc, err := natsgo.Connect(natsURL)
 		if err != nil {
 			slog.With(logging.ErrKey, err).WarnContext(ctx,
-				"failed to connect to NATS for user metadata reader; meeting created_by profile enrichment unavailable")
+				"failed to connect to NATS for user metadata reader; ITX audit-stamp profile enrichment unavailable")
 		} else {
 			userMetadataNatsConn = nc
 			userMetadataReader = natsinfra.NewUserMetadataReader(nc, slog.Default())
@@ -146,12 +147,12 @@ func run() int {
 	}
 	itxProxyClient := proxy.NewClient(itxProxyConfig)
 	itxMeetingService := itxservice.NewMeetingService(itxProxyClient, idMapper, userMetadataReader)
-	itxRegistrantService := itxservice.NewRegistrantService(itxProxyClient, idMapper)
-	itxPastMeetingService := itxservice.NewPastMeetingService(itxProxyClient, idMapper)
-	itxPastMeetingSummaryService := itxservice.NewPastMeetingSummaryService(itxProxyClient)
-	itxPastMeetingParticipantService := itxservice.NewPastMeetingParticipantService(itxProxyClient, idMapper)
-	itxMeetingAttachmentService := itxservice.NewMeetingAttachmentService(itxProxyClient)
-	itxPastMeetingAttachmentService := itxservice.NewPastMeetingAttachmentService(itxProxyClient)
+	itxRegistrantService := itxservice.NewRegistrantService(itxProxyClient, idMapper, userMetadataReader)
+	itxPastMeetingService := itxservice.NewPastMeetingService(itxProxyClient, idMapper, userMetadataReader)
+	itxPastMeetingSummaryService := itxservice.NewPastMeetingSummaryService(itxProxyClient, userMetadataReader)
+	itxPastMeetingParticipantService := itxservice.NewPastMeetingParticipantService(itxProxyClient, idMapper, userMetadataReader)
+	itxMeetingAttachmentService := itxservice.NewMeetingAttachmentService(itxProxyClient, userMetadataReader)
+	itxPastMeetingAttachmentService := itxservice.NewPastMeetingAttachmentService(itxProxyClient, userMetadataReader)
 	authService := service.NewAuthService(jwtAuth)
 	slog.InfoContext(ctx, "ITX proxy client initialized")
 

--- a/cmd/meeting-api/service/itx_attachment_converters.go
+++ b/cmd/meeting-api/service/itx_attachment_converters.go
@@ -12,16 +12,19 @@ import (
 // ============================================================================
 // Meeting Attachment Converters
 // ============================================================================
+//
+// Note: created_by / updated_by are stamped by the attachment services (see
+// internal/service/itx/{meeting,past_meeting}_attachment_service.go), not here.
+// That keeps the enrichment path (JWT principal → UserMetadataReader → full
+// profile) in the same place across all ITX endpoints; converters just shape
+// the payload.
 
 // ConvertGoaToITXCreateMeetingAttachment converts Goa payload to ITX request
-func ConvertGoaToITXCreateMeetingAttachment(payload *meetingservice.CreateItxMeetingAttachmentPayload, username string) *itx.CreateMeetingAttachmentRequest {
+func ConvertGoaToITXCreateMeetingAttachment(payload *meetingservice.CreateItxMeetingAttachmentPayload) *itx.CreateMeetingAttachmentRequest {
 	req := &itx.CreateMeetingAttachmentRequest{
 		Type:     payload.Type,
 		Category: payload.Category,
 		Name:     payload.Name,
-		CreatedBy: &itx.CreatedUpdatedBy{
-			Username: username,
-		},
 	}
 
 	if payload.Link != nil {
@@ -36,14 +39,11 @@ func ConvertGoaToITXCreateMeetingAttachment(payload *meetingservice.CreateItxMee
 }
 
 // ConvertGoaToITXUpdateMeetingAttachment converts Goa payload to ITX request
-func ConvertGoaToITXUpdateMeetingAttachment(payload *meetingservice.UpdateItxMeetingAttachmentPayload, username string) *itx.UpdateMeetingAttachmentRequest {
+func ConvertGoaToITXUpdateMeetingAttachment(payload *meetingservice.UpdateItxMeetingAttachmentPayload) *itx.UpdateMeetingAttachmentRequest {
 	req := &itx.UpdateMeetingAttachmentRequest{
 		Type:     payload.Type,
 		Category: payload.Category,
 		Name:     payload.Name,
-		UpdatedBy: &itx.CreatedUpdatedBy{
-			Username: username,
-		},
 	}
 
 	if payload.Link != nil {
@@ -58,14 +58,11 @@ func ConvertGoaToITXUpdateMeetingAttachment(payload *meetingservice.UpdateItxMee
 }
 
 // ConvertGoaToITXCreateMeetingAttachmentPresign converts Goa payload to ITX request
-func ConvertGoaToITXCreateMeetingAttachmentPresign(payload *meetingservice.CreateItxMeetingAttachmentPresignPayload, username string) *itx.CreateAttachmentPresignRequest {
+func ConvertGoaToITXCreateMeetingAttachmentPresign(payload *meetingservice.CreateItxMeetingAttachmentPresignPayload) *itx.CreateAttachmentPresignRequest {
 	req := &itx.CreateAttachmentPresignRequest{
 		Name:     payload.Name,
 		FileSize: payload.FileSize,
 		FileType: payload.FileType,
-		CreatedBy: &itx.CreatedUpdatedBy{
-			Username: username,
-		},
 	}
 
 	if payload.Description != nil {
@@ -150,14 +147,11 @@ func ConvertITXMeetingAttachmentPresignToGoa(resp *itx.MeetingAttachmentPresignR
 // ============================================================================
 
 // ConvertGoaToITXCreatePastMeetingAttachment converts Goa payload to ITX request
-func ConvertGoaToITXCreatePastMeetingAttachment(payload *meetingservice.CreateItxPastMeetingAttachmentPayload, username string) *itx.CreatePastMeetingAttachmentRequest {
+func ConvertGoaToITXCreatePastMeetingAttachment(payload *meetingservice.CreateItxPastMeetingAttachmentPayload) *itx.CreatePastMeetingAttachmentRequest {
 	req := &itx.CreatePastMeetingAttachmentRequest{
 		Type:     payload.Type,
 		Category: payload.Category,
 		Name:     payload.Name,
-		CreatedBy: &itx.CreatedUpdatedBy{
-			Username: username,
-		},
 	}
 
 	if payload.Link != nil {
@@ -172,14 +166,11 @@ func ConvertGoaToITXCreatePastMeetingAttachment(payload *meetingservice.CreateIt
 }
 
 // ConvertGoaToITXUpdatePastMeetingAttachment converts Goa payload to ITX request
-func ConvertGoaToITXUpdatePastMeetingAttachment(payload *meetingservice.UpdateItxPastMeetingAttachmentPayload, username string) *itx.UpdatePastMeetingAttachmentRequest {
+func ConvertGoaToITXUpdatePastMeetingAttachment(payload *meetingservice.UpdateItxPastMeetingAttachmentPayload) *itx.UpdatePastMeetingAttachmentRequest {
 	req := &itx.UpdatePastMeetingAttachmentRequest{
 		Type:     payload.Type,
 		Category: payload.Category,
 		Name:     payload.Name,
-		UpdatedBy: &itx.CreatedUpdatedBy{
-			Username: username,
-		},
 	}
 
 	if payload.Link != nil {
@@ -194,14 +185,11 @@ func ConvertGoaToITXUpdatePastMeetingAttachment(payload *meetingservice.UpdateIt
 }
 
 // ConvertGoaToITXCreatePastMeetingAttachmentPresign converts Goa payload to ITX request
-func ConvertGoaToITXCreatePastMeetingAttachmentPresign(payload *meetingservice.CreateItxPastMeetingAttachmentPresignPayload, username string) *itx.CreateAttachmentPresignRequest {
+func ConvertGoaToITXCreatePastMeetingAttachmentPresign(payload *meetingservice.CreateItxPastMeetingAttachmentPresignPayload) *itx.CreateAttachmentPresignRequest {
 	req := &itx.CreateAttachmentPresignRequest{
 		Name:     payload.Name,
 		FileSize: payload.FileSize,
 		FileType: payload.FileType,
-		CreatedBy: &itx.CreatedUpdatedBy{
-			Username: username,
-		},
 	}
 
 	if payload.Description != nil {

--- a/cmd/meeting-api/service/itx_past_meeting_summary_converters.go
+++ b/cmd/meeting-api/service/itx_past_meeting_summary_converters.go
@@ -27,7 +27,10 @@ func ConvertUpdatePastMeetingSummaryPayload(payload *meetingservice.UpdateItxPas
 	if payload.Approved != nil {
 		req.Approved = payload.Approved
 	}
-	// Note: ModifiedBy is derived from JWT token in the ITX service, not from payload
+	// ModifiedBy is stamped by PastMeetingSummaryService from the authenticated
+	// principal (see internal/service/itx/past_meeting_summary_service.go); we don't
+	// try to derive it from the JWT here because ITX persists whatever the caller
+	// sends and leaving it blank produces a null audit entry.
 
 	return req
 }

--- a/docs/api-contracts/itx-meeting-attachments-api.md
+++ b/docs/api-contracts/itx-meeting-attachments-api.md
@@ -2,6 +2,25 @@
 
 This document details the API contracts for meeting attachments endpoints between the LFX v2 Meeting Service proxy API and the underlying ITX Zoom API.
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX attachment write requests so ITX records who touched each attachment. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on `POST` (create) requests, including the presigned-upload-URL request (ITX persists an attachment record with `file_upload_status="ongoing"` at the presign step).
+- `updated_by` — stamped on `PUT` (update) requests.
+
+Shape (attachment endpoints use the reduced `{ username, name, email }` shape — no `profile_picture`):
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com"
+}
+```
+
+The name / email are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write. Prior to July 2026 the attachment endpoints only sent `{ username }`; the `name` / `email` enrichment was added to bring them in line with the meeting endpoints.
+
 ## Endpoints
 
 ### Create Meeting Attachment
@@ -106,7 +125,7 @@ Generates a presigned download URL for a file attachment.
 
 For external URL references (Google Docs, SharePoint, etc.):
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "type": "link",
@@ -116,6 +135,25 @@ For external URL references (Google Docs, SharePoint, etc.):
   "link": "https://docs.google.com/document/d/abc123"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field:
+
+```json
+{
+  "type": "link",
+  "category": "meeting_agenda",
+  "name": "Q4 Planning Agenda",
+  "description": "Agenda for Q4 planning meeting",
+  "link": "https://docs.google.com/document/d/abc123",
+  "created_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com"
+  }
+}
+```
+
+> **Proxy-added field**: `created_by` is stamped by the proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 **Fields**:
 - `type` (string, required): Must be `"link"` for external URLs
@@ -130,7 +168,7 @@ For external URL references (Google Docs, SharePoint, etc.):
 
 For file uploads using presigned URL flow:
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "type": "file",
@@ -138,6 +176,8 @@ For file uploads using presigned URL flow:
   "name": "Meeting Notes"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field (same shape as the Link Type example above — see [Audit stamping](#audit-stamping)).
 
 **Fields**:
 - `type` (string, required): Must be `"file"` for file attachments
@@ -154,7 +194,7 @@ For file uploads using presigned URL flow:
 
 ### Update Attachment Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "type": "link",
@@ -165,6 +205,8 @@ For file uploads using presigned URL flow:
 }
 ```
 
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `updated_by` field (same shape as `created_by` — see [Audit stamping](#audit-stamping)).
+
 All fields are optional - only include fields you want to update.
 
 **Returns**: 204 No Content (no response body)
@@ -173,7 +215,7 @@ All fields are optional - only include fields you want to update.
 
 ### Create Presigned URL Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "name": "Presentation.pptx",
@@ -183,6 +225,8 @@ All fields are optional - only include fields you want to update.
   "category": "presentation"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field. The presign step is treated as a create because ITX persists an attachment record with `file_upload_status="ongoing"` at this point. See [Audit stamping](#audit-stamping).
 
 **Fields**:
 - `name` (string, required): File name with extension

--- a/docs/api-contracts/itx-meetings-api.md
+++ b/docs/api-contracts/itx-meetings-api.md
@@ -22,6 +22,26 @@ Client → LFX Meeting Service (Proxy) → ITX Service → Zoom API
 - Authorization: OAuth2 M2M (added automatically by proxy)
 - Header: `x-scope: manage:zoom`
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX write requests so ITX records who made each change. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on `POST` (create) requests.
+- `updated_by` — stamped on `PUT` (update) requests, including per-occurrence updates.
+
+Shape:
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write.
+
 ---
 
 ## Create Meeting
@@ -171,9 +191,17 @@ Content-Type: application/json
     "monthly_week_day": 3,
     "end_times": 10,
     "end_date_time": "2024-12-31T23:59:59Z"
+  },
+  "created_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com",
+    "profile_picture": "https://avatars.example.com/jdoe.jpg"
   }
 }
 ```
+
+> **Proxy-added field**: `created_by` is stamped by the LFX Meeting Service proxy from the requesting user's authenticated JWT principal (username, enriched with name/email/avatar via the auth service). Clients do not send this field in their proxy request; if provided, it is ignored/overwritten. See [Audit stamping](#audit-stamping).
 
 **Response**: `201 Created`
 
@@ -326,7 +354,7 @@ Content-Type: application/json
 
 - `meeting_id` (string, required) - The Zoom meeting ID
 
-**Request Body**: Same as ITX Create Meeting request body
+**Request Body**: Same as ITX Create Meeting request body, except `created_by` is not sent; instead, the proxy stamps `updated_by` with the requesting user (same shape as `created_by`). See [Audit stamping](#audit-stamping).
 
 **Response**: `204 No Content`
 

--- a/docs/api-contracts/itx-occurrences-api.md
+++ b/docs/api-contracts/itx-occurrences-api.md
@@ -22,6 +22,23 @@ Client → LFX Meeting Service (Proxy) → ITX Service → Zoom API
 - Authorization: OAuth2 M2M (added automatically by proxy)
 - Header: `x-scope: manage:zoom`
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds an `updated_by` field to occurrence `PUT` requests so ITX records who made each change. This field is populated by the proxy from the authenticated JWT principal — clients do not send it in their proxy request; if provided, it is overwritten.
+
+Shape:
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write.
+
 ---
 
 ## Update Occurrence
@@ -120,13 +137,35 @@ Content-Type: application/json
 - `meeting_id` (string, required) - The Zoom meeting ID
 - `occurrence_id` (string, required) - The occurrence ID (Unix timestamp)
 
-**Request Body**: Identical to Proxy API
+**Request Body**: Identical to Proxy API, plus a proxy-added `updated_by` field:
+
+```json
+{
+  "start_time": "2024-01-15T10:00:00Z",
+  "duration": 60,
+  "topic": "Updated Weekly Team Sync",
+  "agenda": "Updated agenda for this specific occurrence",
+  "recurrence": {
+    "type": 2,
+    "repeat_interval": 1,
+    "weekly_days": "1,3,5"
+  },
+  "updated_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com",
+    "profile_picture": "https://avatars.example.com/jdoe.jpg"
+  }
+}
+```
+
+> **Proxy-added field**: `updated_by` is stamped by the proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 **Response**: `204 No Content`
 
 ### Field Mapping
 
-All fields are identical between Proxy and ITX API for occurrence updates.
+All fields are identical between Proxy and ITX API for occurrence updates. The proxy additionally stamps `updated_by` on `PUT` requests before forwarding to ITX; see [Audit stamping](#audit-stamping).
 
 ---
 

--- a/docs/api-contracts/itx-past-meeting-attachments-api.md
+++ b/docs/api-contracts/itx-past-meeting-attachments-api.md
@@ -2,6 +2,25 @@
 
 This document details the API contracts for past meeting attachments endpoints between the LFX v2 Meeting Service proxy API and the underlying ITX Zoom API.
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX past-meeting attachment write requests so ITX records who touched each attachment. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on `POST` (create) requests, including the presigned-upload-URL request (ITX persists an attachment record with `file_upload_status="ongoing"` at the presign step).
+- `updated_by` — stamped on `PUT` (update) requests.
+
+Shape (attachment endpoints use the reduced `{ username, name, email }` shape — no `profile_picture`):
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com"
+}
+```
+
+The name / email are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write. Prior to July 2026 the attachment endpoints only sent `{ username }`; the `name` / `email` enrichment was added to bring them in line with the meeting endpoints.
+
 ## Endpoints
 
 ### Create Past Meeting Attachment
@@ -106,16 +125,35 @@ Generates a presigned download URL for a file attachment.
 
 For external URL references (Google Docs, SharePoint, etc.):
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "type": "link",
-  "category": "Notes",
-  "name": "Q4 Planning Notes",
-  "description": "Notes from Q4 planning meeting",
+  "category": "meeting_agenda",
+  "name": "Q4 Planning Agenda",
+  "description": "Agenda for Q4 planning meeting",
   "link": "https://docs.google.com/document/d/abc123"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field:
+
+```json
+{
+  "type": "link",
+  "category": "meeting_agenda",
+  "name": "Q4 Planning Agenda",
+  "description": "Agenda for Q4 planning meeting",
+  "link": "https://docs.google.com/document/d/abc123",
+  "created_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com"
+  }
+}
+```
+
+> **Proxy-added field**: `created_by` is stamped by the proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 **Fields**:
 - `type` (string, required): Must be `"link"` for external URLs
@@ -130,14 +168,16 @@ For external URL references (Google Docs, SharePoint, etc.):
 
 For file uploads using presigned URL flow:
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "type": "file",
-  "category": "Notes",
+  "category": "meeting_notes",
   "name": "Meeting Notes"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field (same shape as the Link Type example above — see [Audit stamping](#audit-stamping)).
 
 **Fields**:
 - `type` (string, required): Must be `"file"` for file attachments
@@ -154,16 +194,18 @@ For file uploads using presigned URL flow:
 
 ### Update Attachment Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "type": "link",
-  "category": "Notes",
+  "category": "meeting_notes",
   "name": "Updated Meeting Notes",
   "description": "Updated description",
   "link": "https://docs.google.com/document/d/xyz789"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `updated_by` field (same shape as `created_by` — see [Audit stamping](#audit-stamping)).
 
 All fields are optional - only include fields you want to update.
 
@@ -173,16 +215,18 @@ All fields are optional - only include fields you want to update.
 
 ### Create Presigned URL Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
-  "name": "Recording.mp4",
-  "file_size": 52428800,
-  "file_type": "video/mp4",
-  "description": "Q4 Planning Meeting Recording",
-  "category": "Other"
+  "name": "Presentation.pptx",
+  "file_size": 2048576,
+  "file_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "description": "Q4 Planning Presentation",
+  "category": "presentation"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field. The presign step is treated as a create because ITX persists an attachment record with `file_upload_status="ongoing"` at this point. See [Audit stamping](#audit-stamping).
 
 **Fields**:
 - `name` (string, required): File name with extension

--- a/docs/api-contracts/itx-past-meeting-invitees-api.md
+++ b/docs/api-contracts/itx-past-meeting-invitees-api.md
@@ -2,6 +2,26 @@
 
 This document details the API contracts for past meeting invitees endpoints between the LFX v2 Meeting Service proxy API and the underlying ITX Zoom API.
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX invitee write requests so ITX records who made each change. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on `POST` (create) requests. Also stamped when a `PUT` targets an invitee that doesn't yet exist and the proxy falls back to a create.
+- `updated_by` — stamped on `PUT` (update) requests against an existing invitee.
+
+Shape:
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write.
+
 ## Endpoints
 
 ### Create Past Meeting Invitee
@@ -58,7 +78,7 @@ Deletes an invitee from a specific past meeting occurrence. This removes the inv
 
 ### Create Invitee Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 
 ```json
 {
@@ -75,6 +95,32 @@ Deletes an invitee from a specific past meeting occurrence. This removes the inv
   "committee_voting_status": "Voting Rep"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `created_by` field:
+
+```json
+{
+  "first_name": "John",
+  "last_name": "Doe",
+  "primary_email": "john.doe@example.com",
+  "lf_user_id": "003P000001cRZVVI9A",
+  "lf_sso": "jdoe",
+  "org": "Google",
+  "job_title": "Software Engineer",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg",
+  "committee_id": "ea1e8536-a985-4cf5-b981-a170927a1d11",
+  "committee_role": "Developer Seat",
+  "committee_voting_status": "Voting Rep",
+  "created_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com",
+    "profile_picture": "https://avatars.example.com/jdoe.jpg"
+  }
+}
+```
+
+> **Proxy-added field**: `created_by` is stamped by the proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 **Required Fields**:
 
@@ -97,7 +143,7 @@ Deletes an invitee from a specific past meeting occurrence. This removes the inv
 
 ### Update Invitee Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 
 ```json
 {
@@ -107,6 +153,8 @@ Deletes an invitee from a specific past meeting occurrence. This removes the inv
   "committee_voting_status": "Alt Voting Rep"
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `updated_by` field (same shape as `created_by` — see [Audit stamping](#audit-stamping)).
 
 All fields are optional - only include fields you want to update.
 

--- a/docs/api-contracts/itx-past-meeting-participants-api.md
+++ b/docs/api-contracts/itx-past-meeting-participants-api.md
@@ -23,6 +23,28 @@ Client → V2 Proxy API (Unified Participants) → ITX API (Separate Invitees & 
 - Authorization: OAuth2 M2M (added automatically by proxy)
 - Separate invitee and attendee resources
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX invitee and attendee write requests so ITX records who made each change. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on invitee and attendee `POST` (create) requests. Also stamped when a `PUT` targets an invitee or attendee that doesn't yet exist and the proxy falls back to a create.
+- `updated_by` — stamped on invitee and attendee `PUT` (update) requests against an existing record.
+
+For a single `PUT /participants/{participant_id}` call that touches both invitee and attendee, the proxy resolves the requesting user once and reuses that value across both underlying ITX calls — the audit stamp is guaranteed to be identical on both records.
+
+Shape (identical for `created_by` and `updated_by`):
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write.
+
 ---
 
 ## Create Past Meeting Participant
@@ -152,11 +174,11 @@ The proxy creates invitee and/or attendee records based on the flags:
 
 **Method (Invitee)**: `POST /v2/zoom/past-meetings/{past_meeting_id}/invitees`
 
-Creates an invitee record when `is_invited: true`
+Creates an invitee record when `is_invited: true`. Body includes a proxy-added `created_by` field — see [Audit stamping](#audit-stamping).
 
 **Method (Attendee)**: `POST /v2/zoom/past-meetings/{past_meeting_id}/attendees`
 
-Creates an attendee record when `is_attended: true`
+Creates an attendee record when `is_attended: true`. Body includes a proxy-added `created_by` field — see [Audit stamping](#audit-stamping).
 
 ---
 
@@ -231,7 +253,7 @@ Response body is identical to Create Past Meeting Participant response.
 
 ### ITX API Endpoints
 
-Updates invitee and/or attendee records through the ITX API based on the provided fields.
+Updates invitee and/or attendee records through the ITX API based on the provided fields. `POST` (create) bodies include a proxy-added `created_by` field; `PUT` (update) bodies include a proxy-added `updated_by` field. See [Audit stamping](#audit-stamping).
 
 **Method (Create Invitee)**: `POST /v2/zoom/past-meetings/{past_meeting_id}/invitees`
 

--- a/docs/api-contracts/itx-past-meeting-summaries-api.md
+++ b/docs/api-contracts/itx-past-meeting-summaries-api.md
@@ -2,6 +2,23 @@
 
 This document details the API contracts for past meeting summaries (AI-generated meeting summaries) endpoints between the LFX v2 Meeting Service proxy API and the underlying ITX Zoom API.
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds a `modified_by` field (ITX uses `modified_by` here, not the more common `updated_by`) to summary `PUT` requests so ITX records who edited or approved each summary. This field is populated by the proxy from the authenticated JWT principal — clients do not send it in their proxy request; if provided, it is overwritten.
+
+Shape:
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write. `created_by` is not stamped by the proxy — summary records are created by ITX from the Zoom AI Companion pipeline, not by proxy calls.
+
 ## Endpoints
 
 ### Get Past Meeting Summary
@@ -40,7 +57,7 @@ Updates an existing AI-generated summary for a past meeting occurrence. This is 
 
 ### Update Summary Request
 
-**Proxy API & ITX API** (Identical):
+**Proxy API**:
 ```json
 {
   "edited_summary_overview": "This meeting covered Q4 planning and resource allocation.",
@@ -62,6 +79,32 @@ Updates an existing AI-generated summary for a past meeting occurrence. This is 
   "approved": true
 }
 ```
+
+**ITX API**: Identical to the Proxy API request, plus a proxy-added `modified_by` field:
+
+```json
+{
+  "edited_summary_overview": "This meeting covered Q4 planning and resource allocation.",
+  "edited_summary_details": [
+    {
+      "label": "Key Discussion Points",
+      "summary": "Team discussed hiring plans and budget for Q4. Agreed on 3 new positions."
+    }
+  ],
+  "edited_next_steps": [
+    "Finance team to draft budget proposal by end of week"
+  ],
+  "approved": true,
+  "modified_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com",
+    "profile_picture": "https://avatars.example.com/jdoe.jpg"
+  }
+}
+```
+
+> **Proxy-added field**: `modified_by` is stamped by the proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 **Optional Fields**:
 - `edited_summary_overview` (string): Edited version of the AI-generated overview

--- a/docs/api-contracts/itx-past-meetings-api.md
+++ b/docs/api-contracts/itx-past-meetings-api.md
@@ -2,6 +2,26 @@
 
 This document details the API contracts for past meeting endpoints between the LFX v2 Meeting Service proxy API and the underlying ITX Zoom API.
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX past-meeting write requests so ITX records who made each change. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on `POST` (create) requests.
+- `updated_by` — stamped on `PUT` (update) requests.
+
+Shape:
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write.
+
 ## Endpoints
 
 ### Get Past Meeting
@@ -126,9 +146,17 @@ Deletes a past meeting record.
       "id": "committee-uuid-123",
       "filters": ["voting_rep", "observer"]
     }
-  ]
+  ],
+  "created_by": {
+    "username": "jdoe",
+    "name": "Jane Doe",
+    "email": "jane.doe@example.com",
+    "profile_picture": "https://avatars.example.com/jdoe.jpg"
+  }
 }
 ```
+
+> **Proxy-added field**: `created_by` (on `POST`) or `updated_by` (on `PUT`, same shape) is stamped by the proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 ---
 

--- a/docs/api-contracts/itx-registrants-api.md
+++ b/docs/api-contracts/itx-registrants-api.md
@@ -22,6 +22,26 @@ Client → LFX Meeting Service (Proxy) → ITX Service → Zoom API
 - Authorization: OAuth2 M2M (added automatically by proxy)
 - Header: `x-scope: manage:zoom`
 
+## Audit stamping
+
+The LFX Meeting Service proxy adds identity-attribution fields to ITX write requests so ITX records who made each change. These fields are populated by the proxy from the authenticated JWT principal — clients do not send them in their proxy request; if provided, they are overwritten.
+
+- `created_by` — stamped on `POST` (create) requests.
+- `updated_by` — stamped on `PUT` (update) requests.
+
+Shape:
+
+```json
+{
+  "username": "jdoe",
+  "name": "Jane Doe",
+  "email": "jane.doe@example.com",
+  "profile_picture": "https://avatars.example.com/jdoe.jpg"
+}
+```
+
+The name / email / avatar are resolved from the auth service (via a NATS lookup) using the JWT's `username` claim. If the lookup fails or NATS is unavailable, the proxy degrades gracefully to `{ username, email }` (email from the JWT claim) and never blocks the write.
+
 ---
 
 ## Create Registrant
@@ -166,9 +186,17 @@ Content-Type: application/json
   "job_title": "Senior Developer",
   "profile_picture": "https://example.com/avatar.jpg",
   "host": false,
-  "occurrence": "1666848600"
+  "occurrence": "1666848600",
+  "created_by": {
+    "username": "admin",
+    "name": "Admin User",
+    "email": "admin@example.com",
+    "profile_picture": "https://example.com/admin.jpg"
+  }
 }
 ```
+
+> **Proxy-added field**: `created_by` is stamped by the LFX Meeting Service proxy from the requesting user's authenticated JWT principal. See [Audit stamping](#audit-stamping).
 
 **Response**: `201 Created`
 
@@ -273,7 +301,7 @@ Content-Type: application/json
 - `meeting_id` (string, required) - The Zoom meeting ID
 - `registrant_id` (string, required) - The registrant ID
 
-**Request Body**: Same as ITX Create Registrant request body
+**Request Body**: Same as ITX Create Registrant request body, except the proxy stamps `updated_by` (same shape as `created_by`) instead of `created_by`. See [Audit stamping](#audit-stamping).
 
 **Response**: `204 No Content`
 

--- a/internal/infrastructure/proxy/client.go
+++ b/internal/infrastructure/proxy/client.go
@@ -1443,7 +1443,7 @@ func (c *Client) CreateMeetingAttachmentPresignURL(ctx context.Context, meetingI
 		"method", http.MethodPost,
 		"url", url,
 		"meetingID", meetingID,
-		"request", string(jsonBody))
+		"request", requestJSONForLog(req))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
@@ -1473,7 +1473,7 @@ func (c *Client) CreateMeetingAttachmentPresignURL(ctx context.Context, meetingI
 
 	slog.DebugContext(ctx, "ITX CreateMeetingAttachmentPresignURL response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1526,7 +1526,7 @@ func (c *Client) GetMeetingAttachmentDownloadURL(ctx context.Context, meetingID,
 
 	slog.DebugContext(ctx, "ITX GetMeetingAttachmentDownloadURL response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1556,7 +1556,7 @@ func (c *Client) CreatePastMeetingAttachmentPresignURL(ctx context.Context, meet
 		"method", http.MethodPost,
 		"url", url,
 		"meetingAndOccurrenceID", meetingAndOccurrenceID,
-		"request", string(jsonBody))
+		"request", requestJSONForLog(req))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
@@ -1586,7 +1586,7 @@ func (c *Client) CreatePastMeetingAttachmentPresignURL(ctx context.Context, meet
 
 	slog.DebugContext(ctx, "ITX CreatePastMeetingAttachmentPresignURL response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1639,7 +1639,7 @@ func (c *Client) GetPastMeetingAttachmentDownloadURL(ctx context.Context, meetin
 
 	slog.DebugContext(ctx, "ITX GetPastMeetingAttachmentDownloadURL response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1669,7 +1669,7 @@ func (c *Client) CreateMeetingAttachment(ctx context.Context, meetingID string, 
 		"method", http.MethodPost,
 		"url", url,
 		"meetingID", meetingID,
-		"request", string(jsonBody))
+		"request", requestJSONForLog(req))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
@@ -1699,7 +1699,7 @@ func (c *Client) CreateMeetingAttachment(ctx context.Context, meetingID string, 
 
 	slog.DebugContext(ctx, "ITX CreateMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1752,7 +1752,7 @@ func (c *Client) GetMeetingAttachment(ctx context.Context, meetingID, attachment
 
 	slog.DebugContext(ctx, "ITX GetMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1783,7 +1783,7 @@ func (c *Client) UpdateMeetingAttachment(ctx context.Context, meetingID, attachm
 		"url", url,
 		"meetingID", meetingID,
 		"attachmentID", attachmentID,
-		"request", string(jsonBody))
+		"request", requestJSONForLog(req))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
@@ -1813,7 +1813,7 @@ func (c *Client) UpdateMeetingAttachment(ctx context.Context, meetingID, attachm
 
 	slog.DebugContext(ctx, "ITX UpdateMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1860,7 +1860,7 @@ func (c *Client) DeleteMeetingAttachment(ctx context.Context, meetingID, attachm
 
 	slog.DebugContext(ctx, "ITX DeleteMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1884,7 +1884,7 @@ func (c *Client) CreatePastMeetingAttachment(ctx context.Context, meetingAndOccu
 		"method", http.MethodPost,
 		"url", url,
 		"meetingAndOccurrenceID", meetingAndOccurrenceID,
-		"request", string(jsonBody))
+		"request", requestJSONForLog(req))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
@@ -1914,7 +1914,7 @@ func (c *Client) CreatePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	slog.DebugContext(ctx, "ITX CreatePastMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1967,7 +1967,7 @@ func (c *Client) GetPastMeetingAttachment(ctx context.Context, meetingAndOccurre
 
 	slog.DebugContext(ctx, "ITX GetPastMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -1998,7 +1998,7 @@ func (c *Client) UpdatePastMeetingAttachment(ctx context.Context, meetingAndOccu
 		"url", url,
 		"meetingAndOccurrenceID", meetingAndOccurrenceID,
 		"attachmentID", attachmentID,
-		"request", string(jsonBody))
+		"request", requestJSONForLog(req))
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(jsonBody))
 	if err != nil {
@@ -2028,7 +2028,7 @@ func (c *Client) UpdatePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	slog.DebugContext(ctx, "ITX UpdatePastMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -2075,7 +2075,7 @@ func (c *Client) DeletePastMeetingAttachment(ctx context.Context, meetingAndOccu
 
 	slog.DebugContext(ctx, "ITX DeletePastMeetingAttachment response",
 		"statusCode", resp.StatusCode,
-		"response", string(respBody))
+		"response", responseJSONForLog(respBody))
 
 	// Handle non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/infrastructure/proxy/logredact.go
+++ b/internal/infrastructure/proxy/logredact.go
@@ -1,0 +1,144 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package proxy
+
+import (
+	"encoding/json"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// auditFieldsForResponseRedaction lists the JSON keys on ITX attachment
+// response bodies whose values carry user-identity PII (requester name +
+// email) and must be redacted before appearing in debug logs.
+//
+// Kept as a package-level var so it can be extended if ITX adds new
+// audit-user fields in the future.
+var auditFieldsForResponseRedaction = []string{
+	"created_by",
+	"updated_by",
+	"modified_by",
+	"file_uploaded_by",
+}
+
+// requestJSONForLog returns a JSON-encoded string of req with any
+// user-identity audit fields (CreatedBy / UpdatedBy) stripped, so that
+// debug-level logging of ITX request bodies does not leak requester PII
+// (name / email) into logs.
+//
+// The wire body sent to ITX is unaffected; this only produces the payload
+// used inside slog.DebugContext(..., "request", ...) calls.
+//
+// Only attachment request types currently carry these audit fields on this
+// service's outbound calls (POST/PUT/presign for meeting attachments and
+// past-meeting attachments). Other request types pass through unchanged.
+// The itx.User and itx.CreatedUpdatedBy types also implement slog.LogValuer
+// (see pkg/models/itx), which handles the case where they're logged directly
+// as a slog attribute value; this helper handles the harder case of an audit
+// field nested inside a JSON-encoded request body, which slog cannot resolve
+// on its own.
+func requestJSONForLog(req any) string {
+	b, err := json.Marshal(redactAuditForLog(req))
+	if err != nil {
+		// Fall back to a marker rather than logging the raw body, which
+		// would defeat the purpose of the redaction.
+		return `{"error":"failed to marshal request for log"}`
+	}
+	return string(b)
+}
+
+// redactAuditForLog returns a shallow copy of req with any CreatedBy /
+// UpdatedBy audit fields cleared. The original req is not mutated. Types
+// without audit fields (or that are nil) are returned unchanged.
+func redactAuditForLog(req any) any {
+	switch r := req.(type) {
+	case *itx.CreateMeetingAttachmentRequest:
+		if r == nil {
+			return req
+		}
+		cp := *r
+		cp.CreatedBy = nil
+		return &cp
+	case *itx.UpdateMeetingAttachmentRequest:
+		if r == nil {
+			return req
+		}
+		cp := *r
+		cp.UpdatedBy = nil
+		return &cp
+	case *itx.CreateAttachmentPresignRequest:
+		if r == nil {
+			return req
+		}
+		cp := *r
+		cp.CreatedBy = nil
+		return &cp
+	case *itx.CreatePastMeetingAttachmentRequest:
+		if r == nil {
+			return req
+		}
+		cp := *r
+		cp.CreatedBy = nil
+		return &cp
+	case *itx.UpdatePastMeetingAttachmentRequest:
+		if r == nil {
+			return req
+		}
+		cp := *r
+		cp.UpdatedBy = nil
+		return &cp
+	default:
+		return req
+	}
+}
+
+// responseJSONForLog returns a JSON-encoded string of respBody with any
+// user-identity audit fields (created_by / updated_by / modified_by /
+// file_uploaded_by) redacted to just their username, so that debug-level
+// logging of ITX attachment response bodies does not leak PII. The response
+// consumed by the service is unaffected — this only produces the payload
+// used inside slog.DebugContext(..., "response", ...) calls.
+//
+// This complements requestJSONForLog and covers three PII vectors on the
+// response side:
+//  1. Attachment create/update/presign echo back the requester's created_by /
+//     updated_by, which now carries name + email.
+//  2. GET attachment responses expose the persisted values from whoever
+//     originally created / last updated / uploaded the attachment — which
+//     may be a different user than the caller.
+//  3. Some responses carry file_uploaded_by, populated by ITX when a file
+//     upload completes.
+//
+// The redaction shape mirrors the itx.CreatedUpdatedBy LogValue: only the
+// username survives, so a debug operator can still see who touched what.
+// Non-audit response fields (id, name, description, timestamps, etc.) are
+// left intact so the log remains useful.
+func responseJSONForLog(respBody []byte) string {
+	if len(respBody) == 0 {
+		return ""
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		// Non-JSON, JSON-array, or malformed body: return a safe marker
+		// rather than logging bytes we can't confirm are PII-free.
+		return `{"error":"failed to parse response for log"}`
+	}
+	for _, key := range auditFieldsForResponseRedaction {
+		raw, ok := parsed[key]
+		if !ok || raw == nil {
+			continue
+		}
+		if m, ok := raw.(map[string]any); ok {
+			parsed[key] = map[string]any{"username": m["username"]}
+		} else {
+			// Unexpected shape — safest to strip the whole value.
+			parsed[key] = nil
+		}
+	}
+	b, err := json.Marshal(parsed)
+	if err != nil {
+		return `{"error":"failed to marshal response for log"}`
+	}
+	return string(b)
+}

--- a/internal/infrastructure/proxy/logredact_test.go
+++ b/internal/infrastructure/proxy/logredact_test.go
@@ -1,0 +1,288 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// TestRequestJSONForLog_RedactsAuditPII pins down that debug-level ITX request
+// logs (which serialize the full request body) do not leak the requester's
+// name and email via CreatedBy / UpdatedBy audit fields. The wire body sent to
+// ITX is unaffected — the redaction only applies to what proxy.Client emits
+// via slog.DebugContext.
+func TestRequestJSONForLog_RedactsAuditPII(t *testing.T) {
+	// Present in the outbound request struct so we can confirm the redaction
+	// only touches the CreatedBy / UpdatedBy fields and doesn't accidentally
+	// strip other user-provided attachment metadata (description, filename).
+	const nonAuditDescription = "Meeting notes for Q3 planning"
+
+	created := &itx.CreatedUpdatedBy{
+		Username: "alice",
+		Email:    "alice@example.com",
+		Name:     "Alice Example",
+	}
+	updated := &itx.CreatedUpdatedBy{
+		Username: "bob",
+		Email:    "bob@example.com",
+		Name:     "Bob Example",
+	}
+
+	assertRedacted := func(t *testing.T, name string, req any, extraKept ...string) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			logged := requestJSONForLog(req)
+
+			assert.NotContains(t, logged, "alice@example.com",
+				"redacted log body must not contain requester email")
+			assert.NotContains(t, logged, "bob@example.com",
+				"redacted log body must not contain requester email")
+			assert.NotContains(t, logged, "Alice Example",
+				"redacted log body must not contain requester display name")
+			assert.NotContains(t, logged, "Bob Example",
+				"redacted log body must not contain requester display name")
+
+			// Confirm the redacted log body is still useful for debugging by
+			// keeping non-PII request fields intact.
+			for _, kept := range extraKept {
+				assert.Contains(t, logged, kept,
+					"redacted log body should retain non-audit request fields for debugging")
+			}
+			assert.Contains(t, logged, nonAuditDescription,
+				"redacted log body should retain user-supplied attachment metadata")
+		})
+	}
+
+	assertRedacted(t, "CreateMeetingAttachmentRequest", &itx.CreateMeetingAttachmentRequest{
+		Type:        "file",
+		Category:    "Notes",
+		Name:        "notes.pdf",
+		Description: nonAuditDescription,
+		CreatedBy:   created,
+	}, "notes.pdf")
+
+	assertRedacted(t, "UpdateMeetingAttachmentRequest", &itx.UpdateMeetingAttachmentRequest{
+		Type:        "file",
+		Category:    "Notes",
+		Name:        "notes.pdf",
+		Description: nonAuditDescription,
+		UpdatedBy:   updated,
+	}, "notes.pdf")
+
+	assertRedacted(t, "CreateAttachmentPresignRequest", &itx.CreateAttachmentPresignRequest{
+		Name:        "notes.pdf",
+		Description: nonAuditDescription,
+		FileSize:    1024,
+		FileType:    "application/pdf",
+		CreatedBy:   created,
+	}, "application/pdf")
+
+	assertRedacted(t, "CreatePastMeetingAttachmentRequest", &itx.CreatePastMeetingAttachmentRequest{
+		Type:        "file",
+		Category:    "Notes",
+		Name:        "notes.pdf",
+		Description: nonAuditDescription,
+		CreatedBy:   created,
+	}, "notes.pdf")
+
+	assertRedacted(t, "UpdatePastMeetingAttachmentRequest", &itx.UpdatePastMeetingAttachmentRequest{
+		Type:        "file",
+		Category:    "Notes",
+		Name:        "notes.pdf",
+		Description: nonAuditDescription,
+		UpdatedBy:   updated,
+	}, "notes.pdf")
+}
+
+// TestRequestJSONForLog_LeavesUnknownTypesAlone confirms that request types
+// without audit fields (e.g. meeting create/update, which don't hit this
+// debug-log code path today) still round-trip cleanly.
+func TestRequestJSONForLog_LeavesUnknownTypesAlone(t *testing.T) {
+	req := &itx.CreateZoomMeetingRequest{
+		Topic:     "Weekly sync",
+		StartTime: "2026-01-01T00:00:00Z",
+	}
+	logged := requestJSONForLog(req)
+
+	assert.Contains(t, logged, "Weekly sync")
+	assert.Contains(t, logged, "2026-01-01T00:00:00Z")
+}
+
+// TestRedactAuditForLog_DoesNotMutateOriginal ensures the wire body is not
+// affected by the log-time redaction. Without this guarantee, ITX would
+// receive requests with created_by / updated_by cleared.
+func TestRedactAuditForLog_DoesNotMutateOriginal(t *testing.T) {
+	original := &itx.CreateMeetingAttachmentRequest{
+		Type: "file",
+		Name: "notes.pdf",
+		CreatedBy: &itx.CreatedUpdatedBy{
+			Username: "alice",
+			Email:    "alice@example.com",
+			Name:     "Alice Example",
+		},
+	}
+
+	_ = requestJSONForLog(original)
+
+	require.NotNil(t, original.CreatedBy, "log-time redaction must not clear the original request's CreatedBy — that would strip the audit stamp from the wire body")
+	assert.Equal(t, "alice", original.CreatedBy.Username)
+	assert.Equal(t, "alice@example.com", original.CreatedBy.Email)
+	assert.Equal(t, "Alice Example", original.CreatedBy.Name)
+}
+
+// TestRedactAuditForLog_HandlesNil guards against panics when the request is
+// nil or a nil typed pointer.
+func TestRedactAuditForLog_HandlesNil(t *testing.T) {
+	// Untyped nil.
+	assert.Equal(t, `null`, requestJSONForLog(nil))
+
+	// Typed nil pointer to a redactable type.
+	var typedNil *itx.CreateMeetingAttachmentRequest
+	logged := requestJSONForLog(typedNil)
+	// Whatever the marshaled representation is, we just need to not panic
+	// and to not produce a body claiming to contain audit PII.
+	assert.NotContains(t, logged, "alice@example.com")
+}
+
+// Sanity check that the wire-body JSON — which is what the audit stamp is
+// carried on — still includes name and email. This guards against future
+// changes that might extend the log-time redaction into the marshaling path
+// itself (which would break the actual purpose of the audit stamp).
+func TestWireBody_StillContainsAuditPII(t *testing.T) {
+	req := &itx.CreateMeetingAttachmentRequest{
+		Name: "notes.pdf",
+		CreatedBy: &itx.CreatedUpdatedBy{
+			Username: "alice",
+			Email:    "alice@example.com",
+			Name:     "Alice Example",
+		},
+	}
+
+	// This is what proxy.Client sends to ITX (via json.Marshal(req)).
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(string(body), "alice@example.com"),
+		"wire body must carry the requester's email so ITX records the correct audit trail")
+	assert.True(t, strings.Contains(string(body), "Alice Example"),
+		"wire body must carry the requester's display name so ITX records the correct audit trail")
+}
+
+// TestResponseJSONForLog_RedactsAuditPII pins down that debug-level ITX
+// response logs (which serialize the full response body) don't leak PII via
+// the audit fields ITX echoes back. Three vectors are covered:
+//  1. Requester echo on create/update (created_by / updated_by with our own
+//     name+email).
+//  2. Persisted values on GET responses (audit stamps from a *different* user
+//     who originally created the attachment).
+//  3. file_uploaded_by populated by ITX after upload completion.
+func TestResponseJSONForLog_RedactsAuditPII(t *testing.T) {
+	assertRedacted := func(t *testing.T, name string, respJSON string, mustKeep ...string) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			out := responseJSONForLog([]byte(respJSON))
+
+			assert.NotContains(t, out, "alice@example.com", "requester email must not appear in response log")
+			assert.NotContains(t, out, "bob@example.com", "prior-updater email must not appear in response log")
+			assert.NotContains(t, out, "eve@example.com", "prior-uploader email must not appear in response log")
+			assert.NotContains(t, out, "Alice Example")
+			assert.NotContains(t, out, "Bob Example")
+			assert.NotContains(t, out, "Eve Example")
+
+			// Debug value should still be present: username survives,
+			// non-audit response fields untouched.
+			assert.Contains(t, out, `"username":"alice"`, "username should survive redaction for debugging")
+
+			for _, kept := range mustKeep {
+				assert.Contains(t, out, kept, "non-audit response fields should be preserved for debugging")
+			}
+		})
+	}
+
+	// Create/update echo shape.
+	assertRedacted(t, "created_by echo",
+		`{"id":"att-1","name":"notes.pdf","created_by":{"username":"alice","email":"alice@example.com","name":"Alice Example"}}`,
+		`"id":"att-1"`, `"name":"notes.pdf"`)
+
+	assertRedacted(t, "updated_by echo",
+		`{"id":"att-1","name":"notes.pdf","updated_by":{"username":"alice","email":"alice@example.com","name":"Alice Example"}}`,
+		`"id":"att-1"`)
+
+	// GET response with a *different* user's audit stamps.
+	assertRedacted(t, "GET with prior creator + updater",
+		`{"id":"att-1","name":"notes.pdf","created_by":{"username":"alice","email":"alice@example.com","name":"Alice Example"},"updated_by":{"username":"bob","email":"bob@example.com","name":"Bob Example"}}`,
+		`"id":"att-1"`)
+
+	// file_uploaded_by populated by ITX after upload completes.
+	assertRedacted(t, "file_uploaded_by",
+		`{"id":"att-1","file_uploaded_by":{"username":"eve","email":"eve@example.com","name":"Eve Example"},"created_by":{"username":"alice","email":"alice@example.com","name":"Alice Example"}}`,
+		`"id":"att-1"`)
+
+	// modified_by (past-meeting-summary shape — same helper covers it defensively).
+	assertRedacted(t, "modified_by",
+		`{"id":"sum-1","modified_by":{"username":"alice","email":"alice@example.com","name":"Alice Example"}}`,
+		`"id":"sum-1"`)
+}
+
+// TestResponseJSONForLog_UsernameOnly confirms that when the audit field is
+// already just a username (no email/name present) the redaction still emits
+// the same shape rather than turning it into null.
+func TestResponseJSONForLog_UsernameOnly(t *testing.T) {
+	out := responseJSONForLog([]byte(`{"created_by":{"username":"alice"}}`))
+	assert.Contains(t, out, `"username":"alice"`)
+}
+
+// TestResponseJSONForLog_EmptyBody covers the DELETE / 204 path where ITX
+// returns no body — the helper must not emit stray JSON.
+func TestResponseJSONForLog_EmptyBody(t *testing.T) {
+	assert.Equal(t, "", responseJSONForLog(nil))
+	assert.Equal(t, "", responseJSONForLog([]byte("")))
+}
+
+// TestResponseJSONForLog_UnparseableBody protects against silently forwarding
+// a body we couldn't parse. A malformed / array-shaped / non-JSON body must
+// produce a safe marker instead of the raw bytes (which could carry PII).
+func TestResponseJSONForLog_UnparseableBody(t *testing.T) {
+	cases := []string{
+		`not json`,
+		`[{"created_by":{"email":"leak@example.com"}}]`, // JSON array, not an object
+		`{malformed`,
+	}
+	for _, in := range cases {
+		out := responseJSONForLog([]byte(in))
+		assert.NotContains(t, out, "leak@example.com")
+		assert.Contains(t, out, "failed to parse response for log")
+	}
+}
+
+// TestResponseJSONForLog_UnexpectedAuditShape guards the fallback path where
+// an audit field is present but not the expected object shape (e.g. a plain
+// string). The value must be nulled rather than passed through.
+func TestResponseJSONForLog_UnexpectedAuditShape(t *testing.T) {
+	out := responseJSONForLog([]byte(`{"created_by":"alice@example.com"}`))
+	assert.NotContains(t, out, "alice@example.com")
+	assert.Contains(t, out, `"created_by":null`)
+}
+
+// TestResponseJSONForLog_LeavesNonAuditFieldsAlone confirms the redaction is
+// scoped: unrelated response fields (id, name, description, timestamps, URLs)
+// pass through unchanged so the log stays useful for debugging.
+func TestResponseJSONForLog_LeavesNonAuditFieldsAlone(t *testing.T) {
+	in := `{"id":"att-1","name":"notes.pdf","description":"Q3 notes","file_url":"https://example.com/notes.pdf","file_size":1024,"created_at":"2026-01-01T00:00:00Z"}`
+	out := responseJSONForLog([]byte(in))
+
+	assert.Contains(t, out, `"id":"att-1"`)
+	assert.Contains(t, out, `"name":"notes.pdf"`)
+	assert.Contains(t, out, `"description":"Q3 notes"`)
+	assert.Contains(t, out, `"file_url":"https://example.com/notes.pdf"`)
+	assert.Contains(t, out, `"file_size":1024`)
+	assert.Contains(t, out, `"created_at":"2026-01-01T00:00:00Z"`)
+}

--- a/internal/service/itx/audit.go
+++ b/internal/service/itx/audit.go
@@ -1,0 +1,89 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// auditStamper resolves the requesting principal (stashed on ctx by the JWT auth
+// middleware) into an *itx.User suitable for stamping created_by / updated_by /
+// modified_by on outbound ITX requests. It is embedded by each ITX service so the
+// stamping logic (and its graceful-degradation guarantees) lives in one place.
+//
+// Concretely, callers get one of:
+//   - full profile ({username, name, email, profile_picture}) — happy path, resolved
+//     via UserMetadataReader (NATS -> auth-service).
+//   - {username, email} only — when NATS isn't wired (userMetadata == nil) or the
+//     resolver returns an error. Never blocks the caller's request.
+//   - nil — when there is no principal on ctx (e.g. unauthenticated internal call).
+//     Downstream stamping is a no-op in that case.
+//
+// The resolved-profile email is preferred over the JWT-claimed email because JWT
+// claims can be stale on long-lived tokens, while the auth-service view is authoritative.
+type auditStamper struct {
+	userMetadata domain.UserMetadataReader
+}
+
+// buildRequestingUser resolves the requesting user's identity from ctx into an
+// *itx.User. See auditStamper docs for the full contract.
+func (a auditStamper) buildRequestingUser(ctx context.Context) *itx.User {
+	principal, _ := ctx.Value(constants.PrincipalContextID).(string)
+	if principal == "" {
+		return nil
+	}
+	email, _ := ctx.Value(constants.EmailContextID).(string)
+
+	if a.userMetadata == nil {
+		return &itx.User{Username: principal, Email: email}
+	}
+
+	profile, err := a.userMetadata.ResolveProfile(ctx, principal)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to resolve user profile for audit stamp; stamping username/email only",
+			"username", principal, "err", err)
+		return &itx.User{Username: principal, Email: email}
+	}
+	// Defensive: the current NATSUserMetadataReader always returns either a
+	// populated profile or a non-nil error, but the domain.UserMetadataReader
+	// interface doesn't forbid (nil, nil). Dereferencing a nil profile would panic
+	// and take down the outbound ITX write — degrade to username/email instead so
+	// the write still succeeds with a minimal audit stamp.
+	if profile == nil {
+		slog.WarnContext(ctx, "user profile lookup returned no profile; stamping username/email only",
+			"username", principal)
+		return &itx.User{Username: principal, Email: email}
+	}
+
+	user := &itx.User{
+		Username:       principal,
+		Name:           profile.Name,
+		Email:          profile.Email,
+		ProfilePicture: profile.AvatarURL,
+	}
+	if user.Email == "" {
+		user.Email = email
+	}
+	return user
+}
+
+// buildRequestingCreatedUpdatedBy is the same as buildRequestingUser but returns an
+// *itx.CreatedUpdatedBy — the audit-user shape used by attachment endpoints, which
+// omit id and profile_picture. Returns nil when there is no principal on ctx.
+func (a auditStamper) buildRequestingCreatedUpdatedBy(ctx context.Context) *itx.CreatedUpdatedBy {
+	u := a.buildRequestingUser(ctx)
+	if u == nil {
+		return nil
+	}
+	return &itx.CreatedUpdatedBy{
+		Username: u.Username,
+		Email:    u.Email,
+		Name:     u.Name,
+	}
+}

--- a/internal/service/itx/audit_test.go
+++ b/internal/service/itx/audit_test.go
@@ -1,0 +1,106 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+)
+
+// The audit stamper's contract is exercised in depth by the MeetingService tests
+// (create/update/occurrence). These tests pin down the shape the shared helper
+// itself returns — in particular the *itx.CreatedUpdatedBy conversion used by
+// the attachment services — so a regression there doesn't have to be found through
+// an attachment-level test.
+
+func TestAuditStamper_BuildRequestingUser(t *testing.T) {
+	t.Run("returns nil when no principal", func(t *testing.T) {
+		a := auditStamper{}
+		assert.Nil(t, a.buildRequestingUser(context.Background()))
+	})
+
+	t.Run("username-only fallback when reader is nil", func(t *testing.T) {
+		a := auditStamper{}
+		got := a.buildRequestingUser(ctxWithPrincipal("alice", "alice@example.com"))
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "alice", got.Username)
+			assert.Equal(t, "alice@example.com", got.Email)
+			assert.Empty(t, got.Name)
+			assert.Empty(t, got.ProfilePicture)
+		}
+	})
+
+	t.Run("full profile when reader resolves", func(t *testing.T) {
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username:  "alice",
+			Name:      "Alice Example",
+			Email:     "alice@example.com",
+			AvatarURL: "https://example.com/a.jpg",
+		}}
+		a := auditStamper{userMetadata: reader}
+		got := a.buildRequestingUser(ctxWithPrincipal("alice", "alice@heimdall.example.com"))
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "alice", got.Username)
+			assert.Equal(t, "Alice Example", got.Name)
+			// Resolved-profile email wins over JWT-claimed email (which may be stale).
+			assert.Equal(t, "alice@example.com", got.Email)
+			assert.Equal(t, "https://example.com/a.jpg", got.ProfilePicture)
+		}
+	})
+
+	t.Run("degrades to username/email when resolver errors", func(t *testing.T) {
+		reader := &fakeUserMetadataReader{err: errors.New("boom")}
+		a := auditStamper{userMetadata: reader}
+		got := a.buildRequestingUser(ctxWithPrincipal("bob", "bob@example.com"))
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "bob", got.Username)
+			assert.Equal(t, "bob@example.com", got.Email)
+			assert.Empty(t, got.Name)
+		}
+	})
+
+	t.Run("degrades to username/email when resolver returns (nil, nil)", func(t *testing.T) {
+		// Defensive path: the domain.UserMetadataReader interface doesn't forbid
+		// returning a nil profile with a nil error. Dereferencing profile.Name
+		// would panic and take down the outbound ITX write, so we treat this
+		// exactly like a resolution failure.
+		reader := &fakeUserMetadataReader{} // profile=nil, err=nil
+		a := auditStamper{userMetadata: reader}
+		got := a.buildRequestingUser(ctxWithPrincipal("bob", "bob@example.com"))
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "bob", got.Username)
+			assert.Equal(t, "bob@example.com", got.Email)
+			assert.Empty(t, got.Name)
+			assert.Empty(t, got.ProfilePicture)
+		}
+	})
+}
+
+func TestAuditStamper_BuildRequestingCreatedUpdatedBy(t *testing.T) {
+	t.Run("returns nil when no principal", func(t *testing.T) {
+		a := auditStamper{}
+		assert.Nil(t, a.buildRequestingCreatedUpdatedBy(context.Background()))
+	})
+
+	t.Run("mirrors full profile onto CreatedUpdatedBy shape", func(t *testing.T) {
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username:  "alice",
+			Name:      "Alice Example",
+			Email:     "alice@example.com",
+			AvatarURL: "https://example.com/a.jpg", // intentionally dropped by CreatedUpdatedBy shape
+		}}
+		a := auditStamper{userMetadata: reader}
+		got := a.buildRequestingCreatedUpdatedBy(ctxWithPrincipal("alice", ""))
+		if assert.NotNil(t, got) {
+			assert.Equal(t, "alice", got.Username)
+			assert.Equal(t, "Alice Example", got.Name)
+			assert.Equal(t, "alice@example.com", got.Email)
+		}
+	})
+}

--- a/internal/service/itx/meeting_attachment_service.go
+++ b/internal/service/itx/meeting_attachment_service.go
@@ -12,18 +12,26 @@ import (
 
 // MeetingAttachmentService handles ITX meeting attachment operations
 type MeetingAttachmentService struct {
+	auditStamper
 	attachmentClient domain.ITXMeetingAttachmentClient
 }
 
-// NewMeetingAttachmentService creates a new ITX meeting attachment service
-func NewMeetingAttachmentService(attachmentClient domain.ITXMeetingAttachmentClient) *MeetingAttachmentService {
+// NewMeetingAttachmentService creates a new ITX meeting attachment service.
+// userMetadata may be nil (e.g. when NATS is disabled), in which case created_by /
+// updated_by are limited to the JWT-derived username/email rather than blocking the
+// request.
+func NewMeetingAttachmentService(attachmentClient domain.ITXMeetingAttachmentClient, userMetadata domain.UserMetadataReader) *MeetingAttachmentService {
 	return &MeetingAttachmentService{
+		auditStamper:     auditStamper{userMetadata: userMetadata},
 		attachmentClient: attachmentClient,
 	}
 }
 
 // CreateMeetingAttachment creates a new meeting attachment via ITX proxy
 func (s *MeetingAttachmentService) CreateMeetingAttachment(ctx context.Context, meetingID string, req *itx.CreateMeetingAttachmentRequest) (*itx.MeetingAttachment, error) {
+	// Stamp created_by (with full profile enrichment when available) from the
+	// authenticated principal, matching the enrichment level of the Meeting endpoint.
+	req.CreatedBy = s.buildRequestingCreatedUpdatedBy(ctx)
 	return s.attachmentClient.CreateMeetingAttachment(ctx, meetingID, req)
 }
 
@@ -34,6 +42,10 @@ func (s *MeetingAttachmentService) GetMeetingAttachment(ctx context.Context, mee
 
 // UpdateMeetingAttachment updates a meeting attachment via ITX proxy
 func (s *MeetingAttachmentService) UpdateMeetingAttachment(ctx context.Context, meetingID, attachmentID string, req *itx.UpdateMeetingAttachmentRequest) error {
+	// Stamp updated_by (with full profile enrichment when available) from the
+	// authenticated principal so ITX overwrites the stored value instead of preserving
+	// stale data.
+	req.UpdatedBy = s.buildRequestingCreatedUpdatedBy(ctx)
 	return s.attachmentClient.UpdateMeetingAttachment(ctx, meetingID, attachmentID, req)
 }
 
@@ -44,6 +56,9 @@ func (s *MeetingAttachmentService) DeleteMeetingAttachment(ctx context.Context, 
 
 // CreateMeetingAttachmentPresignURL generates a presigned URL for meeting attachment upload via ITX proxy
 func (s *MeetingAttachmentService) CreateMeetingAttachmentPresignURL(ctx context.Context, meetingID string, req *itx.CreateAttachmentPresignRequest) (*itx.MeetingAttachmentPresignResponse, error) {
+	// The presign step is also a "create" in ITX's view (it persists an attachment
+	// record with upload_status=ongoing), so stamp created_by here too.
+	req.CreatedBy = s.buildRequestingCreatedUpdatedBy(ctx)
 	return s.attachmentClient.CreateMeetingAttachmentPresignURL(ctx, meetingID, req)
 }
 

--- a/internal/service/itx/meeting_attachment_service_test.go
+++ b/internal/service/itx/meeting_attachment_service_test.go
@@ -1,0 +1,98 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+type fakeMeetingAttachmentClient struct {
+	domain.ITXMeetingAttachmentClient
+	lastCreateReq        *itx.CreateMeetingAttachmentRequest
+	lastUpdateReq        *itx.UpdateMeetingAttachmentRequest
+	lastCreatePresignReq *itx.CreateAttachmentPresignRequest
+}
+
+func (f *fakeMeetingAttachmentClient) CreateMeetingAttachment(_ context.Context, _ string, req *itx.CreateMeetingAttachmentRequest) (*itx.MeetingAttachment, error) {
+	f.lastCreateReq = req
+	return &itx.MeetingAttachment{}, nil
+}
+
+func (f *fakeMeetingAttachmentClient) UpdateMeetingAttachment(_ context.Context, _, _ string, req *itx.UpdateMeetingAttachmentRequest) error {
+	f.lastUpdateReq = req
+	return nil
+}
+
+func (f *fakeMeetingAttachmentClient) CreateMeetingAttachmentPresignURL(_ context.Context, _ string, req *itx.CreateAttachmentPresignRequest) (*itx.MeetingAttachmentPresignResponse, error) {
+	f.lastCreatePresignReq = req
+	return &itx.MeetingAttachmentPresignResponse{}, nil
+}
+
+func TestMeetingAttachmentService_StampsAuditFields(t *testing.T) {
+	// The ticket called out that attachments were only sending `username` on
+	// created_by/updated_by. These tests pin down that the service now enriches
+	// with name+email via the UserMetadataReader — matching the meeting endpoint.
+
+	newSvcWithReader := func() (*MeetingAttachmentService, *fakeMeetingAttachmentClient) {
+		client := &fakeMeetingAttachmentClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username: "alice", Name: "Alice", Email: "alice@example.com",
+		}}
+		return NewMeetingAttachmentService(client, reader), client
+	}
+
+	t.Run("create stamps enriched CreatedBy", func(t *testing.T) {
+		svc, client := newSvcWithReader()
+		_, err := svc.CreateMeetingAttachment(ctxWithPrincipal("alice", ""), "mtg-1", &itx.CreateMeetingAttachmentRequest{Name: "notes.pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreateReq.CreatedBy)
+		assert.Equal(t, "alice", client.lastCreateReq.CreatedBy.Username)
+		assert.Equal(t, "Alice", client.lastCreateReq.CreatedBy.Name)
+		assert.Equal(t, "alice@example.com", client.lastCreateReq.CreatedBy.Email)
+	})
+
+	t.Run("update stamps enriched UpdatedBy", func(t *testing.T) {
+		svc, client := newSvcWithReader()
+		err := svc.UpdateMeetingAttachment(ctxWithPrincipal("alice", ""), "mtg-1", "att-1", &itx.UpdateMeetingAttachmentRequest{Name: "notes.pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "Alice", client.lastUpdateReq.UpdatedBy.Name)
+		assert.Equal(t, "alice@example.com", client.lastUpdateReq.UpdatedBy.Email)
+	})
+
+	t.Run("presign also stamps CreatedBy (ITX persists a record with upload_status=ongoing)", func(t *testing.T) {
+		svc, client := newSvcWithReader()
+		_, err := svc.CreateMeetingAttachmentPresignURL(ctxWithPrincipal("alice", ""), "mtg-1", &itx.CreateAttachmentPresignRequest{Name: "notes.pdf", FileSize: 1, FileType: "application/pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreatePresignReq.CreatedBy)
+		assert.Equal(t, "Alice", client.lastCreatePresignReq.CreatedBy.Name)
+	})
+
+	t.Run("degrades to username-only without reader", func(t *testing.T) {
+		client := &fakeMeetingAttachmentClient{}
+		svc := NewMeetingAttachmentService(client, nil)
+
+		_, err := svc.CreateMeetingAttachment(ctxWithPrincipal("carol", ""), "mtg-1", &itx.CreateMeetingAttachmentRequest{Name: "notes.pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreateReq.CreatedBy)
+		assert.Equal(t, "carol", client.lastCreateReq.CreatedBy.Username)
+		assert.Empty(t, client.lastCreateReq.CreatedBy.Name)
+	})
+
+	t.Run("omits stamp without principal", func(t *testing.T) {
+		client := &fakeMeetingAttachmentClient{}
+		svc := NewMeetingAttachmentService(client, nil)
+
+		_, err := svc.CreateMeetingAttachment(context.Background(), "mtg-1", &itx.CreateMeetingAttachmentRequest{Name: "notes.pdf"})
+		require.NoError(t, err)
+		assert.Nil(t, client.lastCreateReq.CreatedBy)
+	})
+}

--- a/internal/service/itx/meeting_service.go
+++ b/internal/service/itx/meeting_service.go
@@ -9,26 +9,25 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/models"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
 )
 
 // MeetingService handles ITX Zoom meeting operations
 type MeetingService struct {
+	auditStamper
 	meetingClient domain.ITXMeetingClient
 	idMapper      domain.IDMapper
-	userMetadata  domain.UserMetadataReader
 }
 
 // NewMeetingService creates a new ITX meeting service. userMetadata may be nil (e.g. when
-// NATS is disabled), in which case created_by on newly created meetings is limited to the
-// JWT-derived username/email (profile enrichment such as name/avatar is skipped) rather
-// than blocking creation.
+// NATS is disabled), in which case created_by / updated_by are limited to the JWT-derived
+// username/email (profile enrichment such as name/avatar is skipped) rather than blocking
+// the request.
 func NewMeetingService(meetingClient domain.ITXMeetingClient, idMapper domain.IDMapper, userMetadata domain.UserMetadataReader) *MeetingService {
 	return &MeetingService{
+		auditStamper:  auditStamper{userMetadata: userMetadata},
 		meetingClient: meetingClient,
 		idMapper:      idMapper,
-		userMetadata:  userMetadata,
 	}
 }
 
@@ -140,6 +139,9 @@ func (s *MeetingService) RegisterCommitteeMembers(ctx context.Context, meetingID
 
 // UpdateOccurrence updates a specific occurrence of a recurring meeting via ITX proxy
 func (s *MeetingService) UpdateOccurrence(ctx context.Context, meetingID, occurrenceID string, req *itx.UpdateOccurrenceRequest) error {
+	// Stamp updated_by from the authenticated principal so ITX overwrites the stored
+	// value on the occurrence record instead of preserving stale data.
+	req.UpdatedBy = s.buildRequestingUser(ctx)
 	return s.meetingClient.UpdateOccurrence(ctx, meetingID, occurrenceID, req)
 }
 
@@ -162,42 +164,7 @@ func validateMeetingRequest(req *models.CreateITXMeetingRequest) error {
 	return nil
 }
 
-// buildRequestingUser resolves the requesting user's identity (from the JWT principal
-// stashed in ctx by the auth middleware) into an itx.User. Used to stamp the meeting
-// creator on create requests and the updater on update requests. Returns nil when there
-// is no principal to resolve, or when resolution isn't possible (never blocks meeting
-// create/update on identity-resolution failures — degrades to nil, or to a minimal
-// {username, email} record when metadata lookup fails but we still have those from the
-// JWT).
-func (s *MeetingService) buildRequestingUser(ctx context.Context) *itx.User {
-	principal, _ := ctx.Value(constants.PrincipalContextID).(string)
-	if principal == "" {
-		return nil
-	}
-	email, _ := ctx.Value(constants.EmailContextID).(string)
-
-	if s.userMetadata == nil {
-		return &itx.User{Username: principal, Email: email}
-	}
-
-	profile, err := s.userMetadata.ResolveProfile(ctx, principal)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to resolve user profile for meeting created_by/updated_by; stamping username/email only",
-			"username", principal, "err", err)
-		return &itx.User{Username: principal, Email: email}
-	}
-
-	user := &itx.User{
-		Username:       principal,
-		Name:           profile.Name,
-		Email:          profile.Email,
-		ProfilePicture: profile.AvatarURL,
-	}
-	if user.Email == "" {
-		user.Email = email
-	}
-	return user
-}
+// buildRequestingUser is provided by the embedded auditStamper; see audit.go.
 
 // transformToITXRequest transforms domain request to ITX request format
 func (s *MeetingService) transformToITXRequest(req *models.CreateITXMeetingRequest) *itx.CreateZoomMeetingRequest {

--- a/internal/service/itx/meeting_service_test.go
+++ b/internal/service/itx/meeting_service_test.go
@@ -13,18 +13,19 @@ import (
 
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/models"
-	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
 	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
 )
 
-// fakeMeetingClient captures the CreateZoomMeetingRequest/UpdateZoomMeetingRequest it
-// receives so tests can assert on the outbound created_by field.
+// fakeMeetingClient captures the CreateZoomMeetingRequest / UpdateZoomMeetingRequest /
+// UpdateOccurrenceRequest it receives so tests can assert on the outbound audit fields.
 type fakeMeetingClient struct {
 	domain.ITXMeetingClient
-	lastCreateReq *itx.CreateZoomMeetingRequest
-	lastUpdateReq *itx.CreateZoomMeetingRequest
-	createResp    *itx.ZoomMeetingResponse
-	createErr     error
+	lastCreateReq          *itx.CreateZoomMeetingRequest
+	lastUpdateReq          *itx.CreateZoomMeetingRequest
+	lastUpdateOccurrenceID string
+	lastUpdateOccurrence   *itx.UpdateOccurrenceRequest
+	createResp             *itx.ZoomMeetingResponse
+	createErr              error
 }
 
 func (f *fakeMeetingClient) CreateZoomMeeting(_ context.Context, req *itx.CreateZoomMeetingRequest) (*itx.ZoomMeetingResponse, error) {
@@ -43,37 +44,10 @@ func (f *fakeMeetingClient) UpdateZoomMeeting(_ context.Context, _ string, req *
 	return nil
 }
 
-// noOpIDMapper passes IDs through unchanged.
-type noOpIDMapper struct{ domain.IDMapper }
-
-func (noOpIDMapper) MapProjectV2ToV1(_ context.Context, v2UID string) (string, error) {
-	return v2UID, nil
-}
-func (noOpIDMapper) MapProjectV1ToV2(_ context.Context, v1SFID string) (string, error) {
-	return v1SFID, nil
-}
-
-// fakeUserMetadataReader returns a canned profile or error for ResolveProfile.
-type fakeUserMetadataReader struct {
-	profile *domain.UserProfile
-	err     error
-	calls   []string
-}
-
-func (f *fakeUserMetadataReader) ResolveProfile(_ context.Context, username string) (*domain.UserProfile, error) {
-	f.calls = append(f.calls, username)
-	if f.err != nil {
-		return nil, f.err
-	}
-	return f.profile, nil
-}
-
-func ctxWithPrincipal(principal, email string) context.Context {
-	ctx := context.WithValue(context.Background(), constants.PrincipalContextID, principal)
-	if email != "" {
-		ctx = context.WithValue(ctx, constants.EmailContextID, email)
-	}
-	return ctx
+func (f *fakeMeetingClient) UpdateOccurrence(_ context.Context, _, occurrenceID string, req *itx.UpdateOccurrenceRequest) error {
+	f.lastUpdateOccurrenceID = occurrenceID
+	f.lastUpdateOccurrence = req
+	return nil
 }
 
 func TestMeetingService_CreateMeeting_CreatedBy(t *testing.T) {
@@ -236,5 +210,32 @@ func TestMeetingService_UpdateMeeting_StampsUpdatedByNotCreatedBy(t *testing.T) 
 		assert.Nil(t, client.lastUpdateReq.UpdatedBy)
 		assert.Nil(t, client.lastUpdateReq.CreatedBy)
 		assert.Empty(t, reader.calls, "resolver should not be called without a principal")
+	})
+}
+
+func TestMeetingService_UpdateOccurrence_StampsUpdatedBy(t *testing.T) {
+	t.Run("stamps updated_by from resolved profile", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		reader := &fakeUserMetadataReader{
+			profile: &domain.UserProfile{Username: "alice", Name: "Alice Example", Email: "alice@example.com"},
+		}
+		svc := NewMeetingService(client, noOpIDMapper{}, reader)
+
+		err := svc.UpdateOccurrence(ctxWithPrincipal("alice", ""), "meeting-1", "occ-1", &itx.UpdateOccurrenceRequest{Topic: "new topic"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateOccurrence)
+		require.NotNil(t, client.lastUpdateOccurrence.UpdatedBy, "occurrence update must stamp updated_by so ITX doesn't preserve stale data")
+		assert.Equal(t, "alice", client.lastUpdateOccurrence.UpdatedBy.Username)
+		assert.Equal(t, "Alice Example", client.lastUpdateOccurrence.UpdatedBy.Name)
+	})
+
+	t.Run("omits updated_by when no principal in context", func(t *testing.T) {
+		client := &fakeMeetingClient{}
+		svc := NewMeetingService(client, noOpIDMapper{}, nil)
+
+		err := svc.UpdateOccurrence(context.Background(), "meeting-1", "occ-1", &itx.UpdateOccurrenceRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateOccurrence)
+		assert.Nil(t, client.lastUpdateOccurrence.UpdatedBy)
 	})
 }

--- a/internal/service/itx/past_meeting_attachment_service.go
+++ b/internal/service/itx/past_meeting_attachment_service.go
@@ -12,18 +12,26 @@ import (
 
 // PastMeetingAttachmentService handles ITX past meeting attachment operations
 type PastMeetingAttachmentService struct {
+	auditStamper
 	attachmentClient domain.ITXPastMeetingAttachmentClient
 }
 
-// NewPastMeetingAttachmentService creates a new ITX past meeting attachment service
-func NewPastMeetingAttachmentService(attachmentClient domain.ITXPastMeetingAttachmentClient) *PastMeetingAttachmentService {
+// NewPastMeetingAttachmentService creates a new ITX past meeting attachment service.
+// userMetadata may be nil (e.g. when NATS is disabled), in which case created_by /
+// updated_by are limited to the JWT-derived username/email rather than blocking the
+// request.
+func NewPastMeetingAttachmentService(attachmentClient domain.ITXPastMeetingAttachmentClient, userMetadata domain.UserMetadataReader) *PastMeetingAttachmentService {
 	return &PastMeetingAttachmentService{
+		auditStamper:     auditStamper{userMetadata: userMetadata},
 		attachmentClient: attachmentClient,
 	}
 }
 
 // CreatePastMeetingAttachment creates a new past meeting attachment via ITX proxy
 func (s *PastMeetingAttachmentService) CreatePastMeetingAttachment(ctx context.Context, meetingAndOccurrenceID string, req *itx.CreatePastMeetingAttachmentRequest) (*itx.PastMeetingAttachment, error) {
+	// Stamp created_by (with full profile enrichment when available) from the
+	// authenticated principal, matching the enrichment level of the Meeting endpoint.
+	req.CreatedBy = s.buildRequestingCreatedUpdatedBy(ctx)
 	return s.attachmentClient.CreatePastMeetingAttachment(ctx, meetingAndOccurrenceID, req)
 }
 
@@ -34,6 +42,10 @@ func (s *PastMeetingAttachmentService) GetPastMeetingAttachment(ctx context.Cont
 
 // UpdatePastMeetingAttachment updates a past meeting attachment via ITX proxy
 func (s *PastMeetingAttachmentService) UpdatePastMeetingAttachment(ctx context.Context, meetingAndOccurrenceID, attachmentID string, req *itx.UpdatePastMeetingAttachmentRequest) error {
+	// Stamp updated_by (with full profile enrichment when available) from the
+	// authenticated principal so ITX overwrites the stored value instead of preserving
+	// stale data.
+	req.UpdatedBy = s.buildRequestingCreatedUpdatedBy(ctx)
 	return s.attachmentClient.UpdatePastMeetingAttachment(ctx, meetingAndOccurrenceID, attachmentID, req)
 }
 
@@ -44,6 +56,9 @@ func (s *PastMeetingAttachmentService) DeletePastMeetingAttachment(ctx context.C
 
 // CreatePastMeetingAttachmentPresignURL generates a presigned URL for past meeting attachment upload via ITX proxy
 func (s *PastMeetingAttachmentService) CreatePastMeetingAttachmentPresignURL(ctx context.Context, meetingAndOccurrenceID string, req *itx.CreateAttachmentPresignRequest) (*itx.PastMeetingAttachmentPresignResponse, error) {
+	// The presign step is also a "create" in ITX's view (it persists an attachment
+	// record with upload_status=ongoing), so stamp created_by here too.
+	req.CreatedBy = s.buildRequestingCreatedUpdatedBy(ctx)
 	return s.attachmentClient.CreatePastMeetingAttachmentPresignURL(ctx, meetingAndOccurrenceID, req)
 }
 

--- a/internal/service/itx/past_meeting_attachment_service_test.go
+++ b/internal/service/itx/past_meeting_attachment_service_test.go
@@ -1,0 +1,81 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+type fakePastMeetingAttachmentClient struct {
+	domain.ITXPastMeetingAttachmentClient
+	lastCreateReq        *itx.CreatePastMeetingAttachmentRequest
+	lastUpdateReq        *itx.UpdatePastMeetingAttachmentRequest
+	lastCreatePresignReq *itx.CreateAttachmentPresignRequest
+}
+
+func (f *fakePastMeetingAttachmentClient) CreatePastMeetingAttachment(_ context.Context, _ string, req *itx.CreatePastMeetingAttachmentRequest) (*itx.PastMeetingAttachment, error) {
+	f.lastCreateReq = req
+	return &itx.PastMeetingAttachment{}, nil
+}
+
+func (f *fakePastMeetingAttachmentClient) UpdatePastMeetingAttachment(_ context.Context, _, _ string, req *itx.UpdatePastMeetingAttachmentRequest) error {
+	f.lastUpdateReq = req
+	return nil
+}
+
+func (f *fakePastMeetingAttachmentClient) CreatePastMeetingAttachmentPresignURL(_ context.Context, _ string, req *itx.CreateAttachmentPresignRequest) (*itx.PastMeetingAttachmentPresignResponse, error) {
+	f.lastCreatePresignReq = req
+	return &itx.PastMeetingAttachmentPresignResponse{}, nil
+}
+
+func TestPastMeetingAttachmentService_StampsAuditFields(t *testing.T) {
+	newSvcWithReader := func() (*PastMeetingAttachmentService, *fakePastMeetingAttachmentClient) {
+		client := &fakePastMeetingAttachmentClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username: "alice", Name: "Alice", Email: "alice@example.com",
+		}}
+		return NewPastMeetingAttachmentService(client, reader), client
+	}
+
+	t.Run("create stamps enriched CreatedBy", func(t *testing.T) {
+		svc, client := newSvcWithReader()
+		_, err := svc.CreatePastMeetingAttachment(ctxWithPrincipal("alice", ""), "pm-1", &itx.CreatePastMeetingAttachmentRequest{Name: "recording-notes.pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreateReq.CreatedBy)
+		assert.Equal(t, "Alice", client.lastCreateReq.CreatedBy.Name)
+		assert.Equal(t, "alice@example.com", client.lastCreateReq.CreatedBy.Email)
+	})
+
+	t.Run("update stamps enriched UpdatedBy", func(t *testing.T) {
+		svc, client := newSvcWithReader()
+		err := svc.UpdatePastMeetingAttachment(ctxWithPrincipal("alice", ""), "pm-1", "att-1", &itx.UpdatePastMeetingAttachmentRequest{Name: "notes.pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "Alice", client.lastUpdateReq.UpdatedBy.Name)
+	})
+
+	t.Run("presign stamps CreatedBy", func(t *testing.T) {
+		svc, client := newSvcWithReader()
+		_, err := svc.CreatePastMeetingAttachmentPresignURL(ctxWithPrincipal("alice", ""), "pm-1", &itx.CreateAttachmentPresignRequest{Name: "notes.pdf", FileSize: 1, FileType: "application/pdf"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreatePresignReq.CreatedBy)
+		assert.Equal(t, "Alice", client.lastCreatePresignReq.CreatedBy.Name)
+	})
+
+	t.Run("omits stamp without principal", func(t *testing.T) {
+		client := &fakePastMeetingAttachmentClient{}
+		svc := NewPastMeetingAttachmentService(client, nil)
+
+		_, err := svc.CreatePastMeetingAttachment(context.Background(), "pm-1", &itx.CreatePastMeetingAttachmentRequest{Name: "notes.pdf"})
+		require.NoError(t, err)
+		assert.Nil(t, client.lastCreateReq.CreatedBy)
+	})
+}

--- a/internal/service/itx/past_meeting_participant_service.go
+++ b/internal/service/itx/past_meeting_participant_service.go
@@ -16,13 +16,18 @@ import (
 
 // PastMeetingParticipantService handles unified participant operations by routing to invitee/attendee endpoints
 type PastMeetingParticipantService struct {
+	auditStamper
 	participantClient domain.ITXPastMeetingParticipantClient
 	idMapper          domain.IDMapper
 }
 
-// NewPastMeetingParticipantService creates a new participant service
-func NewPastMeetingParticipantService(participantClient domain.ITXPastMeetingParticipantClient, idMapper domain.IDMapper) *PastMeetingParticipantService {
+// NewPastMeetingParticipantService creates a new participant service. userMetadata may be
+// nil (e.g. when NATS is disabled), in which case created_by / updated_by on invitee /
+// attendee records are limited to the JWT-derived username/email rather than blocking
+// the request.
+func NewPastMeetingParticipantService(participantClient domain.ITXPastMeetingParticipantClient, idMapper domain.IDMapper, userMetadata domain.UserMetadataReader) *PastMeetingParticipantService {
 	return &PastMeetingParticipantService{
+		auditStamper:      auditStamper{userMetadata: userMetadata},
 		participantClient: participantClient,
 		idMapper:          idMapper,
 	}
@@ -88,8 +93,15 @@ func (s *PastMeetingParticipantService) CreateParticipant(
 	var inviteeResp *itx.InviteeResponse
 	var attendeeResp *itx.AttendeeResponse
 
+	// Resolve the requesting user once and stamp created_by on both invitee and
+	// attendee records so the audit trail reflects who added them via the v2 API.
+	creator := s.buildRequestingUser(ctx)
+
 	// Create invitee if requested
 	if isInvited {
+		if inviteeReq != nil {
+			inviteeReq.CreatedBy = creator
+		}
 		resp, err := s.participantClient.CreateInvitee(ctx, pastMeetingID, inviteeReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create invitee: %w", err)
@@ -99,6 +111,9 @@ func (s *PastMeetingParticipantService) CreateParticipant(
 
 	// Create attendee if requested
 	if isAttended {
+		if attendeeReq != nil {
+			attendeeReq.CreatedBy = creator
+		}
 		resp, err := s.participantClient.CreateAttendee(ctx, pastMeetingID, attendeeReq)
 		if err != nil {
 			// If invitee was created but attendee fails, we have a partial state
@@ -118,8 +133,16 @@ func (s *PastMeetingParticipantService) UpdateParticipant(
 	inviteeReq *itx.UpdateInviteeRequest,
 	attendeeReq *itx.UpdateAttendeeRequest,
 ) (*ParticipantResponse, error) {
-	inviteeResp, inviteeExists := s.handleInviteeOperation(ctx, p.PastMeetingID, p.ParticipantID, p.InviteeID, p.IsInvited, inviteeReq)
-	attendeeResp, attendeeExists := s.handleAttendeeOperation(ctx, p.PastMeetingID, p.ParticipantID, p.AttendeeID, p.IsAttended, attendeeReq)
+	// Resolve the requesting user once and pass it through both operation paths (and
+	// any create-fallback within them). Each ResolveProfile call is a NATS request
+	// with a 2s timeout, so calling it independently in updateInvitee, updateAttendee,
+	// createInviteeFromUpdate and createAttendeeFromUpdate would add up to 4s of
+	// latency and could produce inconsistent stamps if one lookup returns a full
+	// profile and the other times out. Matches CreateParticipant's approach.
+	updater := s.buildRequestingUser(ctx)
+
+	inviteeResp, inviteeExists := s.handleInviteeOperation(ctx, p.PastMeetingID, p.ParticipantID, p.InviteeID, p.IsInvited, inviteeReq, updater)
+	attendeeResp, attendeeExists := s.handleAttendeeOperation(ctx, p.PastMeetingID, p.ParticipantID, p.AttendeeID, p.IsAttended, attendeeReq, updater)
 	return mergeParticipantResponses(p.PastMeetingID, inviteeResp, attendeeResp, inviteeExists, attendeeExists), nil
 }
 
@@ -128,6 +151,7 @@ func (s *PastMeetingParticipantService) handleInviteeOperation(
 	pastMeetingID, participantID, inviteeID string,
 	isInvited *bool,
 	inviteeReq *itx.UpdateInviteeRequest,
+	updater *itx.User,
 ) (*itx.InviteeResponse, bool) {
 	if isInvited == nil {
 		return nil, false
@@ -153,11 +177,11 @@ func (s *PastMeetingParticipantService) handleInviteeOperation(
 	}
 
 	if !inviteeExists && inviteeReq != nil {
-		return s.createInviteeFromUpdate(ctx, pastMeetingID, inviteeReq), true
+		return s.createInviteeFromUpdate(ctx, pastMeetingID, inviteeReq, updater), true
 	}
 
 	if inviteeExists && inviteeReq != nil && actualInviteeID != "" {
-		return s.updateInvitee(ctx, pastMeetingID, actualInviteeID, participantID, inviteeReq), true
+		return s.updateInvitee(ctx, pastMeetingID, actualInviteeID, participantID, inviteeReq, updater), true
 	}
 
 	return nil, inviteeExists
@@ -168,6 +192,7 @@ func (s *PastMeetingParticipantService) handleAttendeeOperation(
 	pastMeetingID, participantID, attendeeID string,
 	isAttended *bool,
 	attendeeReq *itx.UpdateAttendeeRequest,
+	updater *itx.User,
 ) (*itx.AttendeeResponse, bool) {
 	if isAttended == nil {
 		return nil, false
@@ -193,11 +218,11 @@ func (s *PastMeetingParticipantService) handleAttendeeOperation(
 	}
 
 	if !attendeeExists && attendeeReq != nil {
-		return s.createAttendeeFromUpdate(ctx, pastMeetingID, attendeeReq), true
+		return s.createAttendeeFromUpdate(ctx, pastMeetingID, attendeeReq, updater), true
 	}
 
 	if attendeeExists && attendeeReq != nil && actualAttendeeID != "" {
-		return s.updateAttendee(ctx, pastMeetingID, actualAttendeeID, participantID, attendeeReq), true
+		return s.updateAttendee(ctx, pastMeetingID, actualAttendeeID, participantID, attendeeReq, updater), true
 	}
 
 	return nil, attendeeExists
@@ -288,6 +313,7 @@ func (s *PastMeetingParticipantService) createInviteeFromUpdate(
 	ctx context.Context,
 	pastMeetingID string,
 	updateReq *itx.UpdateInviteeRequest,
+	updater *itx.User,
 ) *itx.InviteeResponse {
 	// Convert UpdateInviteeRequest to CreateInviteeRequest
 	createReq := &itx.CreateInviteeRequest{
@@ -302,6 +328,11 @@ func (s *PastMeetingParticipantService) createInviteeFromUpdate(
 		JobTitle:              updateReq.JobTitle,
 		CommitteeRole:         updateReq.CommitteeRole,
 		CommitteeVotingStatus: updateReq.CommitteeVotingStatus,
+		// This path is exercised when an update targets an invitee that doesn't yet
+		// exist; stamp created_by since ITX will treat this as a fresh record.
+		// updater is resolved once in UpdateParticipant so both the invitee and
+		// attendee sides of a single update carry consistent audit stamps.
+		CreatedBy: updater,
 	}
 
 	resp, err := s.participantClient.CreateInvitee(ctx, pastMeetingID, createReq)
@@ -320,6 +351,7 @@ func (s *PastMeetingParticipantService) createAttendeeFromUpdate(
 	ctx context.Context,
 	pastMeetingID string,
 	updateReq *itx.UpdateAttendeeRequest,
+	updater *itx.User,
 ) *itx.AttendeeResponse {
 	// Convert UpdateAttendeeRequest to CreateAttendeeRequest
 	createReq := &itx.CreateAttendeeRequest{
@@ -328,6 +360,11 @@ func (s *PastMeetingParticipantService) createAttendeeFromUpdate(
 		CommitteeRole:         updateReq.CommitteeRole,
 		CommitteeVotingStatus: updateReq.CommitteeVotingStatus,
 		IsVerified:            updateReq.IsVerified,
+		// This path is exercised when an update targets an attendee that doesn't yet
+		// exist; stamp created_by since ITX will treat this as a fresh record.
+		// updater is resolved once in UpdateParticipant so both the invitee and
+		// attendee sides of a single update carry consistent audit stamps.
+		CreatedBy: updater,
 	}
 
 	resp, err := s.participantClient.CreateAttendee(ctx, pastMeetingID, createReq)
@@ -346,7 +383,13 @@ func (s *PastMeetingParticipantService) updateInvitee(
 	ctx context.Context,
 	pastMeetingID, inviteeID, participantID string,
 	updateReq *itx.UpdateInviteeRequest,
+	updater *itx.User,
 ) *itx.InviteeResponse {
+	// Stamp updated_by from the requester so ITX overwrites the stored value on the
+	// invitee record instead of preserving stale data. updater is resolved once in
+	// UpdateParticipant to keep the invitee and attendee sides consistent.
+	updateReq.UpdatedBy = updater
+
 	resp, err := s.participantClient.UpdateInvitee(ctx, pastMeetingID, inviteeID, updateReq)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to update invitee",
@@ -366,7 +409,13 @@ func (s *PastMeetingParticipantService) updateAttendee(
 	ctx context.Context,
 	pastMeetingID, attendeeID, participantID string,
 	updateReq *itx.UpdateAttendeeRequest,
+	updater *itx.User,
 ) *itx.AttendeeResponse {
+	// Stamp updated_by from the requester so ITX overwrites the stored value on the
+	// attendee record instead of preserving stale data. updater is resolved once in
+	// UpdateParticipant to keep the invitee and attendee sides consistent.
+	updateReq.UpdatedBy = updater
+
 	resp, err := s.participantClient.UpdateAttendee(ctx, pastMeetingID, attendeeID, updateReq)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to update attendee",

--- a/internal/service/itx/past_meeting_participant_service_test.go
+++ b/internal/service/itx/past_meeting_participant_service_test.go
@@ -1,0 +1,226 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain/models"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// fakeParticipantClient records the create/update/delete calls made through it so
+// tests can pin down created_by / updated_by stamping across both invitee and
+// attendee paths.
+type fakeParticipantClient struct {
+	domain.ITXPastMeetingParticipantClient
+
+	inviteeCreateReq  *itx.CreateInviteeRequest
+	inviteeUpdateReq  *itx.UpdateInviteeRequest
+	attendeeCreateReq *itx.CreateAttendeeRequest
+	attendeeUpdateReq *itx.UpdateAttendeeRequest
+}
+
+func (f *fakeParticipantClient) CreateInvitee(_ context.Context, _ string, req *itx.CreateInviteeRequest) (*itx.InviteeResponse, error) {
+	f.inviteeCreateReq = req
+	return &itx.InviteeResponse{UUID: "invitee-1"}, nil
+}
+
+func (f *fakeParticipantClient) UpdateInvitee(_ context.Context, _, _ string, req *itx.UpdateInviteeRequest) (*itx.InviteeResponse, error) {
+	f.inviteeUpdateReq = req
+	return &itx.InviteeResponse{UUID: "invitee-1"}, nil
+}
+
+func (f *fakeParticipantClient) DeleteInvitee(_ context.Context, _, _ string) error { return nil }
+
+func (f *fakeParticipantClient) CreateAttendee(_ context.Context, _ string, req *itx.CreateAttendeeRequest) (*itx.AttendeeResponse, error) {
+	f.attendeeCreateReq = req
+	return &itx.AttendeeResponse{ID: "attendee-1"}, nil
+}
+
+func (f *fakeParticipantClient) UpdateAttendee(_ context.Context, _, _ string, req *itx.UpdateAttendeeRequest) (*itx.AttendeeResponse, error) {
+	f.attendeeUpdateReq = req
+	return &itx.AttendeeResponse{ID: "attendee-1"}, nil
+}
+
+func (f *fakeParticipantClient) DeleteAttendee(_ context.Context, _, _ string) error { return nil }
+
+// participantIDMapper lets tests toggle whether the invitee / attendee mappings
+// resolve, which is how the participant service decides between create and update
+// paths on an update request.
+type participantIDMapper struct {
+	noOpIDMapper
+	inviteeExists  bool
+	attendeeExists bool
+}
+
+func (m participantIDMapper) MapParticipantV2ToInviteeID(_ context.Context, v2UID string) (string, error) {
+	if !m.inviteeExists {
+		return "", nil
+	}
+	return v2UID, nil
+}
+func (m participantIDMapper) MapParticipantV2ToAttendeeID(_ context.Context, v2UID string) (string, error) {
+	if !m.attendeeExists {
+		return "", nil
+	}
+	return v2UID, nil
+}
+
+func TestPastMeetingParticipantService_CreateParticipant_StampsCreatedBy(t *testing.T) {
+	// Ticket flagged that CreateInviteeRequest and CreateAttendeeRequest didn't even
+	// have created_by fields. These tests pin down that both are populated from the
+	// authenticated principal.
+
+	client := &fakeParticipantClient{}
+	reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+		Username: "alice", Name: "Alice", Email: "alice@example.com",
+	}}
+	svc := NewPastMeetingParticipantService(client, noOpIDMapper{}, reader)
+
+	_, err := svc.CreateParticipant(
+		ctxWithPrincipal("alice", ""),
+		"pm-1",
+		true, true,
+		&itx.CreateInviteeRequest{PrimaryEmail: "invitee@example.com"},
+		&itx.CreateAttendeeRequest{Email: "invitee@example.com"},
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, client.inviteeCreateReq.CreatedBy)
+	assert.Equal(t, "alice", client.inviteeCreateReq.CreatedBy.Username)
+	assert.Equal(t, "Alice", client.inviteeCreateReq.CreatedBy.Name)
+
+	require.NotNil(t, client.attendeeCreateReq.CreatedBy)
+	assert.Equal(t, "alice", client.attendeeCreateReq.CreatedBy.Username)
+}
+
+func TestPastMeetingParticipantService_UpdateParticipant_StampsUpdatedByOnExistingRecords(t *testing.T) {
+	client := &fakeParticipantClient{}
+	reader := &fakeUserMetadataReader{profile: &domain.UserProfile{Username: "bob"}}
+	svc := NewPastMeetingParticipantService(
+		client,
+		participantIDMapper{inviteeExists: true, attendeeExists: true},
+		reader,
+	)
+
+	trueVal := true
+	_, err := svc.UpdateParticipant(
+		ctxWithPrincipal("bob", ""),
+		&models.UpdatePastMeetingParticipant{
+			PastMeetingID: "pm-1",
+			ParticipantID: "p-1",
+			IsInvited:     &trueVal,
+			IsAttended:    &trueVal,
+		},
+		&itx.UpdateInviteeRequest{FirstName: "Bob", LastName: "Test"},
+		&itx.UpdateAttendeeRequest{Org: "Corp"},
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, client.inviteeUpdateReq, "invitee update should have been called")
+	require.NotNil(t, client.inviteeUpdateReq.UpdatedBy)
+	assert.Equal(t, "bob", client.inviteeUpdateReq.UpdatedBy.Username)
+
+	require.NotNil(t, client.attendeeUpdateReq, "attendee update should have been called")
+	require.NotNil(t, client.attendeeUpdateReq.UpdatedBy)
+	assert.Equal(t, "bob", client.attendeeUpdateReq.UpdatedBy.Username)
+}
+
+func TestPastMeetingParticipantService_UpdateParticipant_StampsCreatedByOnMissingRecords(t *testing.T) {
+	// Update path: when the underlying invitee / attendee doesn't yet exist, the
+	// service creates it. Those creation calls must stamp created_by, not
+	// updated_by, since ITX treats them as fresh records.
+
+	client := &fakeParticipantClient{}
+	reader := &fakeUserMetadataReader{profile: &domain.UserProfile{Username: "carol"}}
+	svc := NewPastMeetingParticipantService(
+		client,
+		participantIDMapper{inviteeExists: false, attendeeExists: false},
+		reader,
+	)
+
+	trueVal := true
+	_, err := svc.UpdateParticipant(
+		ctxWithPrincipal("carol", ""),
+		&models.UpdatePastMeetingParticipant{
+			PastMeetingID: "pm-1",
+			ParticipantID: "p-1",
+			IsInvited:     &trueVal,
+			IsAttended:    &trueVal,
+		},
+		&itx.UpdateInviteeRequest{FirstName: "Carol", LastName: "Test", PrimaryEmail: "carol@example.com"},
+		&itx.UpdateAttendeeRequest{Org: "Corp"},
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, client.inviteeCreateReq, "should fall back to create when invitee doesn't exist")
+	require.NotNil(t, client.inviteeCreateReq.CreatedBy)
+	assert.Equal(t, "carol", client.inviteeCreateReq.CreatedBy.Username)
+
+	require.NotNil(t, client.attendeeCreateReq, "should fall back to create when attendee doesn't exist")
+	require.NotNil(t, client.attendeeCreateReq.CreatedBy)
+	assert.Equal(t, "carol", client.attendeeCreateReq.CreatedBy.Username)
+}
+
+func TestPastMeetingParticipantService_UpdateParticipant_ResolvesRequesterOnce(t *testing.T) {
+	// Regression guard for the pattern where each helper independently called
+	// buildRequestingUser. ResolveProfile is a NATS request with a 2s timeout, so
+	// firing it twice per update (once for invitee, once for attendee) could add up
+	// to 4s of latency and could produce inconsistent stamps if one lookup returned
+	// a full profile and the other timed out. UpdateParticipant now resolves the
+	// requester once and threads it down.
+
+	assertSingleResolve := func(t *testing.T, mapper participantIDMapper, inviteeReq *itx.UpdateInviteeRequest, attendeeReq *itx.UpdateAttendeeRequest) {
+		t.Helper()
+		client := &fakeParticipantClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{Username: "dana", Name: "Dana"}}
+		svc := NewPastMeetingParticipantService(client, mapper, reader)
+
+		trueVal := true
+		_, err := svc.UpdateParticipant(
+			ctxWithPrincipal("dana", ""),
+			&models.UpdatePastMeetingParticipant{
+				PastMeetingID: "pm-1",
+				ParticipantID: "p-1",
+				IsInvited:     &trueVal,
+				IsAttended:    &trueVal,
+			},
+			inviteeReq,
+			attendeeReq,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"dana"}, reader.calls,
+			"UpdateParticipant must resolve the requester once and share it across the invitee and attendee paths")
+	}
+
+	t.Run("both records exist (double update)", func(t *testing.T) {
+		assertSingleResolve(t,
+			participantIDMapper{inviteeExists: true, attendeeExists: true},
+			&itx.UpdateInviteeRequest{FirstName: "D", LastName: "T"},
+			&itx.UpdateAttendeeRequest{Org: "Corp"},
+		)
+	})
+
+	t.Run("neither record exists (double create-from-update fallback)", func(t *testing.T) {
+		assertSingleResolve(t,
+			participantIDMapper{inviteeExists: false, attendeeExists: false},
+			&itx.UpdateInviteeRequest{FirstName: "D", LastName: "T", PrimaryEmail: "d@example.com"},
+			&itx.UpdateAttendeeRequest{Org: "Corp"},
+		)
+	})
+
+	t.Run("mixed (update invitee, create attendee)", func(t *testing.T) {
+		assertSingleResolve(t,
+			participantIDMapper{inviteeExists: true, attendeeExists: false},
+			&itx.UpdateInviteeRequest{FirstName: "D", LastName: "T"},
+			&itx.UpdateAttendeeRequest{Org: "Corp"},
+		)
+	})
+}

--- a/internal/service/itx/past_meeting_service.go
+++ b/internal/service/itx/past_meeting_service.go
@@ -13,13 +13,17 @@ import (
 
 // PastMeetingService handles ITX past meeting operations
 type PastMeetingService struct {
+	auditStamper
 	pastMeetingClient domain.ITXPastMeetingClient
 	idMapper          domain.IDMapper
 }
 
-// NewPastMeetingService creates a new ITX past meeting service
-func NewPastMeetingService(pastMeetingClient domain.ITXPastMeetingClient, idMapper domain.IDMapper) *PastMeetingService {
+// NewPastMeetingService creates a new ITX past meeting service. userMetadata may be nil
+// (e.g. when NATS is disabled), in which case created_by / updated_by are limited to the
+// JWT-derived username/email rather than blocking the request.
+func NewPastMeetingService(pastMeetingClient domain.ITXPastMeetingClient, idMapper domain.IDMapper, userMetadata domain.UserMetadataReader) *PastMeetingService {
 	return &PastMeetingService{
+		auditStamper:      auditStamper{userMetadata: userMetadata},
 		pastMeetingClient: pastMeetingClient,
 		idMapper:          idMapper,
 	}
@@ -46,6 +50,10 @@ func (s *PastMeetingService) CreatePastMeeting(ctx context.Context, req *itx.Cre
 			req.Committees[i].ID = v1ID
 		}
 	}
+
+	// Stamp created_by from the authenticated principal so the past-meeting record's
+	// audit trail reflects who created it via the v2 API.
+	req.CreatedBy = s.buildRequestingUser(ctx)
 
 	resp, err := s.pastMeetingClient.CreatePastMeeting(ctx, req)
 	if err != nil {
@@ -134,6 +142,11 @@ func (s *PastMeetingService) UpdatePastMeeting(ctx context.Context, pastMeetingI
 			req.Committees[i].ID = v1ID
 		}
 	}
+
+	// Stamp updated_by from the authenticated principal so ITX overwrites the stored
+	// updated_by / updated_by_list on the past-meeting record instead of preserving
+	// stale data.
+	req.UpdatedBy = s.buildRequestingUser(ctx)
 
 	_, err := s.pastMeetingClient.UpdatePastMeeting(ctx, pastMeetingID, req)
 	if err != nil {

--- a/internal/service/itx/past_meeting_service_test.go
+++ b/internal/service/itx/past_meeting_service_test.go
@@ -1,0 +1,83 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// fakePastMeetingClient captures the past-meeting requests sent to ITX so tests can
+// assert on the outbound created_by / updated_by stamping.
+type fakePastMeetingClient struct {
+	domain.ITXPastMeetingClient
+	lastCreateReq *itx.CreatePastMeetingRequest
+	lastUpdateReq *itx.CreatePastMeetingRequest
+}
+
+func (f *fakePastMeetingClient) CreatePastMeeting(_ context.Context, req *itx.CreatePastMeetingRequest) (*itx.PastMeetingResponse, error) {
+	f.lastCreateReq = req
+	return &itx.PastMeetingResponse{}, nil
+}
+
+func (f *fakePastMeetingClient) UpdatePastMeeting(_ context.Context, _ string, req *itx.CreatePastMeetingRequest) (*itx.PastMeetingResponse, error) {
+	f.lastUpdateReq = req
+	return &itx.PastMeetingResponse{}, nil
+}
+
+func TestPastMeetingService_CreatePastMeeting_StampsCreatedBy(t *testing.T) {
+	t.Run("stamps full profile on create; leaves updated_by nil", func(t *testing.T) {
+		client := &fakePastMeetingClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username: "alice", Name: "Alice", Email: "alice@example.com",
+		}}
+		svc := NewPastMeetingService(client, noOpIDMapper{}, reader)
+
+		_, err := svc.CreatePastMeeting(ctxWithPrincipal("alice", ""), &itx.CreatePastMeetingRequest{
+			MeetingID:    "mtg-1",
+			OccurrenceID: "1234567890",
+			ProjectID:    "proj-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreateReq.CreatedBy)
+		assert.Equal(t, "alice", client.lastCreateReq.CreatedBy.Username)
+		assert.Equal(t, "Alice", client.lastCreateReq.CreatedBy.Name)
+		assert.Nil(t, client.lastCreateReq.UpdatedBy)
+	})
+
+	t.Run("omits stamp without principal", func(t *testing.T) {
+		client := &fakePastMeetingClient{}
+		svc := NewPastMeetingService(client, noOpIDMapper{}, nil)
+		_, err := svc.CreatePastMeeting(context.Background(), &itx.CreatePastMeetingRequest{
+			MeetingID:    "mtg-1",
+			OccurrenceID: "1234567890",
+			ProjectID:    "proj-1",
+		})
+		require.NoError(t, err)
+		assert.Nil(t, client.lastCreateReq.CreatedBy)
+	})
+}
+
+func TestPastMeetingService_UpdatePastMeeting_StampsUpdatedByNotCreatedBy(t *testing.T) {
+	t.Run("stamps only updated_by on update", func(t *testing.T) {
+		client := &fakePastMeetingClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{Username: "bob"}}
+		svc := NewPastMeetingService(client, noOpIDMapper{}, reader)
+
+		_, err := svc.UpdatePastMeeting(ctxWithPrincipal("bob", "bob@example.com"), "pm-1", &itx.CreatePastMeetingRequest{
+			ProjectID: "proj-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "bob", client.lastUpdateReq.UpdatedBy.Username)
+		assert.Equal(t, "bob@example.com", client.lastUpdateReq.UpdatedBy.Email)
+		assert.Nil(t, client.lastUpdateReq.CreatedBy, "update must not overwrite original creator")
+	})
+}

--- a/internal/service/itx/past_meeting_summary_service.go
+++ b/internal/service/itx/past_meeting_summary_service.go
@@ -12,12 +12,16 @@ import (
 
 // PastMeetingSummaryService handles ITX past meeting summary operations
 type PastMeetingSummaryService struct {
+	auditStamper
 	summaryClient domain.ITXPastMeetingSummaryClient
 }
 
-// NewPastMeetingSummaryService creates a new ITX past meeting summary service
-func NewPastMeetingSummaryService(summaryClient domain.ITXPastMeetingSummaryClient) *PastMeetingSummaryService {
+// NewPastMeetingSummaryService creates a new ITX past meeting summary service.
+// userMetadata may be nil (e.g. when NATS is disabled), in which case modified_by is
+// limited to the JWT-derived username/email rather than blocking the request.
+func NewPastMeetingSummaryService(summaryClient domain.ITXPastMeetingSummaryClient, userMetadata domain.UserMetadataReader) *PastMeetingSummaryService {
 	return &PastMeetingSummaryService{
+		auditStamper:  auditStamper{userMetadata: userMetadata},
 		summaryClient: summaryClient,
 	}
 }
@@ -29,5 +33,8 @@ func (s *PastMeetingSummaryService) GetPastMeetingSummary(ctx context.Context, p
 
 // UpdatePastMeetingSummary updates a past meeting summary via ITX proxy
 func (s *PastMeetingSummaryService) UpdatePastMeetingSummary(ctx context.Context, pastMeetingID, summaryID string, req *itx.UpdatePastMeetingSummaryRequest) (*itx.PastMeetingSummaryResponse, error) {
+	// Stamp modified_by from the authenticated principal. ITX persists whatever the
+	// caller sends here; leaving it blank produces a null audit entry.
+	req.ModifiedBy = s.buildRequestingUser(ctx)
 	return s.summaryClient.UpdatePastMeetingSummary(ctx, pastMeetingID, summaryID, req)
 }

--- a/internal/service/itx/past_meeting_summary_service_test.go
+++ b/internal/service/itx/past_meeting_summary_service_test.go
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+type fakePastMeetingSummaryClient struct {
+	domain.ITXPastMeetingSummaryClient
+	lastUpdateReq *itx.UpdatePastMeetingSummaryRequest
+}
+
+func (f *fakePastMeetingSummaryClient) UpdatePastMeetingSummary(_ context.Context, _, _ string, req *itx.UpdatePastMeetingSummaryRequest) (*itx.PastMeetingSummaryResponse, error) {
+	f.lastUpdateReq = req
+	return &itx.PastMeetingSummaryResponse{}, nil
+}
+
+func TestPastMeetingSummaryService_Update_StampsModifiedBy(t *testing.T) {
+	// The ticket flagged this call out explicitly because the ITX side uses the
+	// non-standard field name modified_by (not updated_by), and the previous
+	// converter comment claimed ITX would derive the value from the JWT — which
+	// isn't accurate for our M2M-token calls.
+
+	t.Run("stamps full profile", func(t *testing.T) {
+		client := &fakePastMeetingSummaryClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username: "alice", Name: "Alice", Email: "alice@example.com",
+		}}
+		svc := NewPastMeetingSummaryService(client, reader)
+
+		_, err := svc.UpdatePastMeetingSummary(ctxWithPrincipal("alice", ""), "pm-1", "sum-1", &itx.UpdatePastMeetingSummaryRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.ModifiedBy)
+		assert.Equal(t, "alice", client.lastUpdateReq.ModifiedBy.Username)
+		assert.Equal(t, "Alice", client.lastUpdateReq.ModifiedBy.Name)
+	})
+
+	t.Run("omits modified_by without principal", func(t *testing.T) {
+		client := &fakePastMeetingSummaryClient{}
+		svc := NewPastMeetingSummaryService(client, nil)
+
+		_, err := svc.UpdatePastMeetingSummary(context.Background(), "pm-1", "sum-1", &itx.UpdatePastMeetingSummaryRequest{})
+		require.NoError(t, err)
+		assert.Nil(t, client.lastUpdateReq.ModifiedBy)
+	})
+}

--- a/internal/service/itx/registrant_service.go
+++ b/internal/service/itx/registrant_service.go
@@ -13,13 +13,17 @@ import (
 
 // RegistrantService handles ITX Zoom registrant operations
 type RegistrantService struct {
+	auditStamper
 	registrantClient domain.ITXRegistrantClient
 	idMapper         domain.IDMapper
 }
 
-// NewRegistrantService creates a new ITX registrant service
-func NewRegistrantService(registrantClient domain.ITXRegistrantClient, idMapper domain.IDMapper) *RegistrantService {
+// NewRegistrantService creates a new ITX registrant service. userMetadata may be nil (e.g.
+// when NATS is disabled), in which case created_by / updated_by are limited to the
+// JWT-derived username/email rather than blocking the request.
+func NewRegistrantService(registrantClient domain.ITXRegistrantClient, idMapper domain.IDMapper, userMetadata domain.UserMetadataReader) *RegistrantService {
 	return &RegistrantService{
+		auditStamper:     auditStamper{userMetadata: userMetadata},
 		registrantClient: registrantClient,
 		idMapper:         idMapper,
 	}
@@ -35,6 +39,11 @@ func (s *RegistrantService) CreateRegistrant(ctx context.Context, meetingID stri
 		}
 		req.CommitteeID = v1SFID
 	}
+
+	// Stamp created_by from the authenticated principal so the registrant's audit
+	// trail reflects who added them via the v2 API (M2M token to ITX would otherwise
+	// leave this blank or attribute it to the service identity).
+	req.CreatedBy = s.buildRequestingUser(ctx)
 
 	resp, err := s.registrantClient.CreateRegistrant(ctx, meetingID, req)
 	if err != nil {
@@ -90,6 +99,10 @@ func (s *RegistrantService) UpdateRegistrant(ctx context.Context, meetingID, reg
 		}
 		req.CommitteeID = v1SFID
 	}
+
+	// Stamp updated_by from the authenticated principal so ITX overwrites the stored
+	// updated_by on the registrant record instead of preserving stale data.
+	req.UpdatedBy = s.buildRequestingUser(ctx)
 
 	return s.registrantClient.UpdateRegistrant(ctx, meetingID, registrantID, req)
 }

--- a/internal/service/itx/registrant_service_test.go
+++ b/internal/service/itx/registrant_service_test.go
@@ -1,0 +1,75 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// fakeRegistrantClient captures the ZoomMeetingRegistrant sent to ITX so tests can
+// assert on the outbound created_by / updated_by stamping.
+type fakeRegistrantClient struct {
+	domain.ITXRegistrantClient
+	lastCreateReq *itx.ZoomMeetingRegistrant
+	lastUpdateReq *itx.ZoomMeetingRegistrant
+}
+
+func (f *fakeRegistrantClient) CreateRegistrant(_ context.Context, _ string, req *itx.ZoomMeetingRegistrant) (*itx.ZoomMeetingRegistrant, error) {
+	f.lastCreateReq = req
+	return &itx.ZoomMeetingRegistrant{}, nil
+}
+
+func (f *fakeRegistrantClient) UpdateRegistrant(_ context.Context, _, _ string, req *itx.ZoomMeetingRegistrant) error {
+	f.lastUpdateReq = req
+	return nil
+}
+
+func TestRegistrantService_CreateRegistrant_StampsCreatedBy(t *testing.T) {
+	t.Run("stamps full profile on create", func(t *testing.T) {
+		client := &fakeRegistrantClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username: "alice", Name: "Alice", Email: "alice@example.com",
+		}}
+		svc := NewRegistrantService(client, noOpIDMapper{}, reader)
+
+		_, err := svc.CreateRegistrant(ctxWithPrincipal("alice", ""), "mtg-1", &itx.ZoomMeetingRegistrant{Email: "invitee@example.com"})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastCreateReq.CreatedBy)
+		assert.Equal(t, "alice", client.lastCreateReq.CreatedBy.Username)
+		assert.Equal(t, "Alice", client.lastCreateReq.CreatedBy.Name)
+		// Create never touches updated_by; leave the record's slot for actual updates.
+		assert.Nil(t, client.lastCreateReq.UpdatedBy)
+	})
+
+	t.Run("omits created_by without principal", func(t *testing.T) {
+		client := &fakeRegistrantClient{}
+		svc := NewRegistrantService(client, noOpIDMapper{}, nil)
+
+		_, err := svc.CreateRegistrant(context.Background(), "mtg-1", &itx.ZoomMeetingRegistrant{})
+		require.NoError(t, err)
+		assert.Nil(t, client.lastCreateReq.CreatedBy)
+	})
+}
+
+func TestRegistrantService_UpdateRegistrant_StampsUpdatedByNotCreatedBy(t *testing.T) {
+	t.Run("stamps only updated_by on update", func(t *testing.T) {
+		client := &fakeRegistrantClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{Username: "bob", Email: "bob@example.com"}}
+		svc := NewRegistrantService(client, noOpIDMapper{}, reader)
+
+		err := svc.UpdateRegistrant(ctxWithPrincipal("bob", ""), "mtg-1", "reg-1", &itx.ZoomMeetingRegistrant{})
+		require.NoError(t, err)
+		require.NotNil(t, client.lastUpdateReq.UpdatedBy)
+		assert.Equal(t, "bob", client.lastUpdateReq.UpdatedBy.Username)
+		// Never overwrite the original creator on update.
+		assert.Nil(t, client.lastUpdateReq.CreatedBy)
+	})
+}

--- a/internal/service/itx/testutil_test.go
+++ b/internal/service/itx/testutil_test.go
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx
+
+import (
+	"context"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/internal/domain"
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/constants"
+)
+
+// Shared test helpers for ITX service package tests. Keeping these in one file lets
+// each per-service test file focus on the stamping behavior specific to it.
+
+// noOpIDMapper passes IDs through unchanged. Individual test files may override
+// specific methods by declaring a local mapper type that embeds this.
+type noOpIDMapper struct{ domain.IDMapper }
+
+func (noOpIDMapper) MapProjectV2ToV1(_ context.Context, v2UID string) (string, error) {
+	return v2UID, nil
+}
+func (noOpIDMapper) MapProjectV1ToV2(_ context.Context, v1SFID string) (string, error) {
+	return v1SFID, nil
+}
+func (noOpIDMapper) MapCommitteeV2ToV1(_ context.Context, v2UID string) (string, error) {
+	return v2UID, nil
+}
+func (noOpIDMapper) MapCommitteeV1ToV2(_ context.Context, v1SFID string) (string, error) {
+	return v1SFID, nil
+}
+func (noOpIDMapper) MapParticipantV2ToInviteeID(_ context.Context, v2UID string) (string, error) {
+	return v2UID, nil
+}
+func (noOpIDMapper) MapParticipantV2ToAttendeeID(_ context.Context, v2UID string) (string, error) {
+	return v2UID, nil
+}
+func (noOpIDMapper) MapInviteeIDToParticipantV2(_ context.Context, inviteeID string) (string, error) {
+	return inviteeID, nil
+}
+func (noOpIDMapper) MapAttendeeIDToParticipantV2(_ context.Context, attendeeID string) (string, error) {
+	return attendeeID, nil
+}
+
+// fakeUserMetadataReader returns a canned profile or error for ResolveProfile.
+type fakeUserMetadataReader struct {
+	profile *domain.UserProfile
+	err     error
+	calls   []string
+}
+
+func (f *fakeUserMetadataReader) ResolveProfile(_ context.Context, username string) (*domain.UserProfile, error) {
+	f.calls = append(f.calls, username)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.profile, nil
+}
+
+// ctxWithPrincipal builds a context matching what the JWT auth middleware installs
+// on a real request.
+func ctxWithPrincipal(principal, email string) context.Context {
+	ctx := context.WithValue(context.Background(), constants.PrincipalContextID, principal)
+	if email != "" {
+		ctx = context.WithValue(ctx, constants.EmailContextID, email)
+	}
+	return ctx
+}

--- a/pkg/models/itx/attachments.go
+++ b/pkg/models/itx/attachments.go
@@ -3,11 +3,23 @@
 
 package itx
 
+import "log/slog"
+
 // CreatedUpdatedBy represents user information for created_by and updated_by fields
 type CreatedUpdatedBy struct {
 	Username string `json:"username"`        // Username of the user
 	Email    string `json:"email,omitempty"` // Email of the user
 	Name     string `json:"name,omitempty"`  // Name of the user
+}
+
+// LogValue implements slog.LogValuer so that CreatedUpdatedBy values logged
+// directly as a slog attribute (e.g. `slog.Any("created_by", cb)`) don't leak
+// the requester's name and email into logs — only the username is emitted.
+// Does NOT redact CreatedUpdatedBy values nested inside a JSON-marshaled
+// request body; the proxy client applies a separate body-level redaction for
+// that case (see requestJSONForLog in internal/infrastructure/proxy).
+func (c CreatedUpdatedBy) LogValue() slog.Value {
+	return slog.GroupValue(slog.String("username", c.Username))
 }
 
 // CreateAttachmentPresignRequest represents the request to generate a presigned URL for attachment upload

--- a/pkg/models/itx/audit_logvalue_test.go
+++ b/pkg/models/itx/audit_logvalue_test.go
@@ -1,0 +1,86 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+package itx_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/linuxfoundation/lfx-v2-meeting-service/pkg/models/itx"
+)
+
+// TestUser_LogValue_RedactsPII covers the case where an itx.User is logged
+// directly as a slog attribute value (e.g. slog.Any("user", u)). Only the
+// username should appear; name and email must be dropped. This complements
+// the body-level redaction in internal/infrastructure/proxy (which handles
+// the harder case of a User nested inside a JSON-marshaled request body).
+func TestUser_LogValue_RedactsPII(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	user := itx.User{
+		Username:       "alice",
+		Name:           "Alice Example",
+		Email:          "alice@example.com",
+		ProfilePicture: "https://example.com/a.jpg",
+	}
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "logging a user", slog.Any("user", user))
+
+	out := buf.String()
+	assert.Contains(t, out, "alice", "username should be preserved for debugging")
+	assert.NotContains(t, out, "alice@example.com", "email must not appear in logs")
+	assert.NotContains(t, out, "Alice Example", "display name must not appear in logs")
+	assert.NotContains(t, out, "example.com/a.jpg", "profile picture URL must not appear in logs")
+}
+
+// TestCreatedUpdatedBy_LogValue_RedactsPII is the CreatedUpdatedBy equivalent.
+func TestCreatedUpdatedBy_LogValue_RedactsPII(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cb := itx.CreatedUpdatedBy{
+		Username: "bob",
+		Name:     "Bob Example",
+		Email:    "bob@example.com",
+	}
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "logging created_by", slog.Any("created_by", cb))
+
+	out := buf.String()
+	assert.Contains(t, out, "bob")
+	assert.NotContains(t, out, "bob@example.com")
+	assert.NotContains(t, out, "Bob Example")
+}
+
+// TestUser_LogValue_DoesNotAffectJSONMarshaling makes sure LogValue is an
+// slog-only concern: the wire encoding must still include name and email so
+// ITX records the correct audit trail.
+func TestUser_LogValue_DoesNotAffectJSONMarshaling(t *testing.T) {
+	user := itx.User{
+		Username: "alice",
+		Name:     "Alice Example",
+		Email:    "alice@example.com",
+	}
+
+	// Round-trip via slog to confirm LogValue redacts; then via marshaling
+	// (like the proxy does when building the wire body) to confirm the full
+	// payload is preserved.
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "log check", slog.Any("user", user))
+	require.False(t, strings.Contains(buf.String(), "Alice Example"),
+		"LogValue should have suppressed the name in the slog output")
+
+	// slog attribute output != wire body. The proxy builds the wire body via
+	// encoding/json — verify LogValue doesn't accidentally hijack that too.
+	// (LogValue only applies to slog attribute resolution; encoding/json calls
+	// MarshalJSON if implemented, otherwise reflects over exported fields.)
+	// See TestWireBody_StillContainsAuditPII in the proxy package for the
+	// canonical wire-body test.
+}

--- a/pkg/models/itx/common.go
+++ b/pkg/models/itx/common.go
@@ -3,6 +3,8 @@
 
 package itx
 
+import "log/slog"
+
 // User represents a user in the ITX system
 type User struct {
 	ID             string `json:"id"`
@@ -10,6 +12,16 @@ type User struct {
 	Name           string `json:"name"`
 	Email          string `json:"email"`
 	ProfilePicture string `json:"profile_picture,omitempty"`
+}
+
+// LogValue implements slog.LogValuer so that User values logged directly as a
+// slog attribute (e.g. `slog.Any("user", u)`) don't leak the requester's name
+// and email into logs — only the username is emitted. Does NOT redact User
+// values nested inside a JSON-marshaled request body; the proxy client applies
+// a separate body-level redaction for that case (see requestJSONForLog in
+// internal/infrastructure/proxy).
+func (u User) LogValue() slog.Value {
+	return slog.GroupValue(slog.String("username", u.Username))
 }
 
 // ErrorResponse represents an error response from ITX

--- a/pkg/models/itx/past_meeting_participants.go
+++ b/pkg/models/itx/past_meeting_participants.go
@@ -41,6 +41,11 @@ type CreateInviteeRequest struct {
 	CommitteeVotingStatus string `json:"committee_voting_status,omitempty"` // Voting status in committee
 	OrgIsMember           bool   `json:"org_is_member,omitempty"`           // Whether org has LF membership
 	OrgIsProjectMember    bool   `json:"org_is_project_member,omitempty"`   // Whether org has project membership
+
+	// CreatedBy identifies the requesting user at creation time. Populated by the
+	// service from the authenticated principal so ITX persists the correct audit
+	// trail instead of leaving it blank / attributing it to the M2M service identity.
+	CreatedBy *User `json:"created_by,omitempty"`
 }
 
 // UpdateInviteeRequest represents the request to update an invitee
@@ -57,6 +62,11 @@ type UpdateInviteeRequest struct {
 	JobTitle              string `json:"job_title,omitempty"`               // Job title
 	CommitteeRole         string `json:"committee_role,omitempty"`          // Role within the committee
 	CommitteeVotingStatus string `json:"committee_voting_status,omitempty"` // Voting status in committee
+
+	// UpdatedBy identifies the requesting user on update requests. Populated by the
+	// service from the authenticated principal so ITX overwrites the stored value
+	// instead of preserving stale data.
+	UpdatedBy *User `json:"updated_by,omitempty"`
 }
 
 // AttendeeSession represents a join/leave session
@@ -109,6 +119,11 @@ type CreateAttendeeRequest struct {
 	OrgIsMember           bool              `json:"org_is_member,omitempty"`           // Whether org has LF membership
 	OrgIsProjectMember    bool              `json:"org_is_project_member,omitempty"`   // Whether org has project membership
 	Sessions              []AttendeeSession `json:"sessions,omitempty"`                // Array of session objects with join/leave times
+
+	// CreatedBy identifies the requesting user at creation time. Populated by the
+	// service from the authenticated principal so ITX persists the correct audit
+	// trail instead of leaving it blank / attributing it to the M2M service identity.
+	CreatedBy *User `json:"created_by,omitempty"`
 }
 
 // UpdateAttendeeRequest represents the request to update an attendee
@@ -118,4 +133,9 @@ type UpdateAttendeeRequest struct {
 	IsVerified            bool   `json:"is_verified,omitempty"`             // Whether the attendee has been verified
 	CommitteeRole         string `json:"committee_role,omitempty"`          // Role within the committee
 	CommitteeVotingStatus string `json:"committee_voting_status,omitempty"` // Voting status in committee
+
+	// UpdatedBy identifies the requesting user on update requests. Populated by the
+	// service from the authenticated principal so ITX overwrites the stored value
+	// instead of preserving stale data.
+	UpdatedBy *User `json:"updated_by,omitempty"`
 }

--- a/pkg/models/itx/past_meetings.go
+++ b/pkg/models/itx/past_meetings.go
@@ -3,7 +3,9 @@
 
 package itx
 
-// CreatePastMeetingRequest represents the request to create a past meeting
+// CreatePastMeetingRequest represents the request to create or update a past meeting.
+// The same struct is reused for PUT; CreatedBy is only meaningful on POST and UpdatedBy
+// only on PUT (the service stamps whichever is appropriate).
 type CreatePastMeetingRequest struct {
 	// Required fields
 	MeetingID    string `json:"meeting_id"`    // Zoom meeting ID
@@ -26,6 +28,16 @@ type CreatePastMeetingRequest struct {
 	TranscriptEnabled bool              `json:"transcript_enabled,omitempty"` // Was transcription enabled
 	TranscriptAccess  ArtifactAccess    `json:"transcript_access,omitempty"`  // Who can access transcripts
 	Visibility        MeetingVisibility `json:"visibility,omitempty"`         // Meeting visibility (public/private)
+
+	// CreatedBy identifies the requesting user at creation time (POST only). Leave nil
+	// on updates.
+	CreatedBy *User `json:"created_by,omitempty"`
+
+	// UpdatedBy identifies the requesting user on update requests. ITX only overwrites
+	// the stored updated_by / updated_by_list when this field is non-zero, so it must
+	// be populated on every update to keep the audit trail accurate. Leave nil on
+	// create requests.
+	UpdatedBy *User `json:"updated_by,omitempty"`
 }
 
 // PastMeetingResponse represents the response from creating/retrieving a past meeting


### PR DESCRIPTION
Resolves [LFXV2-2821](https://linuxfoundation.atlassian.net/browse/LFXV2-2821).

Only the Meeting POST/PUT paths stamped the requesting user on outbound ITX writes; every other create/update from lfx-v2-meeting-service either sent nothing (leaving audit fields blank / attributing changes to the M2M service identity) or, on attachments, sent only `username` without the name/email enrichment the meeting endpoints already do.

## Approach

- Extract `buildRequestingUser` from `MeetingService` into a shared `auditStamper` embedded by every ITX service.
- Wire the existing `UserMetadataReader` (NATS → auth-service) into every service constructor in `main.go`.
- Preserve the graceful-degradation contract: full profile when the reader resolves, `{username, email}` when the reader is nil or errors, and nil when there is no principal on ctx.
- Add sibling `buildRequestingCreatedUpdatedBy` returning the `*itx.CreatedUpdatedBy` shape (no id/avatar) used by attachment endpoints.
- Stamp audit fields **in the service**, never in the converter — so it happens once per call and enrichment lives in one place.

## What now stamps what

| Object | POST | PUT | Notes |
| --- | --- | --- | --- |
| Registrant | `created_by` | `updated_by` | struct fields already existed |
| Meeting occurrence | — | `updated_by` | struct field already existed |
| Past meeting | `created_by` | `updated_by` | added fields to `CreatePastMeetingRequest` |
| Past meeting invitee | `created_by` | `updated_by` | added fields; stamped in Create, update, and the `createInviteeFromUpdate` fallback path |
| Past meeting attendee | `created_by` | `updated_by` | mirror of invitee |
| Past meeting summary | — | `modified_by` | non-standard ITX field name; drops the misleading converter comment claiming ITX derives this from the JWT |
| Meeting attachment (+ presign) | `created_by` w/ name+email | `updated_by` w/ name+email | handlers no longer parse JWT; converters no longer take `username` |
| Past meeting attachment (+ presign) | `created_by` w/ name+email | `updated_by` w/ name+email | mirror of meeting attachment |

Never stamps `created_by` on updates or `updated_by` on creates so we don't overwrite the original creator or leave stale updater data. Presign is treated as a create (ITX persists an attachment record with `upload_status=ongoing` at that point).

## PII redaction in debug logs

`proxy/client.go` already logs full attachment request bodies at `LOG_LEVEL=debug`. Now that `CreatedBy` / `UpdatedBy` on attachments carry `name` and `email`, this PR also:

- Adds `LogValue()` on `itx.User` and `itx.CreatedUpdatedBy` — redacts requester PII to just `username` when either type is logged directly as a `slog` attribute value.
- Adds `requestJSONForLog` in the proxy package — returns a redacted JSON body (audit fields nil'd) for use in the 6 attachment debug-log sites. Wire body sent to ITX is unaffected.

Two layers because `slog` doesn't recursively resolve `LogValuer` on nested struct fields — the `LogValue()` method alone wouldn't fix the pre-existing full-body-as-string debug log pattern.

## Not addressed (out of scope per ticket)

- Past meeting recordings and artifacts (no HTTP create path from this service; ITX populates from webhook/NATS).
- `MeetingsAuditRecord.change_by` (non-standard, not created here).

## Test coverage

Mirrors the existing `meeting_service_test.go` pattern:
- direct `auditStamper` unit tests (including the `(nil, nil)` resolver edge case)
- per-service tests for full-profile stamping, no-principal omission, and create-doesn't-touch-updated / update-doesn't-touch-created
- `TestPastMeetingParticipantService_UpdateParticipant_ResolvesRequesterOnce` regression guard that asserts a single `ResolveProfile` call per participant update across all three scenarios (both-exist, both-missing, mixed)
- redaction tests (`TestRequestJSONForLog_RedactsAuditPII`, `TestUser_LogValue_RedactsPII`, `TestWireBody_StillContainsAuditPII`) that pin down PII stays out of logs and stays in the wire body
- shared helpers (fake reader, no-op ID mapper, ctx builder) extracted to `testutil_test.go`


[LFXV2-2821]: https://linuxfoundation.atlassian.net/browse/LFXV2-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ