### PR TITLE
fix(registrants): fall back to profile email when JWT email claim is absent

### DIFF
--- a/cmd/meeting-api/service/itx_registrant_converters.go
+++ b/cmd/meeting-api/service/itx_registrant_converters.go
@@ -46,8 +46,9 @@ func ConvertUpdateITXRegistrantPayloadToITX(p *meetingservice.UpdateItxRegistran
 }
 
 // ConvertSelfRegisterPayloadToITX converts a self-registration Goa payload to an ITX registrant.
-// Email and username are intentionally absent — both are set by the service layer from the JWT principal
-// so the caller cannot self-register under a different identity.
+// Email and username are intentionally absent — both are set by the service layer from the JWT
+// claim (with auth-service profile as fallback) so the caller cannot self-register under a
+// different identity.
 func ConvertSelfRegisterPayloadToITX(p *meetingservice.SelfRegisterItxMeetingPayload) *itx.ZoomMeetingRegistrant {
 	return &itx.ZoomMeetingRegistrant{
 		FirstName:  p.FirstName,

--- a/cmd/meeting-api/service/itx_registrant_converters.go
+++ b/cmd/meeting-api/service/itx_registrant_converters.go
@@ -46,9 +46,9 @@ func ConvertUpdateITXRegistrantPayloadToITX(p *meetingservice.UpdateItxRegistran
 }
 
 // ConvertSelfRegisterPayloadToITX converts a self-registration Goa payload to an ITX registrant.
-// Email and username are intentionally absent — both are set by the service layer from the JWT
-// claim (with auth-service profile as fallback) so the caller cannot self-register under a
-// different identity.
+// Email and username are intentionally absent from the payload. Email is set by the service layer
+// from the JWT claim, falling back to the auth-service profile when the claim is absent. Username
+// is always derived from the authenticated JWT principal. Neither can be supplied by the caller.
 func ConvertSelfRegisterPayloadToITX(p *meetingservice.SelfRegisterItxMeetingPayload) *itx.ZoomMeetingRegistrant {
 	return &itx.ZoomMeetingRegistrant{
 		FirstName:  p.FirstName,

--- a/docs/api-contracts/itx-registrants-api.md
+++ b/docs/api-contracts/itx-registrants-api.md
@@ -555,7 +555,7 @@ Content-Type: application/json
 | `job_title` | string | No | Job title |
 | `occurrence` | string | No | Specific occurrence ID (blank = all) |
 
-> **Note**: `email` and `username` are intentionally absent from the request body. Both are extracted from the authenticated user's JWT claims by the service and cannot be overridden by the caller, ensuring the registration is always associated with the requesting user's identity.
+> **Note**: `email` and `username` are intentionally absent from the request body. The service sources email from the JWT claim first; if the JWT omits the email claim (e.g. `use_oidc_contextualizer` is disabled in the environment), it falls back to the auth-service profile resolved via NATS. Neither value can be overridden by the caller, ensuring the registration is always associated with the requesting user's identity.
 >
 > **Note**: Only meetings with `visibility: public` are eligible for self-registration. Attempting to self-register for a private meeting returns `403 Forbidden` even if the caller has viewer access.
 

--- a/docs/api-contracts/itx-registrants-api.md
+++ b/docs/api-contracts/itx-registrants-api.md
@@ -565,7 +565,7 @@ Same response shape as [Create Registrant](#create-registrant). The `type` field
 
 **Error Responses**:
 
-- `400 Bad Request` — Authenticated user's JWT does not contain an email claim
+- `400 Bad Request` — Authenticated user's JWT and auth-service profile do not contain an email address
 - `403 Forbidden` — Caller lacks viewer access, or the meeting is private (visibility ≠ public)
 - `409 Conflict` — User is already registered for this meeting
 

--- a/internal/service/itx/registrant_service.go
+++ b/internal/service/itx/registrant_service.go
@@ -72,12 +72,15 @@ func (s *RegistrantService) CreateRegistrant(ctx context.Context, meetingID stri
 }
 
 // SelfRegisterForMeeting registers the authenticated user as a meeting registrant.
-// The caller's email is sourced from the JWT principal on ctx (EmailContextID), not from req.
+// The caller's email is sourced from the JWT claim on ctx (EmailContextID) first; if the JWT
+// omits the email claim (e.g. use_oidc_contextualizer is disabled), it falls back to the
+// auth-service profile resolved via NATS. Email is never accepted from req.
 // All other fields in req (first_name, last_name, org, job_title, occurrence) are used as-is.
 // Returns an error if the user is already registered (ITX returns 409 Conflict).
 func (s *RegistrantService) SelfRegisterForMeeting(ctx context.Context, meetingID string, req *itx.ZoomMeetingRegistrant) (*itx.ZoomMeetingRegistrant, error) {
-	// Derive email from the authenticated principal rather than accepting it from the
-	// request body — prevents a caller from self-registering under a different identity.
+	// Derive email from an authoritative source (JWT claim or auth-service profile) rather
+	// than accepting it from the request body — prevents a caller from self-registering
+	// under a different identity.
 	meeting, err := s.meetingClient.GetZoomMeeting(ctx, meetingID)
 	if err != nil {
 		return nil, err

--- a/internal/service/itx/registrant_service.go
+++ b/internal/service/itx/registrant_service.go
@@ -86,18 +86,12 @@ func (s *RegistrantService) SelfRegisterForMeeting(ctx context.Context, meetingI
 		return nil, domain.NewForbiddenError("self-registration is only available for public meetings")
 	}
 
-	email, _ := ctx.Value(constants.EmailContextID).(string)
-	if email == "" {
-		return nil, domain.NewValidationError("authenticated user email is required for self-registration")
-	}
 	username, _ := ctx.Value(constants.PrincipalContextID).(string)
 	// M2M client principals carry an @clients suffix (e.g. "<id>@clients") and have no
 	// associated LFX user account. Self-registration requires a human identity.
 	if strings.HasSuffix(username, "@clients") {
 		return nil, domain.NewValidationError("self-registration requires a user token, not an M2M client token")
 	}
-	req.Email = email
-	req.Username = username
 
 	// Resolve the user profile once and reuse it for both field enrichment and the
 	// audit stamp. Each ResolveProfile call is a NATS request with a 2s timeout;
@@ -113,6 +107,20 @@ func (s *RegistrantService) SelfRegisterForMeeting(ctx context.Context, meetingI
 			resolvedProfile = profile
 		}
 	}
+
+	// Email must come from an authoritative source — JWT claim or auth-service profile —
+	// not from the request body, to prevent a caller from self-registering under a
+	// different identity. The JWT email claim is omitempty; fall back to the profile
+	// email when the token doesn't carry the claim (e.g. local dev, older tokens).
+	email, _ := ctx.Value(constants.EmailContextID).(string)
+	if email == "" && resolvedProfile != nil {
+		email = resolvedProfile.Email
+	}
+	if email == "" {
+		return nil, domain.NewValidationError("authenticated user email is required for self-registration")
+	}
+	req.Email = email
+	req.Username = username
 
 	// Auth service data is authoritative over what the client sent; the request
 	// payload serves as fallback when a field is absent from the profile or the

--- a/internal/service/itx/registrant_service_test.go
+++ b/internal/service/itx/registrant_service_test.go
@@ -131,11 +131,11 @@ func TestRegistrantService_SelfRegisterForMeeting(t *testing.T) {
 		assert.Nil(t, client.lastCreateReq, "ITX registrant client must not be called for private meetings")
 	})
 
-	t.Run("returns validation error when email absent from context", func(t *testing.T) {
+	t.Run("returns validation error when email absent from JWT and profile", func(t *testing.T) {
 		client := &fakeRegistrantClient{}
+		// No userMetadata reader and no JWT email — both sources are empty.
 		svc := newSvcWithMeeting(client, itx.MeetingVisibilityPublic, nil)
 
-		// Context has a principal but no email — simulates a misconfigured OIDC token.
 		ctx := ctxWithPrincipal("svc-account", "")
 		_, err := svc.SelfRegisterForMeeting(ctx, "mtg-1", &itx.ZoomMeetingRegistrant{})
 		require.Error(t, err)
@@ -143,6 +143,20 @@ func TestRegistrantService_SelfRegisterForMeeting(t *testing.T) {
 		require.ErrorAs(t, err, &de)
 		assert.Equal(t, domain.ErrorTypeValidation, de.Type)
 		assert.Nil(t, client.lastCreateReq, "ITX client must not be called when email is missing")
+	})
+
+	t.Run("uses profile email when JWT email is absent", func(t *testing.T) {
+		client := &fakeRegistrantClient{}
+		reader := &fakeUserMetadataReader{profile: &domain.UserProfile{
+			Username: "alice", Name: "Alice", Email: "alice@example.com",
+		}}
+		svc := newSvcWithMeeting(client, itx.MeetingVisibilityPublic, reader)
+
+		// No JWT email — should fall back to profile.Email.
+		ctx := ctxWithPrincipal("alice", "")
+		_, err := svc.SelfRegisterForMeeting(ctx, "mtg-1", &itx.ZoomMeetingRegistrant{})
+		require.NoError(t, err)
+		assert.Equal(t, "alice@example.com", client.lastCreateReq.Email)
 	})
 
 	t.Run("returns validation error for M2M client token", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fall back to NATS-resolved `profile.Email` when the JWT email claim is absent (e.g. `use_oidc_contextualizer: false` in dev environments like the one in `lfx-v2-argocd/values/dev/lfx-v2-meeting-service.yaml`)
- This prevents a 400 error for valid authenticated users whose token doesn't include the email claim

## Ticket

[GH-1406](https://github.com/linuxfoundation/lfx-v2-meeting-service/issues/1406)

## Test plan

- [x] `go test ./internal/service/itx/...` passes
- [x] New test case: `uses profile email when JWT email is absent`
- [x] Updated test name: `returns validation error when email absent from JWT and profile` (covers both sources empty)

🤖 Generated with [Claude Code](https://claude.ai/code)