### PR TITLE
fix(eventing): derive v1_past_meeting public flag from visibility [LFXV2-3083]

### DIFF
--- a/docs/fga-contract.md
+++ b/docs/fga-contract.md
@@ -116,7 +116,7 @@ Published to `lfx.fga-sync.update_access` on past meeting create or update.
 | Field | Value |
 |---|---|
 | `object_type` | `v1_past_meeting` |
-| `public` | `false` (always) |
+| `public` | `true` when `Visibility == "public"`, otherwise `false` |
 
 #### Relations
 

--- a/docs/indexer-contract.md
+++ b/docs/indexer-contract.md
@@ -481,7 +481,7 @@ Used by `created_by`, `updated_by`, and entries in `updated_by_list`:
 | `access_check_relation` | `viewer` |
 | `history_check_object` | `v1_past_meeting:{id}` |
 | `history_check_relation` | `auditor` |
-| `public` | `false` (always) |
+| `public` | `true` when `visibility == "public"`, `false` otherwise |
 
 ### Search Behavior
 

--- a/internal/infrastructure/eventing/nats_publisher.go
+++ b/internal/infrastructure/eventing/nats_publisher.go
@@ -284,7 +284,7 @@ func (p *NATSPublisher) PublishPastMeetingEvent(ctx context.Context, action stri
 	p.logger.InfoContext(ctx, "publishing past meeting event", "action", action, "past_meeting_id", meeting.MeetingAndOccurrenceID)
 
 	tags := meeting.Tags()
-	publicFalse := false
+	isPublic := meeting.Visibility == "public"
 	indexerMsg := indexerTypes.IndexerMessageEnvelope{
 		Action:  indexerConstants.MessageAction(action),
 		Headers: map[string]string{"authorization": authorizationHeaderValue},
@@ -292,7 +292,7 @@ func (p *NATSPublisher) PublishPastMeetingEvent(ctx context.Context, action stri
 		Tags:    tags,
 		IndexingConfig: &indexerTypes.IndexingConfig{
 			ObjectID:             meeting.MeetingAndOccurrenceID,
-			Public:               &publicFalse,
+			Public:               &isPublic,
 			AccessCheckObject:    objectTypeV1PastMeeting + ":" + meeting.MeetingAndOccurrenceID,
 			AccessCheckRelation:  "viewer",
 			HistoryCheckObject:   objectTypeV1PastMeeting + ":" + meeting.MeetingAndOccurrenceID,
@@ -373,7 +373,7 @@ func (p *NATSPublisher) PublishPastMeetingEvent(ctx context.Context, action stri
 		Operation:  "update_access",
 		Data: fgatypes.GenericAccessData{
 			UID:        meeting.MeetingAndOccurrenceID,
-			Public:     false,
+			Public:     isPublic,
 			Relations:  pastMeetingRelations,
 			References: pastMeetingRefs,
 			// host/invitee/attendee are managed by PublishPastMeetingParticipantEvent


### PR DESCRIPTION
## Summary

The past-meeting indexer envelope and FGA `update_access` payload in `PublishPastMeetingEvent` were hard-coding `public: false`, so a past meeting whose parent is `visibility: "public"` was still indexed as non-public — hiding it from anonymous search even though the live meeting is visible.

## Changes

- `internal/infrastructure/eventing/nats_publisher.go` — `PublishPastMeetingEvent` now mirrors `PublishMeetingEvent`: derives `isPublic := meeting.Visibility == "public"` and forwards it to both the indexer `IndexingConfig.Public` and the FGA `GenericAccessData.Public`.
- `docs/indexer-contract.md` — V1 Past Meeting `public` row now reads `true when visibility == "public", false otherwise` (matching V1 Meeting).
- `docs/fga-contract.md` — same wording for the FGA v1_past_meeting `update_access`.

Per-artifact access (recording / transcript / AI-summary viewers) was already correctly conditional on `recording_access` / `transcript_access` / `ai_summary_access` and remains unchanged.

Issue: [LFXV2-3083](https://linuxfoundation.atlassian.net/browse/LFXV2-3083)

[LFXV2-3083]: https://linuxfoundation.atlassian.net/browse/LFXV2-3083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ